### PR TITLE
Fix: UnicodeEncodeError

### DIFF
--- a/anthropic/tokenizer.py
+++ b/anthropic/tokenizer.py
@@ -22,10 +22,10 @@ def _get_cached_tokenizer_file_as_str() -> str:
     if not os.path.exists(tokenizer_file):
         response = httpx.get(CLAUDE_TOKENIZER_REMOTE_FILE)
         response.raise_for_status()
-        with open(tokenizer_file, 'w') as f:
+        with open(tokenizer_file, 'w', encoding="utf-8") as f:
             f.write(response.text)
 
-    with open(tokenizer_file, 'r') as f:
+    with open(tokenizer_file, 'r', encoding="utf-8") as f:
         return f.read()
 
 def get_tokenizer() -> Tokenizer:


### PR DESCRIPTION
Fixes demo code 
with prompt : `f"{anthropic.HUMAN_PROMPT} How many toes do dogs have?{anthropic.AI_PROMPT}",`

Throwing
 `UnicodeEncodeError: 'charmap' codec can't encode characters`
Using https://stackoverflow.com/questions/27092833/unicodeencodeerror-charmap-codec-cant-encode-characters

specifically:
```
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 1980: character maps to <undefined>
```
and
```
File "C:\Python310\lib\site-packages\anthropic\tokenizer.py", line 26, in _get_cached_tokenizer_file_as_str
    f.write(response.text.encode("utf-8"))
TypeError: write() argument must be str, not bytes
```
otherwise

Appears to work on demo code with this fix but not extensively tested.

![image](https://user-images.githubusercontent.com/18080164/229961320-233b6339-99d5-4998-84a1-b4808e8c2536.png)
