### PR TITLE
feat(bedrock): add tool_runner, parse, and stream methods to beta messages

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,9 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    tool_runner = FirstPartyMessagesAPI.tool_runner
+    parse = FirstPartyMessagesAPI.parse
+    stream = FirstPartyMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +39,9 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    tool_runner = FirstPartyAsyncMessagesAPI.tool_runner
+    parse = FirstPartyAsyncMessagesAPI.parse
+    stream = FirstPartyAsyncMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:


### PR DESCRIPTION
## Summary

This PR adds 	ool_runner, parse, and stream method aliases to both Messages and AsyncMessages classes in the Bedrock beta module.

## Motivation

Fixes #1106 

The 	ool_runner API (client.beta.messages.tool_runner()) was not available on the AnthropicBedrock or AsyncAnthropicBedrock clients, despite the documentation stating it should work across all clients. This created feature parity issues for enterprise AWS Bedrock users.

## Changes

Added method aliases to src/anthropic/lib/bedrock/_beta_messages.py:
- 	ool_runner - Automatic tool execution loop
- parse - Structured output parsing
- stream - Streaming message helpers

The implementation follows the same pattern as the existing create alias at line 15.

## Testing

- Syntax validation passed via py_compile
- Methods are now accessible via client.beta.messages.tool_runner(), client.beta.messages.parse(), and client.beta.messages.stream()

## Checklist
- [x] Changes follow existing code patterns
- [x] No breaking changes
- [x] Commit message follows conventional format