### PR TITLE
fix(types): remove misleading betas TypedDict property for the Batch API

### DIFF
--- a/src/anthropic/types/beta/message_create_params.py
+++ b/src/anthropic/types/beta/message_create_params.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 from typing import List, Union, Iterable
-from typing_extensions import Literal, Required, Annotated, TypedDict
+from typing_extensions import Literal, Required, TypedDict
 
-from ..._utils import PropertyInfo
 from ..model_param import ModelParam
 from .beta_tool_param import BetaToolParam
 from .beta_message_param import BetaMessageParam
 from .beta_metadata_param import BetaMetadataParam
-from ..anthropic_beta_param import AnthropicBetaParam
 from .beta_text_block_param import BetaTextBlockParam
 from .beta_tool_choice_param import BetaToolChoiceParam
 
@@ -255,9 +253,6 @@ class MessageCreateParamsBase(TypedDict, total=False):
     Recommended for advanced use cases only. You usually only need to use
     `temperature`.
     """
-
-    betas: Annotated[List[AnthropicBetaParam], PropertyInfo(alias="anthropic-beta")]
-    """Optional header to specify the beta version(s) you want to use."""
 
 
 class MessageCreateParamsNonStreaming(MessageCreateParamsBase, total=False):

--- a/src/anthropic/types/beta/prompt_caching/message_create_params.py
+++ b/src/anthropic/types/beta/prompt_caching/message_create_params.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from typing import List, Union, Iterable
-from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
+from typing_extensions import Literal, Required, TypeAlias, TypedDict
 
-from ...._utils import PropertyInfo
 from ...model_param import ModelParam
 from ...metadata_param import MetadataParam
 from ...tool_choice_param import ToolChoiceParam
-from ...anthropic_beta_param import AnthropicBetaParam
 from ...tool_choice_any_param import ToolChoiceAnyParam
 from ...tool_choice_auto_param import ToolChoiceAutoParam
 from ...tool_choice_tool_param import ToolChoiceToolParam
@@ -267,9 +265,6 @@ class MessageCreateParamsBase(TypedDict, total=False):
     Recommended for advanced use cases only. You usually only need to use
     `temperature`.
     """
-
-    betas: Annotated[List[AnthropicBetaParam], PropertyInfo(alias="anthropic-beta")]
-    """Optional header to specify the beta version(s) you want to use."""
 
 
 Metadata: TypeAlias = MetadataParam


### PR DESCRIPTION
This is now a type error in the Batch API as the nested `betas` key won't actually do anything, you need to provide it at the top-level
```py
client.beta.messages.batches.create(
    requests=[
        {
            "custom_id": "...",
            "params": {
                "model": "claude-3-sonnet-20240229",
                "messages": [],
                "max_tokens": 1024,
                "betas": [...],
            },
        }
    ]
)
```