### PR TITLE
feat(bedrock): add support for AWS_BEARER_TOKEN_BEDROCK env var

### DIFF
--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import httpx
@@ -8,6 +9,14 @@ from ..._utils import lru_cache
 
 if TYPE_CHECKING:
     import boto3
+
+
+def get_bearer_token() -> str | None:
+    """Get the bearer token from the AWS_BEARER_TOKEN_BEDROCK environment variable.
+
+    Returns the token if set, otherwise None.
+    """
+    return os.environ.get("AWS_BEARER_TOKEN_BEDROCK")
 
 
 @lru_cache(maxsize=512)

--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -196,8 +196,15 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
     @override
     def _prepare_request(self, request: httpx.Request) -> None:
-        from ._auth import get_auth_headers
+        from ._auth import get_auth_headers, get_bearer_token
 
+        # Check for bearer token first (AWS_BEARER_TOKEN_BEDROCK env var)
+        bearer_token = get_bearer_token()
+        if bearer_token is not None:
+            request.headers["Authorization"] = f"Bearer {bearer_token}"
+            return
+
+        # Fall back to SigV4 auth
         data = request.read().decode()
 
         headers = get_auth_headers(
@@ -338,8 +345,15 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
     @override
     async def _prepare_request(self, request: httpx.Request) -> None:
-        from ._auth import get_auth_headers
+        from ._auth import get_auth_headers, get_bearer_token
 
+        # Check for bearer token first (AWS_BEARER_TOKEN_BEDROCK env var)
+        bearer_token = get_bearer_token()
+        if bearer_token is not None:
+            request.headers["Authorization"] = f"Bearer {bearer_token}"
+            return
+
+        # Fall back to SigV4 auth
         data = request.read().decode()
 
         headers = get_auth_headers(


### PR DESCRIPTION
# feat(bedrock): add support for AWS_BEARER_TOKEN_BEDROCK env var

## Summary

This PR adds support for the `AWS_BEARER_TOKEN_BEDROCK` environment variable in the Bedrock client, enabling bearer token authentication as an alternative to SigV4.

## Problem

Currently, the Bedrock client only supports SigV4 authentication. Some users need to use bearer token authentication for specific deployment scenarios.

## Solution

- Added `get_bearer_token()` function to `_auth.py` to retrieve the token from the environment
- Updated `_prepare_request` in both sync and async Bedrock clients to prioritize bearer token if `AWS_BEARER_TOKEN_BEDROCK` is set, falling back to SigV4 otherwise

## Usage

```python
import os
os.environ["AWS_BEARER_TOKEN_BEDROCK"] = "your-bearer-token"

from anthropic import AnthropicBedrock

client = AnthropicBedrock()
# Client now uses bearer token auth instead of SigV4
```

Fixes #1079
