### PR TITLE
feat(vertex): support global region endpoint

### DIFF
--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -117,7 +117,10 @@ class AnthropicVertex(BaseVertexClient[httpx.Client, Stream[Any]], SyncAPIClient
         if base_url is None:
             base_url = os.environ.get("ANTHROPIC_VERTEX_BASE_URL")
             if base_url is None:
-                base_url = f"https://{region}-aiplatform.googleapis.com/v1"
+                if region == "global":
+                    base_url = "https://aiplatform.googleapis.com/v1"
+                else:
+                    base_url = f"https://{region}-aiplatform.googleapis.com/v1"
 
         super().__init__(
             version=__version__,
@@ -259,7 +262,10 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
         if base_url is None:
             base_url = os.environ.get("ANTHROPIC_VERTEX_BASE_URL")
             if base_url is None:
-                base_url = f"https://{region}-aiplatform.googleapis.com/v1"
+                if region == "global":
+                    base_url = "https://aiplatform.googleapis.com/v1"
+                else:
+                    base_url = f"https://{region}-aiplatform.googleapis.com/v1"
 
         super().__init__(
             version=__version__,


### PR DESCRIPTION
Vertex supports a `global` region, which redirects requests to any available region serving the model you're trying to access.  

When specifying a `global` region, the expected endpoint URL changes from `https://{region}-aiplatform.googleapis.com/v1` to `https://aiplatform.googleapis.com/v1`.

This PR adds support for the `global` region.