### PR TITLE
fix(types/beta): add response content block type to params

### DIFF
--- a/src/anthropic/types/beta/beta_content_block_param.py
+++ b/src/anthropic/types/beta/beta_content_block_param.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Union
 from typing_extensions import TypeAlias
 
+from .beta_content_block import BetaContentBlock
 from .beta_text_block_param import BetaTextBlockParam
 from .beta_image_block_param import BetaImageBlockParam
 from .beta_thinking_block_param import BetaThinkingBlockParam
@@ -41,4 +42,5 @@ BetaContentBlockParam: TypeAlias = Union[
     BetaMCPToolUseBlockParam,
     BetaRequestMCPToolResultBlockParam,
     BetaContainerUploadBlockParam,
+    BetaContentBlock,
 ]


### PR DESCRIPTION
so you can round trip it, we already supported this for non-beta