### PR TITLE
fix(security): prevent credentials from leaking into shell logs

### DIFF
--- a/bin/publish-pypi
+++ b/bin/publish-pypi
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -eu
 rm -rf dist
 mkdir -p dist
 uv build

--- a/scripts/utils/upload-artifact.sh
+++ b/scripts/utils/upload-artifact.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exuo pipefail
+set -euo pipefail
 
 FILENAME=$(basename dist/*.whl)
 


### PR DESCRIPTION
## Summary

Fixes a **CRITICAL** security vulnerability where sensitive credentials are leaked into CI/CD logs and shell history.

The `-x` flag in `set` commands enables shell tracing, which prints all commands to stderr before execution. This exposes:

- **Bearer tokens** in `scripts/utils/upload-artifact.sh` (Authorization header)
- **Signed URLs** with embedded credentials  
- **PyPI tokens** in `bin/publish-pypi`

Anyone with access to CI logs or shell history could use these credentials to upload arbitrary artifacts or hijack the PyPI account.

## Changes

- `scripts/utils/upload-artifact.sh`: Changed `set -exuo pipefail` → `set -euo pipefail`
- `bin/publish-pypi`: Changed `set -eux` → `set -eu`

## Impact

- Prevents credential exposure in logs
- No functional changes to script behavior
- Maintains error handling (`-e`) and undefined variable checks (`-u`)