### PR TITLE
fix(tests): suppress warnings in tests when running on the latest Python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,8 @@ xfail_strict = true
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 filterwarnings = [
-  "error"
+  "error",
+  "ignore::DeprecationWarning",
 ]
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,7 @@ xfail_strict = true
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 filterwarnings = [
-  "error",
-  "ignore::DeprecationWarning",
+  "error"
 ]
 
 [tool.pyright]

--- a/tests/lib/streaming/test_partial_json.py
+++ b/tests/lib/streaming/test_partial_json.py
@@ -128,6 +128,8 @@ class TestPartialJson:
             )
             raise AssertionError("Expected ValueError for invalid JSON, but no error was raised.")
         except ValueError as e:
-            assert str(e).startswith("Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt.")
+            assert str(e).startswith(
+                "Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt."
+            )
         except Exception as e:
             raise AssertionError(f"Unexpected error type: {type(e).__name__} with message: {str(e)}") from e

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -24,6 +24,7 @@ class MockRequestCall(Protocol):
     request: httpx.Request
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.respx()
 def test_messages_retries(respx_mock: MockRouter) -> None:
     respx_mock.post(re.compile(r"https://bedrock-runtime\.us-east-1\.amazonaws\.com/model/.*/invoke")).mock(
@@ -93,6 +94,7 @@ async def test_messages_retries_async(respx_mock: MockRouter) -> None:
     )
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.respx()
 def test_application_inference_profile(respx_mock: MockRouter) -> None:
     respx_mock.post(re.compile(r"https://bedrock-runtime\.us-east-1\.amazonaws\.com/model/.*/invoke")).mock(

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -59,6 +59,7 @@ def test_messages_retries(respx_mock: MockRouter) -> None:
     )
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.respx()
 @pytest.mark.asyncio()
 async def test_messages_retries_async(respx_mock: MockRouter) -> None:


### PR DESCRIPTION
Some tests are failing because of deprecated function calls

```
  =================================== FAILURES ===================================
  ____________________________ test_messages_retries _____________________________
  [gw0] linux -- Python 3.12.3 /home/runner/work/stainless/stainless/dist/anthropic/anthropic-python/.venv/bin/python
  tests/lib/test_bedrock.py:36: in test_messages_retries
      sync_client.messages.create(
  src/anthropic/_utils/_utils.py:283: in wrapper
      return func(*args, **kwargs)
  src/anthropic/resources/messages/messages.py:978: in create
      return self._post(
  src/anthropic/_base_client.py:1314: in post
      return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  src/anthropic/_base_client.py:1024: in request
      self._prepare_request(request)
  src/anthropic/lib/bedrock/_client.py:179: in _prepare_request
      headers = get_auth_headers(
  src/anthropic/lib/bedrock/_auth.py:68: in get_auth_headers
      signer.add_auth(request)
  .venv/lib/python3.12/site-packages/botocore/auth.py:425: in add_auth
      datetime_now = datetime.datetime.utcnow()
  E   DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  ------------------------------ Captured log call -------------------------------
  DEBUG    anthropic._base_client:_base_client.py:493 Request options: {'method': 'post', 'url': '/model/anthropic.claude-3-sonnet-20240229-v1:0/invoke', 'timeout': Timeout(connect=5.0, read=600, write=600, pool=600), 'files': None, 'idempotency_key': 'stainless-python-retry-1afd2597-8c13-409a-8bc3-70f637687303', 'json_data': {'max_tokens': 1024, 'messages': [{'role': 'user', 'content': 'Say hello there!'}], 'anthropic_version': 'bedrock-2023-05-31'}}
  _________________________ test_messages_retries_async __________________________
  [gw0] linux -- Python 3.12.3 /home/runner/work/stainless/stainless/dist/anthropic/anthropic-python/.venv/bin/python
  tests/lib/test_bedrock.py:71: in test_messages_retries_async
      await async_client.messages.create(
  src/anthropic/resources/messages/messages.py:2229: in create
      return await self._post(
  src/anthropic/_base_client.py:1888: in post
      return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
  src/anthropic/_base_client.py:1610: in request
      await self._prepare_request(request)
  src/anthropic/lib/bedrock/_client.py:323: in _prepare_request
      headers = get_auth_headers(
  src/anthropic/lib/bedrock/_auth.py:68: in get_auth_headers
      signer.add_auth(request)
  .venv/lib/python3.12/site-packages/botocore/auth.py:425: in add_auth
      datetime_now = datetime.datetime.utcnow()
  ______________________ test_application_inference_profile ______________________
  [gw0] linux -- Python 3.12.3 /home/runner/work/stainless/stainless/dist/anthropic/anthropic-python/.venv/bin/python
  tests/lib/test_bedrock.py:105: in test_application_inference_profile
      sync_client.messages.create(
  src/anthropic/_utils/_utils.py:283: in wrapper
      return func(*args, **kwargs)
  src/anthropic/resources/messages/messages.py:978: in create
      return self._post(
  src/anthropic/_base_client.py:1314: in post
      return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
  src/anthropic/_base_client.py:1024: in request
      self._prepare_request(request)
  src/anthropic/lib/bedrock/_client.py:179: in _prepare_request
      headers = get_auth_headers(
  src/anthropic/lib/bedrock/_auth.py:68: in get_auth_headers
      signer.add_auth(request)
  .venv/lib/python3.12/site-packages/botocore/auth.py:425: in add_auth
      datetime_now = datetime.datetime.utcnow()
  E   DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```