### PR TITLE
feat(client): add the number of API call retries to the raw response API

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -1051,7 +1051,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
             response=response,
             stream=stream,
             stream_cls=stream_cls,
-            retry_count=options.get_max_retries(self.max_retries) - retries,
+            retries_taken=options.get_max_retries(self.max_retries) - retries,
         )
 
     def _retry_request(
@@ -1093,7 +1093,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         response: httpx.Response,
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
-        retry_count: int = 0,
+        retries_taken: int = 0,
     ) -> ResponseT:
         if response.request.headers.get(RAW_RESPONSE_HEADER) == "true":
             return cast(
@@ -1105,7 +1105,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
                     stream=stream,
                     stream_cls=stream_cls,
                     options=options,
-                    retry_count=retry_count,
+                    retries_taken=retries_taken,
                 ),
             )
 
@@ -1125,7 +1125,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
                     stream=stream,
                     stream_cls=stream_cls,
                     options=options,
-                    retry_count=retry_count,
+                    retries_taken=retries_taken,
                 ),
             )
 
@@ -1139,7 +1139,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
             stream=stream,
             stream_cls=stream_cls,
             options=options,
-            retry_count=retry_count,
+            retries_taken=retries_taken,
         )
         if bool(response.request.headers.get(RAW_RESPONSE_HEADER)):
             return cast(ResponseT, api_response)
@@ -1630,7 +1630,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             response=response,
             stream=stream,
             stream_cls=stream_cls,
-            retry_count=options.get_max_retries(self.max_retries) - retries,
+            retries_taken=options.get_max_retries(self.max_retries) - retries,
         )
 
     async def _retry_request(
@@ -1670,7 +1670,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         response: httpx.Response,
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
-        retry_count: int = 0,
+        retries_taken: int = 0,
     ) -> ResponseT:
         if response.request.headers.get(RAW_RESPONSE_HEADER) == "true":
             return cast(
@@ -1682,7 +1682,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
                     stream=stream,
                     stream_cls=stream_cls,
                     options=options,
-                    retry_count=retry_count,
+                    retries_taken=retries_taken,
                 ),
             )
 
@@ -1702,7 +1702,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
                     stream=stream,
                     stream_cls=stream_cls,
                     options=options,
-                    retry_count=retry_count,
+                    retries_taken=retries_taken,
                 ),
             )
 
@@ -1716,7 +1716,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             stream=stream,
             stream_cls=stream_cls,
             options=options,
-            retry_count=retry_count,
+            retries_taken=retries_taken,
         )
         if bool(response.request.headers.get(RAW_RESPONSE_HEADER)):
             return cast(ResponseT, api_response)

--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -1125,6 +1125,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
                     stream=stream,
                     stream_cls=stream_cls,
                     options=options,
+                    retry_count=retry_count,
                 ),
             )
 
@@ -1138,6 +1139,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
             stream=stream,
             stream_cls=stream_cls,
             options=options,
+            retry_count=retry_count,
         )
         if bool(response.request.headers.get(RAW_RESPONSE_HEADER)):
             return cast(ResponseT, api_response)
@@ -1700,6 +1702,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
                     stream=stream,
                     stream_cls=stream_cls,
                     options=options,
+                    retry_count=retry_count,
                 ),
             )
 
@@ -1713,6 +1716,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             stream=stream,
             stream_cls=stream_cls,
             options=options,
+            retry_count=retry_count,
         )
         if bool(response.request.headers.get(RAW_RESPONSE_HEADER)):
             return cast(ResponseT, api_response)

--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -964,9 +964,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         cast_to = self._maybe_override_cast_to(cast_to, options)
         options = self._prepare_options(options)
 
-        max_retries = options.get_max_retries(self.max_retries)
         retries = self._remaining_retries(remaining_retries, options)
-        retry_count = max_retries - retries
         request = self._build_request(options)
         self._prepare_request(request)
 
@@ -1053,7 +1051,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
             response=response,
             stream=stream,
             stream_cls=stream_cls,
