### PR TITLE
Remove checks for `project_id` in `load_auth()`

### DIFF
--- a/src/anthropic/lib/vertex/_auth.py
+++ b/src/anthropic/lib/vertex/_auth.py
@@ -23,12 +23,6 @@ def load_auth() -> tuple[Credentials, str]:
     )
     credentials.refresh(Request())
 
-    if not project_id:
-        raise ValueError("Could not resolve project_id")
-
-    if not isinstance(project_id, str):
-        raise TypeError(f"Expected project_id to be a str but got {type(project_id)}")
-
     return credentials, project_id
 
 


### PR DESCRIPTION
`AnthropicVertex` accepts `project_id` from the caller. So whether `load_auth()` could load the `project_id` from the Google credential should not be a hard requirement.

Right now, if `load_auth()` can't load the `project_id`, it raises `ValueError` and aborts any further execution.