### PR TITLE
fix: use posix paths in file collection for cross-platform compatibility

### DIFF
--- a/src/anthropic/lib/_files.py
+++ b/src/anthropic/lib/_files.py
@@ -22,7 +22,7 @@ def _collect_files(directory: Path, relative_to: Path, files: list[FileTypes]) -
             _collect_files(path, relative_to, files)
             continue
 
-        files.append((str(path.relative_to(relative_to)), path.read_bytes()))
+        files.append((path.relative_to(relative_to).as_posix(), path.read_bytes()))
 
 
 async def async_files_from_dir(directory: str | os.PathLike[str]) -> list[FileTypes]:
@@ -39,4 +39,4 @@ async def _async_collect_files(directory: anyio.Path, relative_to: anyio.Path, f
             await _async_collect_files(path, relative_to, files)
             continue
 
-        files.append((str(path.relative_to(relative_to)), await path.read_bytes()))
+        files.append((path.relative_to(relative_to).as_posix(), await path.read_bytes()))


### PR DESCRIPTION
On Windows, calling `client.beta.skills.create()` fails with "Skill contains path with invalid characters" because `str(path.relative_to())` produces backslash-separated paths like `dir\file.txt`.

The API expects POSIX-style paths with forward slashes regardless of OS. Changed both `_collect_files()` and `_async_collect_files()` to use `.as_posix()` instead of `str()`.

Fixes #1051