### PR TITLE
Support customizing the "verify" argument in requests.

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -5,6 +5,7 @@ import time
 import uuid
 import inspect
 import platform
+import ssl
 from types import TracebackType
 from random import random
 from typing import (
@@ -657,6 +658,7 @@ class SyncAPIClient(BaseClient):
         transport: Transport | None = None,
         proxies: ProxiesTypes | None = None,
         limits: Limits | None = DEFAULT_LIMITS,
+        verify: bool | str | ssl.SSLContext = True,
         custom_headers: Mapping[str, str] | None = None,
         custom_query: Mapping[str, object] | None = None,
         _strict_response_validation: bool,
@@ -677,6 +679,7 @@ class SyncAPIClient(BaseClient):
             proxies=proxies,  # type: ignore
             transport=transport,  # type: ignore
             limits=limits,
+            verify=verify,
             headers={"Accept": "application/json"},
         )
 
@@ -1011,6 +1014,7 @@ class AsyncAPIClient(BaseClient):
         transport: Transport | None = None,
         proxies: ProxiesTypes | None = None,
         limits: Limits | None = DEFAULT_LIMITS,
+        verify: bool | str | ssl.SSLContext = True,
         custom_headers: Mapping[str, str] | None = None,
         custom_query: Mapping[str, object] | None = None,
     ) -> None:
@@ -1030,6 +1034,7 @@ class AsyncAPIClient(BaseClient):
             proxies=proxies,  # type: ignore
             transport=transport,  # type: ignore
             limits=limits,
+            verify=verify,
             headers={"Accept": "application/json"},
         )
 

--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -73,6 +73,8 @@ class Anthropic(SyncAPIClient):
         proxies: Optional[ProxiesTypes] = None,
         # See httpx documentation for [limits](https://www.python-httpx.org/advanced/#pool-limit-configuration)
         connection_pool_limits: httpx.Limits | None = DEFAULT_LIMITS,
+        # See httpx documentation for [verify](https://www.python-httpx.org/advanced/#ssl-certificates)
+        verify: bool | str | ssl.SSLContext = True,
         # Enable or disable schema validation for data returned by the API.
         # When enabled an error APIResponseValidationError is raised
         # if the API responds with invalid data for the expected schema.
@@ -106,6 +108,7 @@ class Anthropic(SyncAPIClient):
             transport=transport,
             proxies=proxies,
             limits=connection_pool_limits,
+            verify=verify,
             custom_headers=default_headers,
             custom_query=default_query,
             _strict_response_validation=_strict_response_validation,
@@ -264,6 +267,8 @@ class AsyncAnthropic(AsyncAPIClient):
         proxies: Optional[ProxiesTypes] = None,
         # See httpx documentation for [limits](https://www.python-httpx.org/advanced/#pool-limit-configuration)
         connection_pool_limits: httpx.Limits | None = DEFAULT_LIMITS,
+        # See httpx documentation for [verify](https://www.python-httpx.org/advanced/#ssl-certificates)
+        verify: bool | str | ssl.SSLContext = True,
         # Enable or disable schema validation for data returned by the API.
         # When enabled an error APIResponseValidationError is raised
         # if the API responds with invalid data for the expected schema.
@@ -297,6 +302,7 @@ class AsyncAnthropic(AsyncAPIClient):
             transport=transport,
             proxies=proxies,
             limits=connection_pool_limits,
+            verify=verify,
             custom_headers=default_headers,
             custom_query=default_query,
             _strict_response_validation=_strict_response_validation,


### PR DESCRIPTION
Hi! I'm working on a project that needs to use Anthropic APIs via a proxy. The current API has almost everything we need, but since the proxy uses a custom certificate we also need to change the `verify` argument. This pull requests adds that ability.

I see that `_client.py` is generated by [Stainless](https://www.stainlessapi.com/), but I don't have access to it. Please let me know if I should move my changes to `_client.py` to somewhere else.

Thanks!