### PR TITLE
fix: convert paths to POSIX format for cross-platform compatibility

### DIFF
--- a/src/anthropic/lib/_files.py
+++ b/src/anthropic/lib/_files.py
@@ -22,7 +22,7 @@ def _collect_files(directory: Path, relative_to: Path, files: list[FileTypes]) -
             _collect_files(path, relative_to, files)
             continue
 
-        files.append((str(path.relative_to(relative_to)), path.read_bytes()))
+        files.append((path.relative_to(relative_to).as_posix(), path.read_bytes()))
 
 
 async def async_files_from_dir(directory: str | os.PathLike[str]) -> list[FileTypes]:
@@ -39,4 +39,4 @@ async def _async_collect_files(directory: anyio.Path, relative_to: anyio.Path, f
             await _async_collect_files(path, relative_to, files)
             continue
 
-        files.append((str(path.relative_to(relative_to)), await path.read_bytes()))
+        files.append((path.relative_to(relative_to).as_posix(), await path.read_bytes()))


### PR DESCRIPTION
Fix Windows path handling in skills.create

On Windows, calling `client.beta.skills.create()` fails with "Skill contains path with invalid characters". This happens because `_collect_files()` uses `str(path.relative_to())` which produces backslash-separated paths on Windows (e.g., `dir\file.txt`), but the API expects forward slashes.

Changed to use `.as_posix()` instead, which converts paths to POSIX format on all platforms.

Fixes #1051