### PR TITLE
Add Type Validation for API Key and Auth Token to Prevent Common Configuration Errors

### DIFF
--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -105,10 +105,14 @@ class Anthropic(SyncAPIClient):
         """
         if api_key is None:
             api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if type(api_key) is not str:
+            raise ValueError("api_key must be a string")
         self.api_key = api_key
 
         if auth_token is None:
             auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+        if type(auth_token) is not str:
+            raise ValueError("auth_token must be a string")
         self.auth_token = auth_token
 
         if base_url is None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -77,6 +77,14 @@ class TestAnthropic:
         assert isinstance(response, httpx.Response)
         assert response.json() == {"foo": "bar"}
 
+    def test_bad_api_key_constructor(self) -> None:
+        with pytest.raises(TypeError, match="api_key must be a string"):
+            Anthropic(api_key=[])
+
+    def test_bad_auth_token_constructor(self) -> None:
+        with pytest.raises(TypeError, match="auth_token must be a string"):
+            Anthropic(api_key=[])
+
     def test_copy(self) -> None:
         copied = self.client.copy()
         assert id(copied) != id(self.client)


### PR DESCRIPTION
While integrating the Anthropic API client, I encountered an issue where I mistakenly passed the api_key as a list instead of a string. This led to several hours of debugging to identify the root cause of the issue, as the current implementation does not explicitly validate the type of api_key and auth_token upon instantiation of the Anthropic client class.

To prevent such issues for other developers and to enhance the usability of the API client, I propose adding explicit type validation for both api_key and auth_token parameters within the __init__ method of the Anthropic class. This small yet impactful change ensures that developers are immediately alerted with a clear and informative error message if the types of these parameters do not match the expected string type.

The proposed change has been implemented as follows:

