### PR TITLE
fix(sockets): handle non-portable socket flags

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -794,14 +794,17 @@ class _DefaultHttpxClient(httpx.Client):
                 (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
             ]
 
-            if getattr(socket, 'TCP_KEEPINTVL', None) is not None:
-                socket_options += [(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60)]
-            elif sys.platform == 'darwin':
-                TCP_KEEPALIVE = getattr(socket, 'TCP_KEEPALIVE', 0x10)
-                socket_options += [(socket.IPPROTO_TCP, TCP_KEEPALIVE, 60)]
+            TCP_KEEPINTVL = getattr(socket, "TCP_KEEPINTVL", None)
+            
+            if TCP_KEEPINTVL is not None:
+                socket_options.append((socket.IPPROTO_TCP, TCP_KEEPINTVL, 60))
+            elif sys.platform == "darwin":
+                TCP_KEEPALIVE = getattr(socket, "TCP_KEEPALIVE", 0x10)
+                socket_options.append((socket.IPPROTO_TCP, TCP_KEEPALIVE, 60))
 
-            if getattr(socket, 'TCP_KEEPCNT', None) is not None:
-                socket_options += [(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)]
+            TCP_KEEPCNT = getattr(socket, "TCP_KEEPCNT", None)
+            if TCP_KEEPCNT is not None:
+                socket_options.append((socket.IPPROTO_TCP, TCP_KEEPCNT, 5))
 
             TCP_KEEPIDLE = getattr(socket, "TCP_KEEPIDLE", None)
             if TCP_KEEPIDLE is not None:

--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -791,10 +791,18 @@ class _DefaultHttpxClient(httpx.Client):
 
         if "transport" not in kwargs:
             socket_options = [
-                (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True),
-                (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
-                (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5),
+                (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
             ]
+
+            if getattr(socket, 'TCP_KEEPINTVL', None) is not None:
+                socket_options += [(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60)]
+            elif sys.platform == 'darwin':
+                TCP_KEEPALIVE = getattr(socket, 'TCP_KEEPALIVE', 0x10)
+                socket_options += [(socket.IPPROTO_TCP, TCP_KEEPALIVE, 60)]
+
+            if getattr(socket, 'TCP_KEEPCNT', None) is not None:
+                socket_options += [(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)]
+
             TCP_KEEPIDLE = getattr(socket, "TCP_KEEPIDLE", None)
             if TCP_KEEPIDLE is not None:
                 socket_options.append((socket.IPPROTO_TCP, TCP_KEEPIDLE, 60))

--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -30,6 +30,8 @@ from typing import (
     AsyncIterator,
     cast,
     overload,
+    List,
+    Tuple
 )
 from typing_extensions import Literal, override, get_origin
 
@@ -790,7 +792,7 @@ class _DefaultHttpxClient(httpx.Client):
         kwargs.setdefault("follow_redirects", True)
 
         if "transport" not in kwargs:
-            socket_options = [
+            socket_options:List[Tuple[int, int, Union[int, bool]]] = [
                 (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
             ]
 
@@ -1403,7 +1405,7 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("follow_redirects", True)
 
         if "transport" not in kwargs:
-            socket_options = [
+            socket_options:List[Tuple[int, int, Union[int, bool]]] = [
                 (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
             ]
 

--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -1404,10 +1404,21 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
 
         if "transport" not in kwargs:
             socket_options = [
-                (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True),
-                (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
-                (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5),
+                (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
             ]
+
+            TCP_KEEPINTVL = getattr(socket, "TCP_KEEPINTVL", None)
+            
+            if TCP_KEEPINTVL is not None:
+                socket_options.append((socket.IPPROTO_TCP, TCP_KEEPINTVL, 60))
+            elif sys.platform == "darwin":
+                TCP_KEEPALIVE = getattr(socket, "TCP_KEEPALIVE", 0x10)
+                socket_options.append((socket.IPPROTO_TCP, TCP_KEEPALIVE, 60))
+
+            TCP_KEEPCNT = getattr(socket, "TCP_KEEPCNT", None)
+            if TCP_KEEPCNT is not None:
+                socket_options.append((socket.IPPROTO_TCP, TCP_KEEPCNT, 5))
+
             TCP_KEEPIDLE = getattr(socket, "TCP_KEEPIDLE", None)
             if TCP_KEEPIDLE is not None:
                 socket_options.append((socket.IPPROTO_TCP, TCP_KEEPIDLE, 60))

--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -18,7 +18,9 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    List,
     Type,
+    Tuple,
     Union,
     Generic,
     Mapping,
@@ -30,8 +32,6 @@ from typing import (
     AsyncIterator,
     cast,
     overload,
-    List,
-    Tuple
 )
 from typing_extensions import Literal, override, get_origin
 
@@ -792,12 +792,10 @@ class _DefaultHttpxClient(httpx.Client):
         kwargs.setdefault("follow_redirects", True)
 
         if "transport" not in kwargs:
-            socket_options:List[Tuple[int, int, Union[int, bool]]] = [
-                (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
-            ]
+            socket_options: List[Tuple[int, int, Union[int, bool]]] = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)]
 
             TCP_KEEPINTVL = getattr(socket, "TCP_KEEPINTVL", None)
-            
+
             if TCP_KEEPINTVL is not None:
                 socket_options.append((socket.IPPROTO_TCP, TCP_KEEPINTVL, 60))
             elif sys.platform == "darwin":
@@ -1405,12 +1403,10 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("follow_redirects", True)
 
         if "transport" not in kwargs:
-            socket_options:List[Tuple[int, int, Union[int, bool]]] = [
-                (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
-            ]
+            socket_options: List[Tuple[int, int, Union[int, bool]]] = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)]
 
             TCP_KEEPINTVL = getattr(socket, "TCP_KEEPINTVL", None)
-            
+
             if TCP_KEEPINTVL is not None:
                 socket_options.append((socket.IPPROTO_TCP, TCP_KEEPINTVL, 60))
             elif sys.platform == "darwin":


### PR DESCRIPTION
I'm trying to use the anthropic-sdk on both Windows and macOS, but I'm encountering the following error on both platforms:

```
anthropic\_base_client.py:795 Message: AttributeError: module 'socket' has no attribute 'TCP_KEEPINTVL'
```

After investigating, I found that the socket.TCP_KEEPINTVL attribute isn't available on all platforms, particularly Windows and macOS.

To resolve the issue locally, I modified _base_client.py as follows:

```
if "transport" not in kwargs:
    socket_options = [
        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True)
    ]

    if getattr(socket, 'TCP_KEEPINTVL', None) is not None:
        socket_options += [(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60)]
    elif sys.platform == 'darwin':
        TCP_KEEPALIVE = getattr(socket, 'TCP_KEEPALIVE', 0x10)
        socket_options += [(socket.IPPROTO_TCP, TCP_KEEPALIVE, 60)]

    if getattr(socket, 'TCP_KEEPCNT', None) is not None:
        socket_options += [(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5)]

    TCP_KEEPIDLE = getattr(socket, "TCP_KEEPIDLE", None)
    if TCP_KEEPIDLE is not None:
        socket_options.append((socket.IPPROTO_TCP, TCP_KEEPIDLE, 60))
```
With this change, the SDK works as expected on both platforms.

Issue link: https://github.com/anthropics/anthropic-sdk-python/issues/930