### PR TITLE
fix(structured outputs): avoid including beta header if `output_format` is missing

### DIFF
--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -2789,7 +2789,7 @@ class AsyncMessages(AsyncAPIResource):
             )
         betas = [beta for beta in betas] if is_given(betas) else []
 
-        if "structured-outputs-2025-11-13" not in betas and is_given(output_format) and output_format is not None:
+        if "structured-outputs-2025-11-13" not in betas and is_given(output_format):
             # Ensure structured outputs beta is included for parse method
             betas.append("structured-outputs-2025-11-13")
 

--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -1113,7 +1113,7 @@ class Messages(SyncAPIResource):
 
         betas = [beta for beta in betas] if is_given(betas) else []
 
-        if "structured-outputs-2025-11-13" not in betas:
+        if "structured-outputs-2025-11-13" not in betas and is_given(output_format):
             # Ensure structured outputs beta is included for parse method
             betas.append("structured-outputs-2025-11-13")
 
@@ -2789,7 +2789,7 @@ class AsyncMessages(AsyncAPIResource):
             )
         betas = [beta for beta in betas] if is_given(betas) else []
 
-        if "structured-outputs-2025-11-13" not in betas:
+        if "structured-outputs-2025-11-13" not in betas and is_given(output_format) and output_format is not None:
             # Ensure structured outputs beta is included for parse method
             betas.append("structured-outputs-2025-11-13")
 

--- a/src/anthropic/types/beta/messages/batch_create_params.py
+++ b/src/anthropic/types/beta/messages/batch_create_params.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, Iterable
+from typing import List, Iterable
 from typing_extensions import Required, Annotated, TypedDict
 
 from ...._utils import PropertyInfo
@@ -26,8 +26,6 @@ class BatchCreateParams(TypedDict, total=False):
 class RequestParamsOutputFormat(TypedDict, total=False):
     schema: Required[object]
     """The JSON schema of the format"""
-
-
 
 
 class Request(TypedDict, total=False):

--- a/uv.lock
+++ b/uv.lock
@@ -185,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.75.0"
+version = "0.76.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Third-party clients (Vertex, Bedrock) don’t support structured outputs and its beta header, so when the SDK sets it, the remote server returns `Error code: 400 - {'message': 'invalid beta flag'}.`

This change just avoids always setting that header, so we can still port the `tool_runner` and `stream` helpers, which use `parse` method internally, with minimal changes.