### PR TITLE
fix(vertex,bedrock): Added missing stream and batches method to vertex and bedrock beta libs

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,7 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    stream = FirstPartyMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +37,7 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    stream = FirstPartyAsyncMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:

--- a/src/anthropic/lib/vertex/_beta_messages.py
+++ b/src/anthropic/lib/vertex/_beta_messages.py
@@ -13,6 +13,7 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    stream = FirstPartyMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +37,7 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    stream = FirstPartyAsyncMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:


### PR DESCRIPTION
Bedrock and vertex client doesn't currently expose .beta.messages.stream and .beta.messages.batches