### PR TITLE
feat: support special types for structured outputs

### DIFF
--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -79,17 +79,17 @@ if TYPE_CHECKING:
 __all__ = ["Messages", "AsyncMessages"]
 
 
-class BetaMessagesParseParamsWithoutFormat(message_create_params.MessageCreateParamsNonStreaming):
+class _BetaMessagesParseParamsWithoutOutputFormat(message_create_params.MessageCreateParamsNonStreaming):
     output_format: None | Omit = omit  # type: ignore[assignment, misc]
 
 
-class BetaMessagesParseParamsWithFormatType(
+class _BetaMessagesParseParamsWithOutputFormat(
     message_create_params.MessageCreateParamsNonStreaming, Generic[ResponseFormatT]
 ):
     output_format: ResponseFormatT  # type: ignore[assignment, misc]
 
 
-class BetaMessagesParseParamsIntersection(
+class _BetaMessagesParseParamsWithAnyFormat(
     message_create_params.MessageCreateParamsNonStreaming, Generic[ResponseFormatT]
 ):
     output_format: None | type[ResponseFormatT] | ResponseFormatT | Omit = omit  # type: ignore[assignment, misc]
@@ -1118,7 +1118,7 @@ class Messages(SyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-        **kwargs: Unpack[BetaMessagesParseParamsWithoutFormat],
+        **kwargs: Unpack[_BetaMessagesParseParamsWithoutOutputFormat],
     ) -> ParsedBetaMessage[None]: ...
 
     @overload
@@ -1131,7 +1131,7 @@ class Messages(SyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-        **kwargs: Unpack[BetaMessagesParseParamsWithFormatType[type[ResponseFormatT]]],
+        **kwargs: Unpack[_BetaMessagesParseParamsWithOutputFormat[type[ResponseFormatT]]],
     ) -> ParsedBetaMessage[ResponseFormatT]: ...
 
     @overload
@@ -1144,7 +1144,7 @@ class Messages(SyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-        **kwargs: Unpack[BetaMessagesParseParamsWithFormatType[ResponseFormatT]],
+        **kwargs: Unpack[_BetaMessagesParseParamsWithOutputFormat[ResponseFormatT]],
     ) -> ParsedBetaMessage[ResponseFormatT]: ...
 
     def parse(
@@ -1156,7 +1156,7 @@ class Messages(SyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-        **kwargs: Unpack[BetaMessagesParseParamsIntersection[ResponseFormatT]],
+        **kwargs: Unpack[_BetaMessagesParseParamsWithAnyFormat[ResponseFormatT]],
     ) -> ParsedBetaMessage[ResponseFormatT]:
         output_config = kwargs.get("output_config", omit)
         output_format = kwargs.get("output_format", omit)

--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -80,19 +80,19 @@ __all__ = ["Messages", "AsyncMessages"]
 
 
 class BetaMessagesParseParamsWithoutFormat(message_create_params.MessageCreateParamsNonStreaming):
-    output_format: None | Omit = omit  # type: ignore[assignment]
+    output_format: None | Omit = omit  # type: ignore[assignment, misc]
 
 
 class BetaMessagesParseParamsWithFormatType(
     message_create_params.MessageCreateParamsNonStreaming, Generic[ResponseFormatT]
 ):
-    output_format: ResponseFormatT  # type: ignore[assignment]
+    output_format: ResponseFormatT  # type: ignore[assignment, misc]
 
 
 class BetaMessagesParseParamsIntersection(
     message_create_params.MessageCreateParamsNonStreaming, Generic[ResponseFormatT]
 ):
-    output_format: None | type[ResponseFormatT] | ResponseFormatT | Omit = omit  # type: ignore[assignment]
+    output_format: None | type[ResponseFormatT] | ResponseFormatT | Omit = omit  # type: ignore[assignment, misc]
 
 
 class Messages(SyncAPIResource):
@@ -1164,7 +1164,7 @@ class Messages(SyncAPIResource):
         _validate_output_config_conflict(output_config, output_format)
         _warn_output_format_deprecated(output_format)
 
-        if kwargs.get("stream", False) and not is_given(timeout) and self._client.timeout == DEFAULT_TIMEOUT:
+        if not kwargs.get("stream", False) and not is_given(timeout) and self._client.timeout == DEFAULT_TIMEOUT:
             timeout = self._client._calculate_nonstreaming_timeout(
                 kwargs["max_tokens"], MODEL_NONSTREAMING_TOKENS.get(kwargs["model"], None)
             )
@@ -1176,10 +1176,8 @@ class Messages(SyncAPIResource):
                 stacklevel=3,
             )
 
-        if (
-            kwargs["model"] in MODELS_TO_WARN_WITH_THINKING_ENABLED
-            and kwargs.get("thinking", {}).get("type") == "enabled"
-        ):
+        thinking = kwargs.get("thinking")
+        if kwargs["model"] in MODELS_TO_WARN_WITH_THINKING_ENABLED and thinking and thinking.get("type") == "enabled":
             warnings.warn(
                 f"Using Claude with {kwargs['model']} and 'thinking.type=enabled' is deprecated. Use 'thinking.type=adaptive' instead which results in better model performance in our testing: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking",
                 UserWarning,

--- a/src/anthropic/types/beta/messages/batch_create_params.py
+++ b/src/anthropic/types/beta/messages/batch_create_params.py
@@ -23,7 +23,6 @@ class BatchCreateParams(TypedDict, total=False):
     """Optional header to specify the beta version(s) you want to use."""
 
 
-
 class Request(TypedDict, total=False):
     custom_id: Required[str]
     """Developer-provided ID created for each request in a Message Batch.

--- a/src/anthropic/types/messages/batch_create_params.py
+++ b/src/anthropic/types/messages/batch_create_params.py
@@ -18,7 +18,6 @@ class BatchCreateParams(TypedDict, total=False):
     """
 
 
-
 class Request(TypedDict, total=False):
     custom_id: Required[str]
     """Developer-provided ID created for each request in a Message Batch.

--- a/uv.lock
+++ b/uv.lock
@@ -185,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.77.0"
+version = "0.78.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Fixes typing so it also works with special types like `Literal`, `Union`, etc. Currently, we use `type[T]` and return `T` to unwrap the class type, telling the type checker that we return the instance, not the type. When special types are passed, the type checker fails because special types are not subclasses of type, and there is nothing to unwrap in this case.

[PEP 747](https://peps.python.org/pep-0747/) would solve this problem by providing a way to annotate these types. Until then, this workaround can be used:

```python
from __future__ import annotations

from typing import Union, TypeVar, cast, overload

T = TypeVar("T")


class Omit: ...


omit = Omit()


class SomeModel: ...


# This overload should be listed first to prioritize it over generic overload
# so calls with Omit() resolve to ParsedBetaMessage[None] not ParsedBetaMessage[Omit]
@overload
def parse(output_format: None | Omit = omit) -> None: ...
# This should be before the generic overload, so if the type is a class type, we unwrap it.
# Otherwise, something like Union[str, int] would incorrectly resolve to type[str] | type[int].
@overload
def parse(output_format: type[T]) -> T: ... # for classes
@overload
def parse(output_format: T) -> T: ...  # for special types
def parse(output_format: None | type[T] | T | Omit = omit) -> T:
    return cast(T, None)


just_none = parse(omit) # None
special_type = parse(Union[str, int]) # str | int 
model_type = parse(SomeModel) # SomeModel
```