### PR TITLE
fix(beta): streaming breakage due to breaking change in dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "sniffio",
     "cached-property; python_version < '3.8'",
     "tokenizers >= 0.13.0",
-    "jiter>=0.1.0, <1",
+    "jiter>=0.4.0, <1",
 ]
 requires-python = ">= 3.7"
 classifiers = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -66,7 +66,7 @@ idna==3.4
 importlib-metadata==7.0.0
 iniconfig==2.0.0
     # via pytest
-jiter==0.1.0
+jiter==0.4.0
     # via anthropic
 jmespath==1.0.1
     # via boto3

--- a/requirements.lock
+++ b/requirements.lock
@@ -49,7 +49,7 @@ idna==3.4
     # via anyio
     # via httpx
     # via requests
-jiter==0.1.0
+jiter==0.4.0
     # via anthropic
 jmespath==1.0.1
     # via boto3

--- a/src/anthropic/lib/streaming/beta/_tools.py
+++ b/src/anthropic/lib/streaming/beta/_tools.py
@@ -474,7 +474,7 @@ def accumulate_event(
             json_buf += bytes(event.delta.partial_json, "utf-8")
 
             if json_buf:
-                content.input = from_json(json_buf, allow_partial=True)
+                content.input = from_json(json_buf, partial_mode=True)
 
             setattr(content, JSON_BUF_PROPERTY, json_buf)
     elif event.type == "message_delta":

--- a/src/anthropic/types/content_block.py
+++ b/src/anthropic/types/content_block.py
@@ -1,7 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 
-
 from .text_block import TextBlock
 
 ContentBlock = TextBlock

--- a/src/anthropic/types/message_delta_usage.py
+++ b/src/anthropic/types/message_delta_usage.py
@@ -1,7 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 
-
 from .._models import BaseModel
 
 __all__ = ["MessageDeltaUsage"]

--- a/src/anthropic/types/usage.py
+++ b/src/anthropic/types/usage.py
@@ -1,7 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 
-
 from .._models import BaseModel
 
 __all__ = ["Usage"]


### PR DESCRIPTION
Fixes https://github.com/anthropics/anthropic-sdk-python/issues/523

Chose v0.4.0 because it's the only release since v0.1.0: https://pypi.org/project/jiter/0.4.0/#history and I don't see a CHANGELOG at https://github.com/pydantic/jiter/tree/main/crates/jiter-python

Tested locally, with:
```sh
rye sync --all-features
rye run pytest
rye run format
rye run lint
```
the formatting command caused a few changes, so I am committing them too.

