### PR TITLE
Remove pydantic constraint via fallback imports to cover both v1 & v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7"
 httpx = ">= 0.23.0, < 1"
-pydantic = "^1.9.0"
+pydantic = "*"
 typing-extensions = ">= 4.1.1, < 5"
 anyio = ">= 3.5.0, < 4"
 distro = ">= 1.7.0, < 2"

--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -28,9 +28,11 @@ from typing_extensions import Literal, get_origin
 import anyio
 import httpx
 import distro
-import pydantic
 from httpx import URL, Limits
-from pydantic import PrivateAttr
+try:
+    from pydantic import v1 as pydantic
+except ImportError:
+    import pydantic
 
 from . import _base_exceptions as exceptions
 from ._qs import Querystring
@@ -129,8 +131,8 @@ class PageInfo:
 
 
 class BasePage(GenericModel, Generic[ModelT]):
-    _options: FinalRequestOptions = PrivateAttr()
-    _model: Type[ModelT] = PrivateAttr()
+    _options: FinalRequestOptions = pydantic.PrivateAttr()
+    _model: Type[ModelT] = pydantic.PrivateAttr()
 
     def has_next_page(self) -> bool:
         items = self._get_page_items()

--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -5,12 +5,18 @@ from typing import Any, Type, Union, Generic, TypeVar, cast
 from datetime import date, datetime
 from typing_extensions import final
 
-import pydantic
-import pydantic.generics
-from pydantic import Extra
-from pydantic.fields import ModelField
-from pydantic.typing import get_args, is_union, get_origin, is_literal_type
-from pydantic.datetime_parse import parse_date
+try:
+    from pydantic import v1 as pydantic
+    from pydantic.v1 import generics, Extra
+    from pydantic.v1.fields import ModelField
+    from pydantic.v1.typing import get_args, is_union, get_origin, is_literal_type
+    from pydantic.v1.datetime_parse import parse_date
+except ImportError:
+    import pydantic
+    from pydantic import generics, Extra
+    from pydantic.fields import ModelField
+    from pydantic.typing import get_args, is_union, get_origin, is_literal_type
+    from pydantic.datetime_parse import parse_date
 
 from ._types import (
     Body,
@@ -174,7 +180,7 @@ def _create_pydantic_field(type_: type) -> ModelField:
     return model_type.__fields__["__root__"]
 
 
-class GenericModel(BaseModel, pydantic.generics.GenericModel):
+class GenericModel(BaseModel, generics.GenericModel):
     pass
 
 

--- a/src/anthropic/_types.py
+++ b/src/anthropic/_types.py
@@ -17,7 +17,10 @@ from typing import (
 from typing_extensions import Literal, Protocol, TypedDict, runtime_checkable
 
 import httpx
-import pydantic
+try:
+    from pydantic import v1 as pydantic
+except ImportError:
+    import pydantic
 from httpx import Proxy, Timeout, Response, BaseTransport
 
 if TYPE_CHECKING:

--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -4,7 +4,10 @@ from typing import Any, List, Mapping, TypeVar, cast
 from datetime import date, datetime
 from typing_extensions import Literal, get_args, get_type_hints
 
-from pydantic.typing import is_typeddict
+try:
+    from pydantic.v1.typing import is_typeddict
+except ImportError:
+    from pydantic.typing import is_typeddict
 
 from ._utils import (
     is_list,

--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -7,11 +7,18 @@ from typing import Any, Mapping, TypeVar, Callable, Iterable, Sequence, cast, ov
 from pathlib import Path
 from typing_extensions import Required, Annotated, TypeGuard, get_args, get_origin
 
-from pydantic.typing import is_union as _is_union
+try:
+    from pydantic.v1.typing import is_union as _is_union
 
-# re-export for forwards compat
-from pydantic.datetime_parse import parse_date as parse_date
-from pydantic.datetime_parse import parse_datetime as parse_datetime
+    # re-export for forwards compat
+    from pydantic.v1.datetime_parse import parse_date as parse_date
+    from pydantic.v1.datetime_parse import parse_datetime as parse_datetime
+except ImportError:
+    from pydantic.typing import is_union as _is_union
+
+    # re-export for forwards compat
+    from pydantic.datetime_parse import parse_date as parse_date
+    from pydantic.datetime_parse import parse_datetime as parse_datetime
 
 from .._types import NotGiven, FileTypes
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,10 @@ from datetime import datetime, timezone
 from typing_extensions import Literal
 
 import pytest
-from pydantic import Field
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 from anthropic._models import BaseModel
 


### PR DESCRIPTION
Pydantic is constrained to version 1 in pyproject.toml, this means the anthropic library can't be installed with any other library that's upgraded to pydantic version 2.

This is the case, with me trying to develop an [llm-claude](https://github.com/tomviner/llm-claude/) plugin for the [llm library](https://github.com/simonw/llm). I noted the problem in https://github.com/tomviner/llm-claude/issues/1

Luckily there's a workaround: pydantic have, in version 2, [retained a copy of all version 1 functionality](https://docs.pydantic.dev/2.0/migration/#continue-using-pydantic-v1-features) under the pydantic.v1 namespace. This PR attempts to import from this v1 namespace (for when v2 is installed), or upon ImportError (for when v1 is installed) import from pydantic as before.

This allows us to drop the constraint on the pydantic version.

### A note on testing

I couldn't see a documented way to run the tests, to check my changes worked. However after guessing a bit, I got them working against an openapi.yml file I (an AI) generated based on the API docs. I have not included that in this branch, but it did run against v1 and v2 of pydantic here:
- [pydantic changes on top of test runner branch](https://github.com/tomviner/anthropic-sdk-python/compare/main...tomviner:anthropic-sdk-python:pydantic-v2-compat-with-tests?expand=1)

If possible, I'd request some docs showing a better way for contributors to run the tests in future. Thanks.