### PR TITLE
Fail open when the tokenizer fails to load 

### DIFF
--- a/anthropic/api.py
+++ b/anthropic/api.py
@@ -273,10 +273,13 @@ def _validate_request(params: dict) -> None:
 
 def _validate_prompt_length(params: dict) -> None:
     prompt: str = params["prompt"]
-    prompt_tokens = tokenizer.count_tokens(prompt)
-    max_tokens_to_sample: int = params["max_tokens_to_sample"]
-    token_limit = 9 * 1024
-    if prompt_tokens + max_tokens_to_sample > token_limit:
-        raise ApiException(
-            f"Prompt tokens ({prompt_tokens}) + max-sampled tokens ({max_tokens_to_sample}) exceeds max ({token_limit})",
-        )
+    try:
+        prompt_tokens = tokenizer.count_tokens(prompt)
+        max_tokens_to_sample: int = params["max_tokens_to_sample"]
+        token_limit = 9 * 1024
+        if prompt_tokens + max_tokens_to_sample > token_limit:
+            raise ApiException(
+                f"Prompt tokens ({prompt_tokens}) + max-sampled tokens ({max_tokens_to_sample}) exceeds max ({token_limit})",
+            )
+    except tokenizer.TokenizerException:
+        pass

--- a/anthropic/api.py
+++ b/anthropic/api.py
@@ -1,5 +1,6 @@
 from typing import Dict, AsyncIterator, Iterator, Optional, Tuple, NamedTuple, Union
 import aiohttp
+import logging
 import requests
 import requests.adapters
 import urllib.parse
@@ -281,5 +282,5 @@ def _validate_prompt_length(params: dict) -> None:
             raise ApiException(
                 f"Prompt tokens ({prompt_tokens}) + max-sampled tokens ({max_tokens_to_sample}) exceeds max ({token_limit})",
             )
-    except tokenizer.TokenizerException:
-        pass
+    except tokenizer.TokenizerException as e:
+        logging.warning(f"Cannot guarantee proper prompt lengths, because failed to use tokenizer: {e}")

--- a/anthropic/tokenizer.py
+++ b/anthropic/tokenizer.py
@@ -39,6 +39,11 @@ def get_tokenizer() -> Tokenizer:
         try:
             claude_tokenizer = Tokenizer.from_str(tokenizer_data)
         except Exception as e:
+            # If the tokenizer file is unparseable, let's delete it here and clean things up
+            try:
+                os.remove(_get_tokenizer_filename())
+            except FileNotFoundError:
+                pass
             raise TokenizerException(f'Failed to load tokenizer: {e}')
 
     return claude_tokenizer

--- a/anthropic/tokenizer.py
+++ b/anthropic/tokenizer.py
@@ -14,7 +14,7 @@ class TokenizerException(Exception):
 def _get_tokenizer_filename() -> str:
     cache_dir = os.path.join(tempfile.gettempdir(), "anthropic")
     os.makedirs(cache_dir, exist_ok=True)
-    tokenizer_file = os.path.join(cache_dir, 'claude_tokenizer_file.json')
+    tokenizer_file = os.path.join(cache_dir, 'claude_tokenizer.json')
     return tokenizer_file
 
 def _get_cached_tokenizer_file_as_str() -> str:

--- a/anthropic/tokenizer.py
+++ b/anthropic/tokenizer.py
@@ -11,12 +11,15 @@ claude_tokenizer = None
 class TokenizerException(Exception):
     pass
 
-def _get_cached_tokenizer_file_as_str() -> str:
+def _get_tokenizer_filename() -> str:
     cache_dir = os.path.join(tempfile.gettempdir(), "anthropic")
-
+    os.makedirs(cache_dir, exist_ok=True)
     tokenizer_file = os.path.join(cache_dir, 'claude_tokenizer_file.json')
+    return tokenizer_file
+
+def _get_cached_tokenizer_file_as_str() -> str:
+    tokenizer_file = _get_tokenizer_filename()
     if not os.path.exists(tokenizer_file):
-        os.makedirs(cache_dir, exist_ok=True)
         response = httpx.get(CLAUDE_TOKENIZER_REMOTE_FILE)
         response.raise_for_status()
         with open(tokenizer_file, 'w') as f:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 import anthropic
-from anthropic import api, ApiException
+from anthropic import api, ApiException, tokenizer
+import os
 
 def test_prompt_validator():
     # No exceptions expected
@@ -26,3 +27,14 @@ def test_sample_length():
     bad_request["prompt"] = bad_request["prompt"] * 2000
     with pytest.raises(ApiException):
         api._validate_request(bad_request)
+
+def test_prompt_validator_fail(monkeypatch):
+    # Ensure we don't have any tokenizer loaded or saved
+    monkeypatch.setattr(tokenizer, "CLAUDE_TOKENIZER_REMOTE_FILE", tokenizer.CLAUDE_TOKENIZER_REMOTE_FILE + '-but-nonexistent')
+    tokenizer.claude_tokenizer = None
+    os.remove(tokenizer._get_tokenizer_filename())
+    # Now verify a good request fails open
+    api._validate_prompt_length({"max_tokens_to_sample": 1, "prompt": f"{anthropic.HUMAN_PROMPT} Hello{anthropic.AI_PROMPT}"})
+    # And now verify a bad request fails open too
+    api._validate_prompt_length({"max_tokens_to_sample": 100000, "prompt": f"{anthropic.HUMAN_PROMPT} Hello{anthropic.AI_PROMPT}"})
+


### PR DESCRIPTION
(ie, due to some AWS bucket issue). Fixes https://github.com/anthropics/anthropic-sdk-python/issues/13 and https://github.com/anthropics/anthropic-sdk-python/issues/14 in a better way