### PR TITLE
anthropic.types.tool_param.InputSchema: Explicitly define allowed top-level keys (#485)

### DIFF
--- a/src/anthropic/types/tool_param.py
+++ b/src/anthropic/types/tool_param.py
@@ -10,13 +10,36 @@ from .cache_control_ephemeral_param import CacheControlEphemeralParam
 __all__ = ["ToolParam", "InputSchema"]
 
 
-class InputSchemaTyped(TypedDict, total=False):
-    type: Required[Literal["object"]]
+InputSchemaTyped = TypedDict(
+    'InputSchemaType',
+    {
+        '$comment': str,
+        '$defs': object,
+        '$dynamicAnchor': str,
+        '$dynamicRef': str,
+        '$id': str,
+        '$schema': str,
+        'additionalProperties': bool,
+        'default': object,
+        'deprecated': bool,
+        'examples': list[object],
+        'if': object,
+        'maxProperties': int,
+        'minProperties': int,
+        'patternProperties': object,
+        'properties': object,
+        'readOnly': bool,
+        'writeOnly': bool,
+        'then': object,
+        'title': str,
+        'description': str,
+        'type': Required[Literal["object"]],
+        'unevaluatedProperties': bool,
+    },
+    total=False,
+)
 
-    properties: Optional[object]
-
-
-InputSchema: TypeAlias = Union[InputSchemaTyped, Dict[str, object]]
+InputSchema: TypeAlias = InputSchemaTyped
 
 
 class ToolParam(TypedDict, total=False):


### PR DESCRIPTION
The original fix to #485 does not actually work: pydantic discards fields other than `type` and `properties` when coercing to an `InputSchema`.

This is an alternate approach that explicitly sets out the fields allowed by the JSONSchema specification, ensuring that none of these fields will be stripped.