### PR TITLE
fix(tools): filter self and cls parameters from @beta_tool schema generation

### DIFF
--- a/src/anthropic/lib/tools/_beta_functions.py
+++ b/src/anthropic/lib/tools/_beta_functions.py
@@ -155,6 +155,15 @@ class BaseFunctionTool(Generic[CallableT]):
                 if not properties or not is_dict(properties):
                     return schema
 
+                # Filter out 'self' and 'cls' parameters for class/instance methods
+                for param_name in ("self", "cls"):
+                    if param_name in properties:
+                        del properties[param_name]
+                    # Also remove from required if present
+                    required = schema.get("required")
+                    if required and isinstance(required, list) and param_name in required:
+                        cast(list[str], required).remove(param_name)
+
                 # Add parameter descriptions from docstring
                 for param in self._parsed_docstring.params:
                     prop_schema = properties.get(param.arg_name)


### PR DESCRIPTION
# fix(tools): filter self and cls parameters from @beta_tool schema generation

## Summary

This PR enables class methods and instance methods to be used with the `@beta_tool` decorator by filtering out `self` and `cls` parameters from the generated JSON schema.

## Problem

When using `@beta_tool` on a class method or instance method, the generated JSON schema incorrectly includes `self` or `cls` as required parameters, causing validation errors.

## Solution

Modified `kw_arguments_schema` in `_beta_functions.py` to filter out `self` and `cls` parameters from both the `properties` and `required` fields of the generated schema.

## Example

```python
class MyTools:
    def __init__(self, user_id: int):
        self.user_id = user_id

    @beta_tool
    def get_user_info(self, query: str) -> str:
        """Get user information.
        
        Args:
            query: The query string to search for
        """
        return f"User {self.user_id}: {query}"

# Now works correctly - 'self' is not in the schema
tools = MyTools(user_id=123)
print(tools.get_user_info.input_schema)
# {'properties': {'query': {...}}, 'required': ['query'], ...}
```

Fixes #1087
