### PR TITLE
feat: update streaming error message to say 'required' not 'recommended'

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -704,7 +704,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         expected_time = maximum_time * max_tokens / 128_000
         if expected_time > default_time or (max_nonstreaming_tokens and max_tokens > max_nonstreaming_tokens):
             raise ValueError(
-                "Streaming is strongly recommended for operations that may take longer than 10 minutes. "
+                "Streaming is required for operations that may take longer than 10 minutes. "
                 + "See https://github.com/anthropics/anthropic-sdk-python#long-requests for more details",
             )
         return Timeout(

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.58.2"
+version = "0.59.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio", version = "4.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
Updates the error message from 'streaming is strongly recommended' to 'streaming is required' for consistency across all Anthropic SDKs.

## Changes
Changes the error message in timeout calculation function from 'strongly recommended' to 'required' when streaming is needed for operations that may take longer than 10 minutes.

## Related
CE-732

🤖 Generated with [Claude Code](https://claude.ai/code)