### PR TITLE
refactor(vertex): remove deprecated HTTP client options 

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -55,11 +55,11 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
         else:
             options.url = f"/model/{model}/invoke"
 
-    if options.url.startswith('/v1/messages/batches'):
-        raise AnthropicError('The Batch API is not supported in Bedrock yet')
-    
-    if options.url == '/v1/messages/count_tokens':
-        raise AnthropicError('Token counting is not supported in Bedrock yet')
+    if options.url.startswith("/v1/messages/batches"):
+        raise AnthropicError("The Batch API is not supported in Bedrock yet")
+
+    if options.url == "/v1/messages/count_tokens":
+        raise AnthropicError("Token counting is not supported in Bedrock yet")
 
     return options
 

--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -9,7 +9,7 @@ import httpx
 from ... import _exceptions
 from ._auth import load_auth, refresh_auth
 from ._beta import Beta, AsyncBeta
-from ..._types import NOT_GIVEN, NotGiven, Transport, ProxiesTypes, AsyncTransport
+from ..._types import NOT_GIVEN, NotGiven
 from ..._utils import is_dict, asyncify, is_given
 from ..._compat import model_copy, typed_cached_property
 from ..._models import FinalRequestOptions
@@ -18,12 +18,9 @@ from ..._streaming import Stream, AsyncStream
 from ..._exceptions import AnthropicError, APIStatusError
 from ..._base_client import (
     DEFAULT_MAX_RETRIES,
-    DEFAULT_CONNECTION_LIMITS,
     BaseClient,
     SyncAPIClient,
     AsyncAPIClient,
-    SyncHttpxClientWrapper,
-    AsyncHttpxClientWrapper,
 )
 from ...resources.messages import Messages, AsyncMessages
 
@@ -102,12 +99,6 @@ class AnthropicVertex(BaseVertexClient[httpx.Client, Stream[Any]], SyncAPIClient
         default_query: Mapping[str, object] | None = None,
         # Configure a custom httpx client. See the [httpx documentation](https://www.python-httpx.org/api/#client) for more details.
         http_client: httpx.Client | None = None,
-        # See httpx documentation for [custom transports](https://www.python-httpx.org/advanced/#custom-transports)
-        transport: Transport | None = None,
-        # See httpx documentation for [proxies](https://www.python-httpx.org/advanced/#http-proxying)
-        proxies: ProxiesTypes | None = None,
-        # See httpx documentation for [limits](https://www.python-httpx.org/advanced/#pool-limit-configuration)
-        connection_pool_limits: httpx.Limits | None = None,
         _strict_response_validation: bool = False,
     ) -> None:
         if not is_given(region):
@@ -130,9 +121,6 @@ class AnthropicVertex(BaseVertexClient[httpx.Client, Stream[Any]], SyncAPIClient
             custom_headers=default_headers,
             custom_query=default_query,
             http_client=http_client,
-            transport=transport,
-            proxies=proxies,
-            limits=connection_pool_limits,
             _strict_response_validation=_strict_response_validation,
         )
 
@@ -186,7 +174,6 @@ class AnthropicVertex(BaseVertexClient[httpx.Client, Stream[Any]], SyncAPIClient
         base_url: str | httpx.URL | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx.Client | None = None,
-        connection_pool_limits: httpx.Limits | None = None,
         max_retries: int | NotGiven = NOT_GIVEN,
         default_headers: Mapping[str, str] | None = None,
         set_default_headers: Mapping[str, str] | None = None,
@@ -215,23 +202,7 @@ class AnthropicVertex(BaseVertexClient[httpx.Client, Stream[Any]], SyncAPIClient
         elif set_default_query is not None:
             params = set_default_query
 
-        if connection_pool_limits is not None:
-            if http_client is not None:
-                raise ValueError("The 'http_client' argument is mutually exclusive with 'connection_pool_limits'")
-
-            if not isinstance(self._client, SyncHttpxClientWrapper):
-                raise ValueError(
-                    "A custom HTTP client has been set and is mutually exclusive with the 'connection_pool_limits' argument"
-                )
-
-            http_client = None
-        else:
-            if self._limits is not DEFAULT_CONNECTION_LIMITS:
-                connection_pool_limits = self._limits
-            else:
-                connection_pool_limits = None
-
-            http_client = http_client or self._client
+        http_client = http_client or self._client
 
         return self.__class__(
             region=region if is_given(region) else self.region,
@@ -270,12 +241,6 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
         default_query: Mapping[str, object] | None = None,
         # Configure a custom httpx client. See the [httpx documentation](https://www.python-httpx.org/api/#client) for more details.
         http_client: httpx.AsyncClient | None = None,
-        # See httpx documentation for [custom transports](https://www.python-httpx.org/advanced/#custom-transports)
-        transport: AsyncTransport | None = None,
-        # See httpx documentation for [proxies](https://www.python-httpx.org/advanced/#http-proxying)
-        proxies: ProxiesTypes | None = None,
-        # See httpx documentation for [limits](https://www.python-httpx.org/advanced/#pool-limit-configuration)
-        connection_pool_limits: httpx.Limits | None = None,
         _strict_response_validation: bool = False,
     ) -> None:
         if not is_given(region):
@@ -298,9 +263,6 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
             custom_headers=default_headers,
             custom_query=default_query,
             http_client=http_client,
-            transport=transport,
-            proxies=proxies,
-            limits=connection_pool_limits,
             _strict_response_validation=_strict_response_validation,
         )
 
@@ -354,7 +316,6 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
         base_url: str | httpx.URL | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx.AsyncClient | None = None,
-        connection_pool_limits: httpx.Limits | None = None,
         max_retries: int | NotGiven = NOT_GIVEN,
         default_headers: Mapping[str, str] | None = None,
         set_default_headers: Mapping[str, str] | None = None,
@@ -383,23 +344,7 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
         elif set_default_query is not None:
             params = set_default_query
 
-        if connection_pool_limits is not None:
-            if http_client is not None:
-                raise ValueError("The 'http_client' argument is mutually exclusive with 'connection_pool_limits'")
-
-            if not isinstance(self._client, AsyncHttpxClientWrapper):
-                raise ValueError(
-                    "A custom HTTP client has been set and is mutually exclusive with the 'connection_pool_limits' argument"
-                )
-
-            http_client = None
-        else:
-            if self._limits is not DEFAULT_CONNECTION_LIMITS:
-                connection_pool_limits = self._limits
-            else:
-                connection_pool_limits = None
-
-            http_client = http_client or self._client
+        http_client = http_client or self._client
 
         return self.__class__(
             region=region if is_given(region) else self.region,

--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -394,7 +394,7 @@ def _prepare_options(input_options: FinalRequestOptions, *, project_id: str | No
 
         options.url = f"/projects/{project_id}/locations/{region}/publishers/anthropic/models/count-tokens:rawPredict"
 
-    if options.url.startswith('/v1/messages/batches'):
-        raise AnthropicError('The Batch API is not supported in the Vertex client yet')
-    
+    if options.url.startswith("/v1/messages/batches"):
+        raise AnthropicError("The Batch API is not supported in the Vertex client yet")
+
     return options


### PR DESCRIPTION
These were already removed from the main client, if you're still using these, you should pass a custom `http_client` instance instead
https://github.com/anthropics/anthropic-sdk-python?tab=readme-ov-file#configuring-the-http-client