### PR TITLE
Rename `http_client` on `http_async_client` in Anthropic(Client)

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -1439,7 +1439,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         _strict_response_validation: bool,
         max_retries: int = DEFAULT_MAX_RETRIES,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
-        http_client: httpx.AsyncClient | None = None,
+        http_async_client: httpx.AsyncClient | None = None,
         custom_headers: Mapping[str, str] | None = None,
         custom_query: Mapping[str, object] | None = None,
     ) -> None:
@@ -1451,14 +1451,14 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             # where they've explicitly set the timeout to match the default timeout
             # as this check is structural, meaning that we'll think they didn't
             # pass in a timeout and will ignore it
-            if http_client and http_client.timeout != HTTPX_DEFAULT_TIMEOUT:
-                timeout = http_client.timeout
+            if http_async_client and http_async_client.timeout != HTTPX_DEFAULT_TIMEOUT:
+                timeout = http_async_client.timeout
             else:
                 timeout = DEFAULT_TIMEOUT
 
-        if http_client is not None and not isinstance(http_client, httpx.AsyncClient):  # pyright: ignore[reportUnnecessaryIsInstance]
+        if http_async_client is not None and not isinstance(http_async_client, httpx.AsyncClient):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise TypeError(
-                f"Invalid `http_client` argument; Expected an instance of `httpx.AsyncClient` but got {type(http_client)}"
+                f"Invalid `http_async_client` argument; Expected an instance of `httpx.AsyncClient` but got {type(http_async_client)}"
             )
 
         super().__init__(
@@ -1471,7 +1471,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             custom_headers=custom_headers,
             _strict_response_validation=_strict_response_validation,
         )
-        self._client = http_client or AsyncHttpxClientWrapper(
+        self._client = http_async_client or AsyncHttpxClientWrapper(
             base_url=base_url,
             # cast to a valid type because mypy doesn't understand our type narrowing
             timeout=cast(Timeout, timeout),

--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -312,7 +312,7 @@ class AsyncAnthropic(AsyncAPIClient):
         # Configure a custom httpx client.
         # We provide a `DefaultAsyncHttpxClient` class that you can pass to retain the default values we use for `limits`, `timeout` & `follow_redirects`.
         # See the [httpx documentation](https://www.python-httpx.org/api/#asyncclient) for more details.
-        http_client: httpx.AsyncClient | None = None,
+        http_async_client: httpx.AsyncClient | None = None,
         # Enable or disable schema validation for data returned by the API.
         # When enabled an error APIResponseValidationError is raised
         # if the API responds with invalid data for the expected schema.
@@ -347,7 +347,7 @@ class AsyncAnthropic(AsyncAPIClient):
             base_url=base_url,
             max_retries=max_retries,
             timeout=timeout,
-            http_client=http_client,
+            http_async_client=http_async_client,
             custom_headers=default_headers,
             custom_query=default_query,
             _strict_response_validation=_strict_response_validation,
@@ -444,7 +444,7 @@ class AsyncAnthropic(AsyncAPIClient):
         auth_token: str | None = None,
         base_url: str | httpx.URL | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
-        http_client: httpx.AsyncClient | None = None,
+        http_async_client: httpx.AsyncClient | None = None,
         max_retries: int | NotGiven = NOT_GIVEN,
         default_headers: Mapping[str, str] | None = None,
         set_default_headers: Mapping[str, str] | None = None,
@@ -473,13 +473,13 @@ class AsyncAnthropic(AsyncAPIClient):
         elif set_default_query is not None:
             params = set_default_query
 
-        http_client = http_client or self._client
+        http_async_client = http_async_client or self._client
         return self.__class__(
             api_key=api_key or self.api_key,
             auth_token=auth_token or self.auth_token,
             base_url=base_url or self.base_url,
             timeout=self.timeout if isinstance(timeout, NotGiven) else timeout,
-            http_client=http_client,
+            http_async_client=http_async_client,
             max_retries=max_retries if is_given(max_retries) else self.max_retries,
             default_headers=headers,
             default_query=params,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1199,7 +1199,7 @@ class TestAsyncAnthropic:
         # custom timeout given to the httpx client should be used
         async with httpx.AsyncClient(timeout=None) as http_client:
             client = AsyncAnthropic(
-                base_url=base_url, api_key=api_key, _strict_response_validation=True, http_client=http_client
+                base_url=base_url, api_key=api_key, _strict_response_validation=True, http_async_client=http_client
             )
 
             request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
@@ -1209,7 +1209,7 @@ class TestAsyncAnthropic:
         # no timeout given to the httpx client should not use the httpx default
         async with httpx.AsyncClient() as http_client:
             client = AsyncAnthropic(
-                base_url=base_url, api_key=api_key, _strict_response_validation=True, http_client=http_client
+                base_url=base_url, api_key=api_key, _strict_response_validation=True, http_async_client=http_client
             )
 
             request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
@@ -1219,7 +1219,7 @@ class TestAsyncAnthropic:
         # explicitly passing the default timeout currently results in it being ignored
         async with httpx.AsyncClient(timeout=HTTPX_DEFAULT_TIMEOUT) as http_client:
             client = AsyncAnthropic(
-                base_url=base_url, api_key=api_key, _strict_response_validation=True, http_client=http_client
+                base_url=base_url, api_key=api_key, _strict_response_validation=True, http_async_client=http_client
             )
 
             request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
@@ -1227,13 +1227,13 @@ class TestAsyncAnthropic:
             assert timeout == DEFAULT_TIMEOUT  # our default
 
     def test_invalid_http_client(self) -> None:
-        with pytest.raises(TypeError, match="Invalid `http_client` arg"):
+        with pytest.raises(TypeError, match="Invalid `http_async_client` arg"):
             with httpx.Client() as http_client:
                 AsyncAnthropic(
                     base_url=base_url,
                     api_key=api_key,
                     _strict_response_validation=True,
-                    http_client=cast(Any, http_client),
+                    http_async_client=cast(Any, http_client),
                 )
 
     def test_default_headers_option(self) -> None:
@@ -1500,7 +1500,7 @@ class TestAsyncAnthropic:
                 base_url="http://localhost:5000/custom/path/",
                 api_key=api_key,
                 _strict_response_validation=True,
-                http_client=httpx.AsyncClient(),
+                http_async_client=httpx.AsyncClient(),
             ),
         ],
         ids=["standard", "custom http client"],
@@ -1525,7 +1525,7 @@ class TestAsyncAnthropic:
                 base_url="http://localhost:5000/custom/path/",
                 api_key=api_key,
                 _strict_response_validation=True,
-                http_client=httpx.AsyncClient(),
+                http_async_client=httpx.AsyncClient(),
             ),
         ],
         ids=["standard", "custom http client"],
@@ -1550,7 +1550,7 @@ class TestAsyncAnthropic:
                 base_url="http://localhost:5000/custom/path/",
                 api_key=api_key,
                 _strict_response_validation=True,
-                http_client=httpx.AsyncClient(),
+                http_async_client=httpx.AsyncClient(),
             ),
         ],
         ids=["standard", "custom http client"],


### PR DESCRIPTION
Split _http_client_ for each client (sync and async) in the Client(Anthropic) constructor.