### PR TITLE
Include almost all source files in sdist (#482)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,20 @@ include = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/anthropic"]
 
+[tool.hatch.build.targets.sdist]
+# Basically everything except hidden files/directories (such as .github, .devcontainers, .python-version, etc)
+include = [
+  "/*.json",
+  "/*.lock",
+  "/*.md",
+  "/mypy.ini",
+  "/noxfile.py",
+  "bin/*",
+  "examples/*",
+  "src/*",
+  "tests/*",
+]
+
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"
 


### PR DESCRIPTION
Presently, the sdist published to pypi cannot be built (failing as shown in #482), because hatch-fancy-pypi-readme is configured to read `README.md` but that file is not included in the source distribution.

Here we make the sdist _almost_ all-inclusive (differing from `git archive` output only by leaving out only hidden files and directories -- presently `.github`, `.devcontainers`, `.python-version`, and `.stats.yml`).