### PR TITLE
fix(tools): use modified messages list in async compaction

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -451,7 +451,7 @@ class BaseAsyncToolRunner(
                 messages.pop()
 
         messages = [
-            *self._params["messages"],
+            *messages,
             BetaMessageParam(
                 role="user",
                 content=self._compaction_control.get("summary_prompt", DEFAULT_SUMMARY_PROMPT),


### PR DESCRIPTION
## Summary

Fixes a bug in the async `_check_and_compact()` method where it was using `self._params["messages"]` instead of the local `messages` variable when building the compaction request.

## The Bug

The compaction logic filters out `tool_use` blocks from the last assistant message before sending for summarization. The sync version correctly uses the filtered `messages` list, but the async version was discarding that work:

**Sync (correct) - line 202:**
```python
messages = [
    *messages,  # Uses filtered local variable
    BetaMessageParam(...)
]
```

**Async (bug) - line 453:**
```python
messages = [
    *self._params["messages"],  # Used original, ignoring filtering
    BetaMessageParam(...)
]
```

This would cause errors when compaction runs because unfiltered `tool_use` blocks (without matching `tool_result`) would be sent to the API.

## Fix

Single character change - use `messages` instead of `self._params["messages"]` in the async version to match sync behavior.

## Test plan

- [x] All existing tests pass
- [x] Linting passes
- [x] Type checking passes
- [x] Manual integration test with async tool runner + compaction