### PR TITLE
fix(beta): strip betas from per-request batch params

### DIFF
--- a/src/anthropic/resources/beta/messages/batches.py
+++ b/src/anthropic/resources/beta/messages/batches.py
@@ -93,6 +93,13 @@ class Batches(SyncAPIResource):
             **(extra_headers or {}),
         }
         extra_headers = {"anthropic-beta": "message-batches-2024-09-24", **(extra_headers or {})}
+
+        # Strip betas from individual requests as they are only supported at the top-level.
+        # Including them in individual requests causes API errors.
+        requests = [
+            {**request, "params": {**request["params"], "betas": omit}} for request in requests
+        ]
+
         return self._post(
             "/v1/messages/batches?beta=true",
             body=maybe_transform({"requests": requests}, batch_create_params.BatchCreateParams),
@@ -480,6 +487,13 @@ class AsyncBatches(AsyncAPIResource):
             **(extra_headers or {}),
         }
         extra_headers = {"anthropic-beta": "message-batches-2024-09-24", **(extra_headers or {})}
+
+        # Strip betas from individual requests as they are only supported at the top-level.
+        # Including them in individual requests causes API errors.
+        requests = [
+            {**request, "params": {**request["params"], "betas": omit}} for request in requests
+        ]
+
         return await self._post(
             "/v1/messages/batches?beta=true",
             body=await async_maybe_transform({"requests": requests}, batch_create_params.BatchCreateParams),

--- a/src/anthropic/types/anthropic_beta_param.py
+++ b/src/anthropic/types/anthropic_beta_param.py
@@ -29,5 +29,6 @@ AnthropicBetaParam: TypeAlias = Union[
         "context-management-2025-06-27",
         "model-context-window-exceeded-2025-08-26",
         "skills-2025-10-02",
+        "structured-outputs-2025-11-13",
     ],
 ]


### PR DESCRIPTION
The Message Batches API only supports beta flags at the top level (sent as a header for the batch create request). Including them in the JSON body for individual requests inside the batch causes API errors like output_format: Extra inputs are not permitted.

This PR ensures that betas are stripped from individual request parameters in both synchronous and asynchronous batch creation.

It also adds the missing "structured-outputs-2025-11-13" string to the AnthropicBetaParam literal to provide correct type hints for structured outputs.

Fixes #1118
