### PR TITLE
WIP: update ToolResultBlockParam content type to accept Iterable[Co…

### DIFF
--- a/src/anthropic/types/tool_result_block_param.py
+++ b/src/anthropic/types/tool_result_block_param.py
@@ -18,6 +18,6 @@ class ToolResultBlockParam(TypedDict, total=False):
 
     type: Required[Literal["tool_result"]]
 
-    content: Iterable[Content]
+    content: Iterable[Content] | str
 
     is_error: bool


### PR DESCRIPTION
# Add support for string content in ToolResultBlockParam

## Description
This PR updates the `ToolResultBlockParam` type to support string content, aligning with the use case shown in the documentation:

> content: The result of the tool, as a string (e.g. "content": "15 degrees") or list of nested content blocks (e.g. "content": [{"type": "text", "text": "15 degrees"}]). These content blocks can use the text or image types.

The `content` field in `ToolResultBlockParam` now accepts either a string or an iterable of `Content` (which includes `TextBlockParam` and `ImageBlockParam`).

## Changes
- Updated the `content` field type in `ToolResultBlockParam` to `Union[Iterable[Content], str]`

## TODO
- [ ] Add unit tests to cover the new string content case
- [ ] Run existing tests to ensure no regressions
- [ ] Update any relevant documentation

## Status
This PR is currently a work in progress (WIP). Tests have not been run or added yet. Please do not merge until all TODOs are completed and tests pass. Also, not sure if this is supported out of the gate.