### PR TITLE
chore(tools): rely on pydantic's JSON parser instead of pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "distro>=1.7.0, <2",
     "sniffio",
     "cached-property; python_version < '3.8'",
-    "tokenizers >= 0.13.0"
+    "tokenizers >= 0.13.0",
+    "jiter>=0.1.0, <1",
 ]
 requires-python = ">= 3.7"
 classifiers = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -66,6 +66,8 @@ idna==3.4
 importlib-metadata==7.0.0
 iniconfig==2.0.0
     # via pytest
+jiter==0.1.0
+    # via anthropic
 jmespath==1.0.1
     # via boto3
     # via botocore

--- a/requirements.lock
+++ b/requirements.lock
@@ -49,6 +49,8 @@ idna==3.4
     # via anyio
     # via httpx
     # via requests
+jiter==0.1.0
+    # via anthropic
 jmespath==1.0.1
     # via boto3
     # via botocore

--- a/src/anthropic/lib/streaming/beta/_tools.py
+++ b/src/anthropic/lib/streaming/beta/_tools.py
@@ -465,18 +465,13 @@ def accumulate_event(
         if content.type == "text" and event.delta.type == "text_delta":
             content.text += event.delta.text
         elif content.type == "tool_use" and event.delta.type == "input_json_delta":
-            try:
-                from pydantic_core import from_json
-            except ImportError as exc:
-                raise RuntimeError(
-                    "Could not import `pydantic_core.from_json` which is required for tool use accumulation, do you have pydantic >= 2.7 installed?"
-                ) from exc
+            from jiter import from_json
 
             # we need to keep track of the raw JSON string as well so that we can
             # re-parse it for each delta, for now we just store it as an untyped
             # property on the snapshot
-            json_buf = cast(str, getattr(content, JSON_BUF_PROPERTY, ""))
-            json_buf += event.delta.partial_json
+            json_buf = cast(bytes, getattr(content, JSON_BUF_PROPERTY, b""))
+            json_buf += bytes(event.delta.partial_json, "utf-8")
 
             if json_buf:
                 content.input = from_json(json_buf, allow_partial=True)

--- a/src/anthropic/resources/beta/tools/messages.py
+++ b/src/anthropic/resources/beta/tools/messages.py
@@ -919,8 +919,6 @@ class Messages(SyncAPIResource):
         """Create a message stream with the beta tools API.
 
         https://docs.anthropic.com/en/docs/tool-use-examples
-
-        Note: unlike the rest of the SDK, this method requires `pydantic >= 2.7`.
         """
         ...
 
@@ -950,8 +948,6 @@ class Messages(SyncAPIResource):
         """Create a message stream with the beta tools API.
 
         https://docs.anthropic.com/en/docs/tool-use-examples
-
-        Note: unlike the rest of the SDK, this method requires `pydantic >= 2.7`.
         """
         ...
 
@@ -980,8 +976,6 @@ class Messages(SyncAPIResource):
         """Create a message stream with the beta tools API.
 
         https://docs.anthropic.com/en/docs/tool-use-examples
-
-        Note: unlike the rest of the SDK, this method requires `pydantic >= 2.7`.
         """
         extra_headers = {
             "X-Stainless-Stream-Helper": "messages",
@@ -1899,8 +1893,6 @@ class AsyncMessages(AsyncAPIResource):
         """Create a message stream with the beta tools API.
 
         https://docs.anthropic.com/en/docs/tool-use-examples
-
-        Note: unlike the rest of the SDK, this method requires `pydantic >= 2.7`.
         """
         ...
 
@@ -1930,8 +1922,6 @@ class AsyncMessages(AsyncAPIResource):
         """Create a message stream with the beta tools API.
 
         https://docs.anthropic.com/en/docs/tool-use-examples
-
-        Note: unlike the rest of the SDK, this method requires `pydantic >= 2.7`.
         """
         ...
 
@@ -1963,8 +1953,6 @@ class AsyncMessages(AsyncAPIResource):
         """Create a message stream with the beta tools API.
 
         https://docs.anthropic.com/en/docs/tool-use-examples
-
-        Note: unlike the rest of the SDK, this method requires `pydantic >= 2.7`.
         """
         extra_headers = {
             "X-Stainless-Stream-Helper": "messages",


### PR DESCRIPTION
This means we can loosen the pydantic version restriction that the tools helpers have :)