### PR TITLE
fix(tests): suppress deprecation error of event_loop

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Generator
 
 import pytest
 
@@ -6,5 +7,7 @@ pytest.register_assert_rewrite("tests.utils")
 
 
 @pytest.fixture(scope="session")
-def event_loop() -> asyncio.AbstractEventLoop:
-    return asyncio.new_event_loop()
+def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()


### PR DESCRIPTION
The event_loop of pytest-asyncio should be closed explicitly, as shown in the following document.
https://github.com/pytest-dev/pytest-asyncio/tree/v0.18.3#event_loop
As of 0.18.3, which is fixed in pyproject.toml, it closes automatically, but as of 0.21.0, it throws an error. 

It would be good to fix this for future updates.