-            retry_count=retry_count,
+            retry_count=options.get_max_retries(self.max_retries) - retries,
         )
 
     def _retry_request(
@@ -1095,7 +1093,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         response: httpx.Response,
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
-        retry_count: Optional[int] = 0,
+        retry_count: int = 0,
     ) -> ResponseT:
         if response.request.headers.get(RAW_RESPONSE_HEADER) == "true":
             return cast(
@@ -1551,9 +1549,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         cast_to = self._maybe_override_cast_to(cast_to, options)
         options = await self._prepare_options(options)
 
-        max_retries = options.get_max_retries(self.max_retries)
         retries = self._remaining_retries(remaining_retries, options)
-        retry_count = max_retries - retries
         request = self._build_request(options)
         await self._prepare_request(request)
 
@@ -1632,7 +1628,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             response=response,
             stream=stream,
             stream_cls=stream_cls,
-            retry_count=retry_count,
+            retry_count=options.get_max_retries(self.max_retries) - retries,
         )
 
     async def _retry_request(
@@ -1672,7 +1668,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         response: httpx.Response,
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
-        retry_count: Optional[int] = 0,
+        retry_count: int = 0,
     ) -> ResponseT:
         if response.request.headers.get(RAW_RESPONSE_HEADER) == "true":
             return cast(

--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -964,7 +964,9 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         cast_to = self._maybe_override_cast_to(cast_to, options)
         options = self._prepare_options(options)
 
+        max_retries = options.get_max_retries(self.max_retries)
         retries = self._remaining_retries(remaining_retries, options)
+        retry_count = max_retries - retries
         request = self._build_request(options)
         self._prepare_request(request)
 
@@ -1051,6 +1053,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
             response=response,
             stream=stream,
             stream_cls=stream_cls,
+            retry_count=retry_count,
         )
 
     def _retry_request(
@@ -1092,6 +1095,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         response: httpx.Response,
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
+        retry_count: Optional[int] = 0,
     ) -> ResponseT:
         if response.request.headers.get(RAW_RESPONSE_HEADER) == "true":
             return cast(
@@ -1103,6 +1107,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
                     stream=stream,
                     stream_cls=stream_cls,
                     options=options,
+                    retry_count=retry_count,
                 ),
             )
 
@@ -1546,7 +1551,9 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         cast_to = self._maybe_override_cast_to(cast_to, options)
         options = await self._prepare_options(options)
 
+        max_retries = options.get_max_retries(self.max_retries)
         retries = self._remaining_retries(remaining_retries, options)
+        retry_count = max_retries - retries
         request = self._build_request(options)
         await self._prepare_request(request)
 
@@ -1625,6 +1632,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             response=response,
             stream=stream,
             stream_cls=stream_cls,
+            retry_count=retry_count,
         )
 
     async def _retry_request(
@@ -1664,6 +1672,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         response: httpx.Response,
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
+        retry_count: Optional[int] = 0,
     ) -> ResponseT:
         if response.request.headers.get(RAW_RESPONSE_HEADER) == "true":
             return cast(
@@ -1675,6 +1684,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
                     stream=stream,
                     stream_cls=stream_cls,
                     options=options,
+                    retry_count=retry_count,
                 ),
             )
 

--- a/src/anthropic/_legacy_response.py
+++ b/src/anthropic/_legacy_response.py
@@ -64,7 +64,7 @@ class LegacyAPIResponse(Generic[R]):
 
     http_response: httpx.Response
 
-    retry_count: int
+    retries_taken: int
     """The number of retries made. If no retries happened this will be `0`"""
 
     def __init__(
@@ -76,7 +76,7 @@ class LegacyAPIResponse(Generic[R]):
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
         options: FinalRequestOptions,
-        retry_count: int = 0,
+        retries_taken: int = 0,
     ) -> None:
         self._cast_to = cast_to
         self._client = client
@@ -85,7 +85,7 @@ class LegacyAPIResponse(Generic[R]):
         self._stream_cls = stream_cls
         self._options = options
         self.http_response = raw
-        self.retry_count = retry_count
+        self.retries_taken = retries_taken
 
     @property
     def request_id(self) -> str | None:

