### PR TITLE
feat(messages): add client-side validation for temperature, top_p, and top_k

### DIFF
--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -43,7 +43,7 @@ from ....types.beta import (
 from ...._base_client import make_request_options
 from ...._utils._utils import is_dict
 from ....lib.streaming import BetaMessageStreamManager, BetaAsyncMessageStreamManager
-from ...messages.messages import DEPRECATED_MODELS
+from ...messages.messages import DEPRECATED_MODELS, validate_sampling_params
 from ....types.model_param import ModelParam
 from ....lib._parse._response import ResponseFormatT, parse_response
 from ....lib._parse._transform import transform_schema
@@ -1010,6 +1010,8 @@ class Messages(SyncAPIResource):
                 max_tokens, MODEL_NONSTREAMING_TOKENS.get(model, None)
             )
 
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
+
         if model in DEPRECATED_MODELS:
             warnings.warn(
                 f"The model '{model}' is deprecated and will reach end-of-life on {DEPRECATED_MODELS[model]}.\nPlease migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.",
@@ -1104,6 +1106,8 @@ class Messages(SyncAPIResource):
         if "structured-outputs-2025-11-13" not in betas:
             # Ensure structured outputs beta is included for parse method
             betas.append("structured-outputs-2025-11-13")
+
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
 
         extra_headers = {
             "X-Stainless-Helper": "beta.messages.parse",
@@ -1317,6 +1321,8 @@ class Messages(SyncAPIResource):
                 stacklevel=3,
             )
 
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
+
         extra_headers = {
             "X-Stainless-Helper": "BetaToolRunner",
             **strip_not_given({"anthropic-beta": ",".join(str(e) for e in betas) if is_given(betas) else NOT_GIVEN}),
@@ -1421,6 +1427,9 @@ class Messages(SyncAPIResource):
             )
 
         """Create a Message stream"""
+
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
+
         extra_headers = {
             "X-Stainless-Helper-Method": "stream",
             "X-Stainless-Stream-Helper": "beta.messages",
@@ -2678,6 +2687,9 @@ class AsyncMessages(AsyncAPIResource):
                 stacklevel=3,
             )
 
+
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
+
         extra_headers = {
             **strip_not_given({"anthropic-beta": ",".join(str(e) for e in betas) if is_given(betas) else not_given}),
             **(extra_headers or {}),
@@ -2764,6 +2776,9 @@ class AsyncMessages(AsyncAPIResource):
         if "structured-outputs-2025-11-13" not in betas:
             # Ensure structured outputs beta is included for parse method
             betas.append("structured-outputs-2025-11-13")
+
+
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
 
         extra_headers = {
             "X-Stainless-Helper": "beta.messages.parse",
@@ -2977,6 +2992,9 @@ class AsyncMessages(AsyncAPIResource):
                 stacklevel=3,
             )
 
+
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
+
         extra_headers = {
             "X-Stainless-Helper": "BetaToolRunner",
             **strip_not_given({"anthropic-beta": ",".join(str(e) for e in betas) if is_given(betas) else NOT_GIVEN}),
@@ -3079,6 +3097,9 @@ class AsyncMessages(AsyncAPIResource):
                 DeprecationWarning,
                 stacklevel=3,
             )
+
+
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
 
         extra_headers = {
             "X-Stainless-Helper-Method": "stream",

--- a/src/anthropic/resources/messages/messages.py
+++ b/src/anthropic/resources/messages/messages.py
@@ -64,6 +64,25 @@ DEPRECATED_MODELS = {
 }
 
 
+def validate_sampling_params(
+    *,
+    temperature: float | Omit = omit,
+    top_k: int | Omit = omit,
+    top_p: float | Omit = omit,
+) -> None:
+    if is_given(temperature):
+        if temperature < 0.0 or temperature > 1.0:
+            raise ValueError(f"Invalid temperature: {temperature}; must be between 0.0 and 1.0")
+
+    if is_given(top_p):
+        if top_p < 0.0 or top_p > 1.0:
+            raise ValueError(f"Invalid top_p: {top_p}; must be between 0.0 and 1.0")
+
+    if is_given(top_k):
+        if top_k < 0:
+            raise ValueError(f"Invalid top_k: {top_k}; must be 0 or greater")
+
+
 class Messages(SyncAPIResource):
     @cached_property
     def batches(self) -> Batches:
@@ -922,6 +941,8 @@ class Messages(SyncAPIResource):
                 max_tokens, MODEL_NONSTREAMING_TOKENS.get(model, None)
             )
 
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
+
         if model in DEPRECATED_MODELS:
             warnings.warn(
                 f"The model '{model}' is deprecated and will reach end-of-life on {DEPRECATED_MODELS[model]}.\nPlease migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.",
@@ -991,6 +1012,8 @@ class Messages(SyncAPIResource):
                 DeprecationWarning,
                 stacklevel=3,
             )
+
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
 
         extra_headers = {
             "X-Stainless-Helper-Method": "stream",
@@ -2106,6 +2129,8 @@ class AsyncMessages(AsyncAPIResource):
                 max_tokens, MODEL_NONSTREAMING_TOKENS.get(model, None)
             )
 
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
+
         if model in DEPRECATED_MODELS:
             warnings.warn(
                 f"The model '{model}' is deprecated and will reach end-of-life on {DEPRECATED_MODELS[model]}.\nPlease migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.",
@@ -2175,6 +2200,8 @@ class AsyncMessages(AsyncAPIResource):
                 DeprecationWarning,
                 stacklevel=3,
             )
+
+        validate_sampling_params(temperature=temperature, top_k=top_k, top_p=top_p)
 
         extra_headers = {
             "X-Stainless-Helper-Method": "stream",


### PR DESCRIPTION
# feat(messages): add client-side validation for temperature, top_p, and top_k

This PR adds client-side validation for sampling parameters to ensure they are within the ranges expected by the API, resolving #893.

## Changes
- Added a `validate_sampling_params` helper function to enforce:
  - `temperature`: 0.0 to 1.0
  - `top_p`: 0.0 to 1.0
  - `top_k`: >= 0
- Integrated validation into `Messages.create()` and `Messages.stream()` (sync and async).
- Integrated validation into Beta `Messages.create()`, `Messages.parse()`, `Messages.stream()`, and `Messages.tool_runner()` (sync and async).

## Verification
Verified with a reproduction script testing both standard and beta resources with various invalid values. All tests passed, raising `ValueError` as expected instead of sending invalid requests to the API.

```python
# Example of failure
client.messages.create(
    max_tokens=1024,
    messages=[{"role": "user", "content": "Hello"}],
    model="claude-3-opus-20240229",
    temperature=-1.0
)
# Raises: ValueError: Invalid temperature: -1.0; must be between 0.0 and 1.0
```
