### PR TITLE
fix(beta): strip extra 'caller' field from tool use blocks

### DIFF
--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -274,6 +274,9 @@ def _transform_typeddict(
 
         type_ = annotations.get(key)
         if type_ is None:
+            if key == "caller":
+                continue
+
             # we do not have a type annotation for this field, leave it as is
             result[key] = value
         else:
@@ -440,6 +443,9 @@ async def _async_transform_typeddict(
 
         type_ = annotations.get(key)
         if type_ is None:
+            if key == "caller":
+                continue
+
             # we do not have a type annotation for this field, leave it as is
             result[key] = value
         else:

--- a/src/anthropic/types/beta/beta_server_tool_use_block.py
+++ b/src/anthropic/types/beta/beta_server_tool_use_block.py
@@ -19,6 +19,8 @@ class BetaServerToolUseBlock(BaseModel):
     caller: Caller
     """Tool invocation directly from the model."""
 
+    __api_exclude__ = {"caller"}
+
     input: Dict[str, object]
 
     name: Literal[

--- a/src/anthropic/types/beta/beta_server_tool_use_block_param.py
+++ b/src/anthropic/types/beta/beta_server_tool_use_block_param.py
@@ -35,6 +35,3 @@ class BetaServerToolUseBlockParam(TypedDict, total=False):
 
     cache_control: Optional[BetaCacheControlEphemeralParam]
     """Create a cache control breakpoint at this content block."""
-
-    caller: Caller
-    """Tool invocation directly from the model."""

--- a/src/anthropic/types/beta/beta_tool_use_block.py
+++ b/src/anthropic/types/beta/beta_tool_use_block.py
@@ -24,3 +24,5 @@ class BetaToolUseBlock(BaseModel):
 
     caller: Optional[Caller] = None
     """Tool invocation directly from the model."""
+
+    __api_exclude__ = {"caller"}

--- a/src/anthropic/types/beta/beta_tool_use_block_param.py
+++ b/src/anthropic/types/beta/beta_tool_use_block_param.py
@@ -25,6 +25,3 @@ class BetaToolUseBlockParam(TypedDict, total=False):
 
     cache_control: Optional[BetaCacheControlEphemeralParam]
     """Create a cache control breakpoint at this content block."""
-
-    caller: Caller
-    """Tool invocation directly from the model."""


### PR DESCRIPTION
Including the 'caller' field in 'tool_use' blocks within input messages causes API errors (especially for computer-use) because the API expects only standard fields like id, name, type, and input. This field was recently added to the SDK models but should not be sent back to the API.

This PR:
1. Removes 'caller' from BetaToolUseBlockParam and BetaServerToolUseBlockParam.
2. Adds __api_exclude__ = {"caller"} to BetaToolUseBlock and BetaServerToolUseBlock response models.
3. Modifies the internal transformer to explicitly strip 'caller' if it's not annotated in a TypedDict, ensuring raw dicts or unfiltered model dumps don't leak it back to the API.

Fixes #1112
