### PR TITLE
feat(cloud): add missing beta methods to Vertex and Bedrock clients

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,10 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    stream = FirstPartyMessagesAPI.stream
+    parse = FirstPartyMessagesAPI.parse
+    tool_runner = FirstPartyMessagesAPI.tool_runner
+    count_tokens = FirstPartyMessagesAPI.count_tokens
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +40,10 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    stream = FirstPartyAsyncMessagesAPI.stream
+    parse = FirstPartyAsyncMessagesAPI.parse
+    tool_runner = FirstPartyAsyncMessagesAPI.tool_runner
+    count_tokens = FirstPartyAsyncMessagesAPI.count_tokens
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:
@@ -64,6 +72,12 @@ class MessagesWithRawResponse:
         self.create = _legacy_response.to_raw_response_wrapper(
             messages.create,
         )
+        self.count_tokens = _legacy_response.to_raw_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = _legacy_response.to_raw_response_wrapper(
+            messages.parse,
+        )
 
 
 class AsyncMessagesWithRawResponse:
@@ -72,6 +86,12 @@ class AsyncMessagesWithRawResponse:
 
         self.create = _legacy_response.async_to_raw_response_wrapper(
             messages.create,
+        )
+        self.count_tokens = _legacy_response.async_to_raw_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = _legacy_response.async_to_raw_response_wrapper(
+            messages.parse,
         )
 
 

--- a/src/anthropic/lib/vertex/_beta_messages.py
+++ b/src/anthropic/lib/vertex/_beta_messages.py
@@ -14,6 +14,8 @@ __all__ = ["Messages", "AsyncMessages"]
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
     stream = FirstPartyMessagesAPI.stream
+    parse = FirstPartyMessagesAPI.parse
+    tool_runner = FirstPartyMessagesAPI.tool_runner
     count_tokens = FirstPartyMessagesAPI.count_tokens
 
     @cached_property
@@ -39,6 +41,8 @@ class Messages(SyncAPIResource):
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
     stream = FirstPartyAsyncMessagesAPI.stream
+    parse = FirstPartyAsyncMessagesAPI.parse
+    tool_runner = FirstPartyAsyncMessagesAPI.tool_runner
     count_tokens = FirstPartyAsyncMessagesAPI.count_tokens
 
     @cached_property
@@ -68,6 +72,12 @@ class MessagesWithRawResponse:
         self.create = _legacy_response.to_raw_response_wrapper(
             messages.create,
         )
+        self.count_tokens = _legacy_response.to_raw_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = _legacy_response.to_raw_response_wrapper(
+            messages.parse,
+        )
 
 
 class AsyncMessagesWithRawResponse:
@@ -76,6 +86,12 @@ class AsyncMessagesWithRawResponse:
 
         self.create = _legacy_response.async_to_raw_response_wrapper(
             messages.create,
+        )
+        self.count_tokens = _legacy_response.async_to_raw_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = _legacy_response.async_to_raw_response_wrapper(
+            messages.parse,
         )
 
 


### PR DESCRIPTION
This PR adds full feature parity for beta methods across cloud integrations (Vertex and Bedrock).

### Summary of Changes
- **Vertex**: Added missing parse and 	ool_runner delegations.
- **Bedrock**: Added missing stream, count_tokens, parse, and 	ool_runner delegations.
- Updated with_raw_response versions for both sync and async clients.

### Verification Results
- Verified that client.beta.messages.stream correctly accumulates tool inputs in get_final_message() for Vertex (addressing the root concern of tool input loss during streaming).
- Verified the presence and basic return types of all delegated methods using local reproduction scripts.

Fixes #1020