### PR TITLE
fix(docs): remove reference to rye shell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,7 @@ $ rye sync --all-features
 You can then run scripts using `rye run python script.py` or by activating the virtual environment:
 
 ```sh
-$ rye shell
-# or manually activate - https://docs.python.org/3/library/venv.html#how-venvs-work
+# Activate the virtual environment - https://docs.python.org/3/library/venv.html#how-venvs-work
 $ source .venv/bin/activate
 
 # now you can omit the `rye run` prefix


### PR DESCRIPTION
👋 Hi, this small PR removes a reference to 'rye shell'

The command was removed from rye due to https://github.com/astral-sh/rye/issues/601 ( and through https://github.com/astral-sh/rye/pull/602 )

The Rye's author recommends using venv, which this contributing guide already recommends, so I just deleted reference to `rye shell`.
