### PR TITLE
fix(client): add 424 status code to retry logic for transient Bedrock errors

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -810,6 +810,11 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
             log.debug("Retrying due to status code %i", response.status_code)
             return True
 
+        # Retry on failed dependency (often transient in Bedrock).
+        if response.status_code == 424:
+            log.debug("Retrying due to status code %i", response.status_code)
+            return True
+
         # Retry on lock timeouts.
         if response.status_code == 409:
             log.debug("Retrying due to status code %i", response.status_code)


### PR DESCRIPTION
## Summary

Add status code 424 (Failed Dependency) to the automatic retry logic. This status code is frequently returned by Amazon Bedrock for transient server-side issues.

## Changes

- Added status code 424 to the _should_retry method in _base_client.py

## Motivation

Users have reported transient 424 errors from Bedrock that should be automatically retried.