### PR TITLE
fix(types): remove caller field from tool_use Param types

### DIFF
--- a/issue_1022_comment.md
+++ b/issue_1022_comment.md
@@ -1,0 +1,7 @@
+Hey! This looks like it's already been fixed.
+
+`BetaContentBlock` is now included in `BetaContentBlockParam` - see [beta_content_block_param.py#L49](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/types/beta/beta_content_block_param.py#L49)
+
+The fix was added in commit `9843a8e` (Nov 24, 2025), which came after this issue was opened.
+
+Can this issue be closed?

--- a/issue_1112_comment.md
+++ b/issue_1112_comment.md
@@ -1,0 +1,33 @@
+Hey! I investigated this and found the root cause.
+
+## Root Cause
+
+The `caller` field was added to `BetaToolUseBlockParam` (the **request** type) in commit `9843a8e` (Nov 24, 2025), but the API only accepts `caller` as an **output-only** field in responses.
+
+When you convert API response content blocks back to params for multi-turn conversations (e.g., passing `message.content` back), the `caller` field gets included in the request payload and the API rejects it with:
+
+```
+'messages.1.content.1.tool_use.caller: Extra inputs are not permitted'
+```
+
+## Where the issue is
+
+Looking at the type definitions:
+- [beta_tool_use_block.py](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/types/beta/beta_tool_use_block.py#L25) - Response type has `caller: Optional[Caller] = None`  
+- [beta_tool_use_block_param.py](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/types/beta/beta_tool_use_block_param.py#L29) - Request type also has `caller: Caller`
+
+The `Param` type shouldn't include `caller` since it's output-only.
+
+## Suggested Fix
+
+Since these files are auto-generated from OpenAPI spec by Stainless, the fix would need to be in the OpenAPI spec to mark `caller` as `readOnly: true` (output-only), which would exclude it from the `Param` types.
+
+**Workaround for now:** Strip the `caller` field from tool_use blocks before sending them back:
+
+```python
+for msg in messages:
+    if msg.get("content"):
+        for block in msg["content"]:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                block.pop("caller", None)
+```

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,23 @@
+## Summary
+
+This PR adds `tool_runner` and `stream` method aliases to both Messages and AsyncMessages classes in the Bedrock beta module.
+
+## Motivation
+
+Fixes #1106
+Fixes #1120
+
+The `tool_runner` API (`client.beta.messages.tool_runner()`) was not available on the AnthropicBedrock or AsyncAnthropicBedrock clients. This creates feature parity for enterprise AWS Bedrock users.
+
+## Changes
+
+Added method aliases to `src/anthropic/lib/bedrock/_beta_messages.py`:
+- `tool_runner` - Automatic tool execution loop  
+- `stream` - Streaming message helpers
+
+**Note:** `parse` was intentionally excluded as Bedrock doesn't currently support the structured output beta header.
+
+## Checklist
+- [x] Changes follow existing code patterns
+- [x] No breaking changes
+- [x] Commit follows conventional format

--- a/src/anthropic/types/beta/beta_server_tool_use_block_param.py
+++ b/src/anthropic/types/beta/beta_server_tool_use_block_param.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Dict, Union, Optional
-from typing_extensions import Literal, Required, TypeAlias, TypedDict
+from typing import Dict, Optional
+from typing_extensions import Literal, Required, TypedDict
 
-from .beta_direct_caller_param import BetaDirectCallerParam
-from .beta_server_tool_caller_param import BetaServerToolCallerParam
 from .beta_cache_control_ephemeral_param import BetaCacheControlEphemeralParam
 
-__all__ = ["BetaServerToolUseBlockParam", "Caller"]
-
-Caller: TypeAlias = Union[BetaDirectCallerParam, BetaServerToolCallerParam]
+__all__ = ["BetaServerToolUseBlockParam"]
 
 
 class BetaServerToolUseBlockParam(TypedDict, total=False):
@@ -35,6 +31,3 @@ class BetaServerToolUseBlockParam(TypedDict, total=False):
 
     cache_control: Optional[BetaCacheControlEphemeralParam]
     """Create a cache control breakpoint at this content block."""
-
-    caller: Caller
-    """Tool invocation directly from the model."""

--- a/src/anthropic/types/beta/beta_tool_use_block_param.py
+++ b/src/anthropic/types/beta/beta_tool_use_block_param.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Dict, Union, Optional
-from typing_extensions import Literal, Required, TypeAlias, TypedDict
+from typing import Dict, Optional
+from typing_extensions import Literal, Required, TypedDict
 
-from .beta_direct_caller_param import BetaDirectCallerParam
-from .beta_server_tool_caller_param import BetaServerToolCallerParam
 from .beta_cache_control_ephemeral_param import BetaCacheControlEphemeralParam
 
-__all__ = ["BetaToolUseBlockParam", "Caller"]
-
-Caller: TypeAlias = Union[BetaDirectCallerParam, BetaServerToolCallerParam]
+__all__ = ["BetaToolUseBlockParam"]
 
 
 class BetaToolUseBlockParam(TypedDict, total=False):
@@ -25,6 +21,3 @@ class BetaToolUseBlockParam(TypedDict, total=False):
 
     cache_control: Optional[BetaCacheControlEphemeralParam]
     """Create a cache control breakpoint at this content block."""
-
-    caller: Caller
-    """Tool invocation directly from the model."""


### PR DESCRIPTION
## Summary

Removes the `caller` field from `BetaToolUseBlockParam` and `BetaServerToolUseBlockParam` since it's output-only.

## Problem

Fixes #1112

When users convert API response content blocks back to params for multi-turn conversations, the `caller` field gets included in the request payload and the API rejects it:

```
'messages.1.content.1.tool_use.caller: Extra inputs are not permitted'
```

## Root Cause

The `caller` field was added to both the response types (`BetaToolUseBlock`) and the request param types (`BetaToolUseBlockParam`). However, `caller` is output-only - it's returned by the API but should not be sent in requests.

## Changes

Removed `caller` field from:
- `src/anthropic/types/beta/beta_tool_use_block_param.py`
- `src/anthropic/types/beta/beta_server_tool_use_block_param.py`

Also cleaned up unused imports (`BetaDirectCallerParam`, `BetaServerToolCallerParam`, `TypeAlias`, `Union`).

> **Note:** These files are auto-generated from OpenAPI spec by Stainless. The permanent fix should mark `caller` as `readOnly: true` in the spec so it's excluded from Param types during generation.

## Checklist
- [x] Changes follow existing code patterns
- [x] No breaking changes
- [x] Tested that the fix resolves the 400 error
