### PR TITLE
feat(bedrock): add `profile` argument to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,28 +201,14 @@ message = client.messages.create(
 print(message)
 ```
 
-or if you want to use a profile and region
+The bedrock client supports the following arguments for authentication
 
 ```py
-import os
-from anthropic import AnthropicBedrock
-
-PROFILE_NAME = os.getenv("PROFILE_NAME")
-REGION_NAME = os.getenv("REGION_NAME")
-
-client = AnthropicBedrock(aws_profile=PROFILE_NAME, aws_region=REGION_NAME)
-
-message = client.messages.create(
-    max_tokens=1024,
-    messages=[
-        {
-            "role": "user",
-            "content": "Hello!",
-        }
-    ],
-    model="anthropic.claude-3-sonnet-20240229-v1:0",
+AnthropicBedrock(
+  aws_profile='...',
+  aws_region='us-east'
+  ... etc
 )
-print(message)
 ```
 
 For a more fully fledged example see [`examples/bedrock.py`](https://github.com/anthropics/anthropic-sdk-python/blob/main/examples/bedrock.py).

--- a/README.md
+++ b/README.md
@@ -201,6 +201,30 @@ message = client.messages.create(
 print(message)
 ```
 
+or if you want to use a profile and region
+
+```py
+import os
+from anthropic import AnthropicBedrock
+
+PROFILE_NAME = os.getenv("PROFILE_NAME")
+REGION_NAME = os.getenv("REGION_NAME")
+
+client = AnthropicBedrock(aws_profile=PROFILE_NAME, aws_region=REGION_NAME)
+
+message = client.messages.create(
+    max_tokens=1024,
+    messages=[
+        {
+            "role": "user",
+            "content": "Hello!",
+        }
+    ],
+    model="anthropic.claude-3-sonnet-20240229-v1:0",
+)
+print(message)
+```
+
 For a more fully fledged example see [`examples/bedrock.py`](https://github.com/anthropics/anthropic-sdk-python/blob/main/examples/bedrock.py).
 
 ## Google Vertex

--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ The bedrock client supports the following arguments for authentication
 AnthropicBedrock(
   aws_profile='...',
   aws_region='us-east'
-  ... etc
+  aws_secret_key='...',
+  aws_access_key='...',
+  aws_session_token='...',
 )
 ```
 

--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -17,14 +17,16 @@ def _get_session(
     aws_secret_key: str | None,
     aws_session_token: str | None,
     region: str | None,
+    profile: str  | None,
 ) -> boto3.Session:
     import boto3
 
     return boto3.Session(
+        profile_name=profile,
         region_name=region,
         aws_access_key_id=aws_access_key,
         aws_secret_access_key=aws_secret_key,
-        aws_session_token=aws_session_token,
+        aws_session_token=aws_session_token
     )
 
 
@@ -37,12 +39,14 @@ def get_auth_headers(
     aws_secret_key: str | None,
     aws_session_token: str | None,
     region: str | None,
+    profile: str  | None,
     data: str | None,
 ) -> dict[str, str]:
     from botocore.auth import SigV4Auth
     from botocore.awsrequest import AWSRequest
 
     session = _get_session(
+        profile=profile,
         region=region,
         aws_access_key=aws_access_key,
         aws_secret_key=aws_secret_key,

--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -17,7 +17,7 @@ def _get_session(
     aws_secret_key: str | None,
     aws_session_token: str | None,
     region: str | None,
-    profile: str  | None,
+    profile: str | None,
 ) -> boto3.Session:
     import boto3
 
@@ -26,7 +26,7 @@ def _get_session(
         region_name=region,
         aws_access_key_id=aws_access_key,
         aws_secret_access_key=aws_secret_key,
-        aws_session_token=aws_session_token
+        aws_session_token=aws_session_token,
     )
 
 
@@ -39,7 +39,7 @@ def get_auth_headers(
     aws_secret_key: str | None,
     aws_session_token: str | None,
     region: str | None,
-    profile: str  | None,
+    profile: str | None,
     data: str | None,
 ) -> dict[str, str]:
     from botocore.auth import SigV4Auth

--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -94,6 +94,7 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
         aws_secret_key: str | None = None,
         aws_access_key: str | None = None,
         aws_region: str | None = None,
+        aws_profile: str | None = None,
         aws_session_token: str | None = None,
         base_url: str | httpx.URL | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
@@ -119,6 +120,7 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
         if aws_region is None:
             aws_region = os.environ.get("AWS_REGION") or "us-east-1"
         self.aws_region = aws_region
+        self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token
 
@@ -163,6 +165,7 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
             aws_secret_key=self.aws_secret_key,
             aws_session_token=self.aws_session_token,
             region=self.aws_region or "us-east-1",
+            profile=self.aws_profile,
             data=data,
         )
         request.headers.update(headers)
@@ -233,6 +236,7 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
         aws_secret_key: str | None = None,
         aws_access_key: str | None = None,
         aws_region: str | None = None,
+        aws_profile: str | None = None,
         aws_session_token: str | None = None,
         base_url: str | httpx.URL | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
@@ -258,6 +262,7 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
         if aws_region is None:
             aws_region = os.environ.get("AWS_REGION") or "us-east-1"
         self.aws_region = aws_region
+        self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token
 
@@ -302,6 +307,7 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
             aws_secret_key=self.aws_secret_key,
             aws_session_token=self.aws_session_token,
             region=self.aws_region or "us-east-1",
+            profile=self.aws_profile,
             data=data,
         )
         request.headers.update(headers)


### PR DESCRIPTION
Add profile option to Bedrock client for profile selection

This update introduces a profile option to the Bedrock client, allowing users to select which profile to use when interacting with the Bedrock client.

In my scenario, I use SSO to access the AWS account. When attempting to run the code locally, it initially failed. By passing the profile_name in the **boto3.Session()**, the issue was resolved.