### PR TITLE
fix(security): prevent presigned URL leak and exception data exfiltration

### DIFF
--- a/scripts/utils/upload-artifact.sh
+++ b/scripts/utils/upload-artifact.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -exuo pipefail
+set -euo pipefail
 
 FILENAME=$(basename dist/*.whl)
 
@@ -14,11 +14,11 @@ if [[ "$SIGNED_URL" == "null" ]]; then
   exit 1
 fi
 
-UPLOAD_RESPONSE=$(curl -v -X PUT \
+HTTP_CODE=$(curl -w '%{http_code}' -o /dev/null -s -X PUT \
   -H "Content-Type: binary/octet-stream" \
-  --data-binary "@dist/$FILENAME" "$SIGNED_URL" 2>&1)
+  --data-binary "@dist/$FILENAME" "$SIGNED_URL")
 
-if echo "$UPLOAD_RESPONSE" | grep -q "HTTP/[0-9.]* 200"; then
+if [[ "$HTTP_CODE" == "200" ]]; then
   echo -e "\033[32mUploaded build to Stainless storage.\033[0m"
   echo -e "\033[32mInstallation: pip install 'https://pkg.stainless.com/s/anthropic-python/$SHA/$FILENAME'\033[0m"
 else

--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -192,7 +192,7 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool], Generic[RunnerItemT],
                     {
                         "type": "tool_result",
                         "tool_use_id": tool_use.id,
-                        "content": repr(exc),
+                        "content": f"Error: Tool '{tool_use.name}' execution failed. Check logs for details.",
                         "is_error": True,
                     }
                 )
@@ -359,7 +359,7 @@ class BaseAsyncToolRunner(BaseToolRunner[BetaAsyncRunnableTool], Generic[RunnerI
                     {
                         "type": "tool_result",
                         "tool_use_id": tool_use.id,
-                        "content": repr(exc),
+                        "content": f"Error: Tool '{tool_use.name}' execution failed. Check logs for details.",
                         "is_error": True,
                     }
                 )


### PR DESCRIPTION
## Summary

Fixes two **HIGH** priority security vulnerabilities that could lead to supply chain attacks and data exfiltration.

### 1. Presigned URL Leak - Supply Chain Attack Vector (HIGH)

**Problem:**
The upload script logged sensitive presigned URLs to CI logs through multiple mechanisms:
- `curl -v` flag printed full HTTP headers including the URL
- `2>&1` captured verbose stderr output  
- `set -x` shell tracing echoed the entire curl command with `$SIGNED_URL`

The presigned URL contains HMAC-SHA256 signatures that grant upload rights for ~1 hour. Anyone with CI log access could:
- Replay the URL before expiration
- Overwrite Python wheels in the artifact storage
- Execute supply chain attacks by injecting malicious code

**Fix:**
- Removed `-x` flag from `set -exuo pipefail` → `set -euo pipefail`
- Replaced `curl -v` with `curl -s -w '%{http_code}' -o /dev/null`
- Changed success detection from parsing verbose output to checking HTTP status code
- URL never appears in logs (happy path or error path)

### 2. Exception Data Exfiltration to API (HIGH)

**Problem:**
Tool runner caught all exceptions and automatically sent `repr(exc)` to Anthropic API in `tool_result` content. Exception messages routinely contain:
- **Database credentials**: `postgres://user:password@host:5432/db`
- **API keys**: `sk-proj-...`, `sk_live_...`
- **File paths**: `/home/user/.ssh/id_rsa`, `/var/www/secret-api/`
- **Environment variables**: `AWS_SECRET_ACCESS_KEY=...`
- **Connection strings** and other secrets

This behavior silently exfiltrated sensitive host information to the LLM with:
- No sanitization
- No user control
- No visibility (users unaware of the leak)
- Permanent storage (data in Anthropic API logs indefinitely)

**Fix:**
- Replaced `repr(exc)` with generic error message: `"Error: Tool '{tool_name}' execution failed. Check logs for details."`
- Full exception stack traces still logged locally via `log.exception()` for debugging
- Prevents all sensitive data exfiltration while maintaining debuggability

## Implementation Details

### Curl Fix
**Before:**
```bash
set -exuo pipefail
UPLOAD_RESPONSE=$(curl -v -X PUT ... "$SIGNED_URL" 2>&1)
if echo "$UPLOAD_RESPONSE" | grep -q "HTTP/[0-9.]* 200"; then
```

**After:**
```bash
set -euo pipefail
HTTP_CODE=$(curl -w '%{http_code}' -o /dev/null -s -X PUT ... "$SIGNED_URL")
if [[ "$HTTP_CODE" == "200" ]]; then
```

### Exception Fix
**Before:**
```python
except Exception as exc:
    log.exception(f"Error occurred while calling tool: {tool.name}", exc_info=exc)
    results.append({
        "content": repr(exc),  # ← Leaks credentials!
        "is_error": True,
    })
```

**After:**
```python
except Exception as exc:
    log.exception(f"Error occurred while calling tool: {tool.name}", exc_info=exc)
    results.append({
        "content": f"Error: Tool '{tool_use.name}' execution failed. Check logs for details.",
        "is_error": True,
    })
```

## Security Impact

### Presigned URL Leak
- **Before**: Supply chain attack possible via CI log access
- **After**: URL never logged, attack vector eliminated
- **Risk Eliminated**: Unauthorized artifact uploads

### Exception Exfiltration  
- **Before**: Automatic credential leakage to API
- **After**: Generic errors only, no sensitive data sent
- **Risk Eliminated**: Information disclosure, credential theft

## Changes

- `scripts/utils/upload-artifact.sh:2`
  - Removed `-x` from `set -exuo pipefail`
- `scripts/utils/upload-artifact.sh:17-21`
  - Replaced `curl -v ... 2>&1` with `curl -s -w '%{http_code}' -o /dev/null`
  - Changed HTTP success detection to use status code
- `src/anthropic/lib/tools/_beta_runner.py:195` (sync)
  - Changed `repr(exc)` to generic error message
- `src/anthropic/lib/tools/_beta_runner.py:362` (async)
  - Changed `repr(exc)` to generic error message

## Testing

Both fixes validated with comprehensive security review to ensure:
- ✅ Presigned URLs no longer appear in any logs
- ✅ HTTP status detection remains reliable
- ✅ Exception details no longer sent to API
- ✅ Local logging preserved for debugging
- ✅ No new vulnerabilities introduced