### PR TITLE
feat(client): add more status exceptions

### DIFF
--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -257,11 +257,17 @@ class Anthropic(SyncAPIClient):
         if response.status_code == 409:
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
+        if response.status_code == 413:
+            return _exceptions.RequestTooLargeError(err_msg, response=response, body=body)
+
         if response.status_code == 422:
             return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
 
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
+
+        if response.status_code == 529:
+            return _exceptions.OverloadedError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)

--- a/src/anthropic/_exceptions.py
+++ b/src/anthropic/_exceptions.py
@@ -98,12 +98,28 @@ class ConflictError(APIStatusError):
     status_code: Literal[409] = 409  # pyright: ignore[reportIncompatibleVariableOverride]
 
 
+class RequestTooLargeError(APIStatusError):
+    status_code: Literal[413] = 413  # pyright: ignore[reportIncompatibleVariableOverride]
+
+
 class UnprocessableEntityError(APIStatusError):
     status_code: Literal[422] = 422  # pyright: ignore[reportIncompatibleVariableOverride]
 
 
 class RateLimitError(APIStatusError):
     status_code: Literal[429] = 429  # pyright: ignore[reportIncompatibleVariableOverride]
+
+
+class ServiceUnavailableError(APIStatusError):
+    status_code: Literal[503] = 503  # pyright: ignore[reportIncompatibleVariableOverride]
+
+
+class OverloadedError(APIStatusError):
+    status_code: Literal[529] = 529  # pyright: ignore[reportIncompatibleVariableOverride]
+
+
+class DeadlineExceededError(APIStatusError):
+    status_code: Literal[504] = 504  # pyright: ignore[reportIncompatibleVariableOverride]
 
 
 class InternalServerError(APIStatusError):

--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -94,6 +94,9 @@ class BaseBedrockClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
 
+        if response.status_code == 503:
+            return _exceptions.ServiceUnavailableError(err_msg, response=response, body=body)
+
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)
         return APIStatusError(err_msg, response=response, body=body)

--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -76,6 +76,12 @@ class BaseVertexClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
 
+        if response.status_code == 503:
+            return _exceptions.ServiceUnavailableError(err_msg, response=response, body=body)
+
+        if response.status_code == 504:
+            return _exceptions.DeadlineExceededError(err_msg, response=response, body=body)
+
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)
         return APIStatusError(err_msg, response=response, body=body)


### PR DESCRIPTION
Related issue: https://github.com/anthropics/anthropic-sdk-python/issues/853

This PR adds the exception codes mentioned in 

- https://docs.anthropic.com/en/api/errors
- https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/api-errors
- https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html#API_runtime_InvokeModel_Errors

The main motivation is allowing for easier handling if an API provider throws a 503/529 to indicate overload as it allows for an application to have retry logic built in easier.