### PR TITLE
Added Support to fetch aws region from aws config file .aws/config #537

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import boto3
 from typing import Any, Union, Mapping, TypeVar
 from typing_extensions import Self, override
 
@@ -116,6 +117,8 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
         self.aws_access_key = aws_access_key
 
+        session = boto3.Session()
+        aws_region = session.region_name
         if aws_region is None:
             aws_region = os.environ.get("AWS_REGION") or "us-east-1"
         self.aws_region = aws_region


### PR DESCRIPTION
What does this PR do?
This PR adds support to fetch the AWS region name from the ~/.aws/config file and use the environment variable as a fallback if the aws config is absent. It defaults to us-east-1 in case both of them are not present. It leverages boto3 which is already present in requirements. So no changes to requirements are required.

Tries to fix the issue raised here : #537 