### PR TITLE
fixing type in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ If you need to access undocumented endpoints, params, or response properties, th
 #### Undocumented endpoints
 
 To make requests to undocumented endpoints, you can make requests using `client.get`, `client.post`, and other
-http verbs. Options on the client will be respected (such as retries) will be respected when making this
+http verbs. Options on the client will be respected (such as retries) when making this
 request.
 
 ```py


### PR DESCRIPTION
"will be respected" was duplicated in text