### PR TITLE
fix(tokenizer): encoding issues for special characters

### DIFF
--- a/src/anthropic/_tokenizers.py
+++ b/src/anthropic/_tokenizers.py
@@ -30,7 +30,7 @@ def sync_get_tokenizer() -> Tokenizer:
         return _tokenizer
 
     tokenizer_path = _get_tokenizer_cache_path()
-    text = tokenizer_path.read_text()
+    text = tokenizer_path.read_text(encoding='utf-8')
     return _load_tokenizer(text)
 
 
@@ -39,5 +39,5 @@ async def async_get_tokenizer() -> Tokenizer:
         return _tokenizer
 
     tokenizer_path = AsyncPath(_get_tokenizer_cache_path())
-    text = await tokenizer_path.read_text()
+    text = await tokenizer_path.read_text(encoding='utf-8')
     return _load_tokenizer(text)


### PR DESCRIPTION
When tokenizing some non-English texts(such as Chinese) on windows os, there will be an issue causing by the default encoding format on reading the tokenizer.json:
![image](https://github.com/anthropics/anthropic-sdk-python/assets/48169215/a6c52105-8ac3-488c-933c-18a0fcc25132)
![image](https://github.com/anthropics/anthropic-sdk-python/assets/48169215/c4ac18eb-70d9-4188-9372-26580f91a7b9)

By specifying " encoding='utf-8' ", this issue can be fixed:
![image](https://github.com/anthropics/anthropic-sdk-python/assets/48169215/492fa643-1c84-4052-87d9-40e0b46a0f17)
![image](https://github.com/anthropics/anthropic-sdk-python/assets/48169215/bcd8adc2-8ccc-4cfb-8411-33c7835abaf2)