--- a/src/anthropic/_legacy_response.py
+++ b/src/anthropic/_legacy_response.py
@@ -13,7 +13,6 @@ from typing import (
     TypeVar,
     Callable,
     Iterator,
-    Optional,
     AsyncIterator,
     cast,
     overload,
@@ -65,6 +64,9 @@ class LegacyAPIResponse(Generic[R]):
 
     http_response: httpx.Response
 
+    retry_count: int
+    """The number of retries made. If no retries happened this will be `0`"""
+
     def __init__(
         self,
         *,
@@ -74,7 +76,7 @@ class LegacyAPIResponse(Generic[R]):
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
         options: FinalRequestOptions,
-        retry_count: Optional[int] = 0,
+        retry_count: int = 0,
     ) -> None:
         self._cast_to = cast_to
         self._client = client

--- a/src/anthropic/_legacy_response.py
+++ b/src/anthropic/_legacy_response.py
@@ -5,7 +5,19 @@ import inspect
 import logging
 import datetime
 import functools
-from typing import TYPE_CHECKING, Any, Union, Generic, TypeVar, Callable, Iterator, AsyncIterator, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Union,
+    Generic,
+    TypeVar,
+    Callable,
+    Iterator,
+    Optional,
+    AsyncIterator,
+    cast,
+    overload,
+)
 from typing_extensions import Awaitable, ParamSpec, override, deprecated, get_origin
 
 import anyio
@@ -62,6 +74,7 @@ class LegacyAPIResponse(Generic[R]):
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
         options: FinalRequestOptions,
+        retry_count: Optional[int] = 0,
     ) -> None:
         self._cast_to = cast_to
         self._client = client
@@ -70,6 +83,7 @@ class LegacyAPIResponse(Generic[R]):
         self._stream_cls = stream_cls
         self._options = options
         self.http_response = raw
+        self.retry_count = retry_count
 
     @property
     def request_id(self) -> str | None:

--- a/src/anthropic/_response.py
+++ b/src/anthropic/_response.py
@@ -55,7 +55,7 @@ class BaseAPIResponse(Generic[R]):
 
     http_response: httpx.Response
 
-    retry_count: int
+    retries_taken: int
     """The number of retries made. If no retries happened this will be `0`"""
 
     def __init__(
@@ -67,7 +67,7 @@ class BaseAPIResponse(Generic[R]):
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
         options: FinalRequestOptions,
-        retry_count: int = 0,
+        retries_taken: int = 0,
     ) -> None:
         self._cast_to = cast_to
         self._client = client
@@ -76,7 +76,7 @@ class BaseAPIResponse(Generic[R]):
         self._stream_cls = stream_cls
         self._options = options
         self.http_response = raw
-        self.retry_count = retry_count
+        self.retries_taken = retries_taken
 
     @property
     def headers(self) -> httpx.Headers:

--- a/src/anthropic/_response.py
+++ b/src/anthropic/_response.py
@@ -55,6 +55,9 @@ class BaseAPIResponse(Generic[R]):
 
     http_response: httpx.Response
 
+    retry_count: int
+    """The number of retries made. If no retries happened this will be `0`"""
+
     def __init__(
         self,
         *,
@@ -64,6 +67,7 @@ class BaseAPIResponse(Generic[R]):
         stream: bool,
         stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
         options: FinalRequestOptions,
+        retry_count: int = 0,
     ) -> None:
         self._cast_to = cast_to
         self._client = client
@@ -72,6 +76,7 @@ class BaseAPIResponse(Generic[R]):
         self._stream_cls = stream_cls
         self._options = options
         self.http_response = raw
+        self.retry_count = retry_count
 
     @property
     def headers(self) -> httpx.Headers:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -876,7 +876,7 @@ class TestAnthropic:
 
         nb_retries = 0
 
-        def retry_handler(request):
+        def retry_handler(_request: httpx.Request) -> httpx.Response:
             nonlocal nb_retries
             if nb_retries < failures_before_success:
                 nb_retries += 1
@@ -1742,7 +1742,7 @@ class TestAsyncAnthropic:
 
         nb_retries = 0
 
