### PR TITLE
[Fix] Add missing error mappings to Vertex AI client

### DIFF
--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -70,6 +70,9 @@ class BaseVertexClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         if response.status_code == 409:
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
+        if response.status_code == 413:
+            return _exceptions.RequestTooLargeError(err_msg, response=response, body=body)
+
         if response.status_code == 422:
             return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
 
@@ -81,6 +84,9 @@ class BaseVertexClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
 
         if response.status_code == 504:
             return _exceptions.DeadlineExceededError(err_msg, response=response, body=body)
+
+        if response.status_code == 529:
+            return _exceptions.OverloadedError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)


### PR DESCRIPTION
## Summary
Adds missing HTTP status code mappings in the Vertex AI client's `_make_status_error` method to ensure consistent error handling with the main Anthropic client.

## Changes
- Added mapping for 413 status code to `RequestTooLargeError`
- Added mapping for 529 status code to `OverloadedError`

## Background
The Vertex AI client was missing mappings for these error types that are already defined in `_exceptions.py` and used by other clients in the SDK. This ensures that users get the appropriate exception types rather than generic `APIStatusError` or `InternalServerError` instances when these status codes are returned.

These error types are already defined in the main exceptions module and used consistently across other parts of the SDK.