### PR TITLE
Prevent KeyError on Vertex retry.

### DIFF
--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -42,7 +42,7 @@ class BaseVertexClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         self,
         options: FinalRequestOptions,
     ) -> httpx.Request:
-        options = options.model_copy()
+        options = options.copy()
         
         if is_dict(options.json_data):
             options.json_data.setdefault("anthropic_version", DEFAULT_VERSION)

--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -42,6 +42,8 @@ class BaseVertexClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         self,
         options: FinalRequestOptions,
     ) -> httpx.Request:
+        options = options.model_copy()
+        
         if is_dict(options.json_data):
             options.json_data.setdefault("anthropic_version", DEFAULT_VERSION)
 


### PR DESCRIPTION
The `json_data.pop("model")` currently causes `KeyError: 'model'` when the request is internally retried after a server error.