-        async def retry_handler(request):
+        async def retry_handler(_request: httpx.Request) -> httpx.Response:
             nonlocal nb_retries
             if nb_retries < failures_before_success:
                 nb_retries += 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -871,7 +871,7 @@ class TestAnthropic:
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
     @mock.patch("anthropic._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)
-    def test_retry_count(self, client: Anthropic, failures_before_success: int, respx_mock: MockRouter) -> None:
+    def test_retries_taken(self, client: Anthropic, failures_before_success: int, respx_mock: MockRouter) -> None:
         client = client.with_options(max_retries=4)
 
         nb_retries = 0
@@ -890,18 +890,18 @@ class TestAnthropic:
             messages=[
                 {
                     "role": "user",
-                    "content": "Hello, Claude",
+                    "content": "Hello, world",
                 }
             ],
-            model="claude-3-opus-20240229",
+            model="claude-3-5-sonnet-20240620",
         )
 
-        assert response.retry_count == failures_before_success
+        assert response.retries_taken == failures_before_success
 
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
     @mock.patch("anthropic._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)
-    def test_retry_count_new_response_class(
+    def test_retries_taken_new_response_class(
         self, client: Anthropic, failures_before_success: int, respx_mock: MockRouter
     ) -> None:
         client = client.with_options(max_retries=4)
@@ -922,12 +922,12 @@ class TestAnthropic:
             messages=[
                 {
                     "role": "user",
-                    "content": "Hello, Claude",
+                    "content": "Hello, world",
                 }
             ],
-            model="claude-3-opus-20240229",
+            model="claude-3-5-sonnet-20240620",
         ) as response:
-            assert response.retry_count == failures_before_success
+            assert response.retries_taken == failures_before_success
 
 
 class TestAsyncAnthropic:
@@ -1768,14 +1768,14 @@ class TestAsyncAnthropic:
     @mock.patch("anthropic._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)
     @pytest.mark.asyncio
-    async def test_retry_count(
+    async def test_retries_taken(
         self, async_client: AsyncAnthropic, failures_before_success: int, respx_mock: MockRouter
     ) -> None:
         client = async_client.with_options(max_retries=4)
 
         nb_retries = 0
 
-        async def retry_handler(_request: httpx.Request) -> httpx.Response:
+        def retry_handler(_request: httpx.Request) -> httpx.Response:
             nonlocal nb_retries
             if nb_retries < failures_before_success:
                 nb_retries += 1
@@ -1789,26 +1789,26 @@ class TestAsyncAnthropic:
             messages=[
                 {
                     "role": "user",
-                    "content": "Hello, Claude",
+                    "content": "Hello, world",
                 }
             ],
-            model="claude-3-opus-20240229",
+            model="claude-3-5-sonnet-20240620",
         )
 
-        assert response.retry_count == failures_before_success
+        assert response.retries_taken == failures_before_success
 
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
     @mock.patch("anthropic._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)
     @pytest.mark.asyncio
-    async def test_retry_count_new_response_class(
+    async def test_retries_taken_new_response_class(
         self, async_client: AsyncAnthropic, failures_before_success: int, respx_mock: MockRouter
     ) -> None:
         client = async_client.with_options(max_retries=4)
 
         nb_retries = 0
 
-        async def retry_handler(_request: httpx.Request) -> httpx.Response:
+        def retry_handler(_request: httpx.Request) -> httpx.Response:
             nonlocal nb_retries
             if nb_retries < failures_before_success:
                 nb_retries += 1
@@ -1822,9 +1822,9 @@ class TestAsyncAnthropic:
             messages=[
                 {
                     "role": "user",
-                    "content": "Hello, Claude",
+                    "content": "Hello, world",
                 }
             ],
-            model="claude-3-opus-20240229",
+            model="claude-3-5-sonnet-20240620",
         ) as response:
-            assert response.retry_count == failures_before_success
+            assert response.retries_taken == failures_before_success


### PR DESCRIPTION
Closes #608.

**Changes proposed:**

- Add the number of API call retries to the raw response API.

**Example:**

```
response = client.messages.with_raw_response.create(...)
response.retry_count # 0
```