### PR TITLE
fix(bedrock): correct URL encoding for model params

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -48,7 +48,7 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
             raise RuntimeError("Expected dictionary json_data for post /completions endpoint")
 
         model = options.json_data.pop("model", None)
-        model = urllib.parse.quote(model, safe="")
+        model = urllib.parse.quote(str(model), safe=":")
         stream = options.json_data.pop("stream", False)
         if stream:
             options.url = f"/model/{model}/invoke-with-response-stream"

--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import urllib.parse
 from typing import Any, Union, Mapping, TypeVar
 from typing_extensions import Self, override
 
@@ -47,6 +48,7 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
             raise RuntimeError("Expected dictionary json_data for post /completions endpoint")
 
         model = options.json_data.pop("model", None)
+        model = urllib.parse.quote(model, safe="")
         stream = options.json_data.pop("stream", False)
         if stream:
             options.url = f"/model/{model}/invoke-with-response-stream"

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -118,9 +118,9 @@ def test_application_inference_profile(respx_mock: MockRouter) -> None:
 
     assert (
         calls[0].request.url
-        == "https://bedrock-runtime.us-east-1.amazonaws.com/model/arn%3Aaws%3Abedrock%3Aus-east-1%3A123456789012%3Aapplication-inference-profile%2Fjf2sje1c0jnb/invoke"
+        == "https://bedrock-runtime.us-east-1.amazonaws.com/model/arn:aws:bedrock:us-east-1:123456789012:application-inference-profile%2Fjf2sje1c0jnb/invoke"
     )
     assert (
         calls[1].request.url
-        == "https://bedrock-runtime.us-east-1.amazonaws.com/model/arn%3Aaws%3Abedrock%3Aus-east-1%3A123456789012%3Aapplication-inference-profile%2Fjf2sje1c0jnb/invoke"
+        == "https://bedrock-runtime.us-east-1.amazonaws.com/model/arn:aws:bedrock:us-east-1:123456789012:application-inference-profile%2Fjf2sje1c0jnb/invoke"
     )


### PR DESCRIPTION
This pull request fixes an issue #740 by using Bedrock's Application Profile.