### PR TITLE
Add litellm example - simplify using Anthropic models

### DIFF
--- a/examples/demo_litellm.py
+++ b/examples/demo_litellm.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env -S poetry run python
+
+import asyncio
+from litellm import completion
+
+def main() -> None:
+    messages = [
+        { "content": "You are a helpful assistant","role": "system"}
+        { "content": "how does a court case get to the Supreme Court?","role": "user"},
+    ]
+    result = completion(model="claude-2", max_tokens=1000))
+    print(result)
+
+
+main()


### PR DESCRIPTION
I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic API Endpoints. 

litellm allows devs to call anthropic models with OpenAI input args - making it easier to use anthropic models 

This PR adds an example on how to use litellm

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["ANTHROPIC_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
``` 

