### PR TITLE
fix file upload 404 due to Omit not being stripped from file upload request

### DIFF
--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -295,7 +295,7 @@ def strip_not_given(obj: None) -> None: ...
 
 
 @overload
-def strip_not_given(obj: Mapping[_K, _V | NotGiven]) -> dict[_K, _V]: ...
+def strip_not_given(obj: Mapping[_K, _V | NotGiven | Omit]) -> dict[_K, _V]: ...
 
 
 @overload
@@ -310,7 +310,7 @@ def strip_not_given(obj: object | None) -> object:
     if not is_mapping(obj):
         return obj
 
-    return {key: value for key, value in obj.items() if not isinstance(value, NotGiven)}
+    return {key: value for key, value in obj.items() if not isinstance(value, (NotGiven, Omit))}
 
 
 def coerce_integer(val: str) -> int:


### PR DESCRIPTION
The function `anthropic_client.beta.files.upload` returns error code 404. Because the object Omit is not being stripped away from the request header, which overrides the otherwise hardcoded beta string for file upload, [see](https://github.com/anthropics/anthropic-sdk-python/blob/8bd83a10f22ee8ca8564d4bee99c0451aaace849/src/anthropic/resources/beta/files.py#L303C1-L304C1).

Without this fix, it renders [this piece](https://docs.claude.com/en/docs/build-with-claude/files#uploading-a-file) of the python sdk example from the Anthropic's official documentation unusable

This is my first time contributing to a public git repo, so I hope I'm doing this right :) I do notice the [contributing doc](https://github.com/anthropics/anthropic-sdk-python?tab=contributing-ov-file) says code are being generated, so was I supposed to generate my code using my own code agent or something?