### PR TITLE
feat(bedrock/vertex): add parity for beta messages (stream, count_tokens, parse, tool_runner)

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,10 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    stream = FirstPartyMessagesAPI.stream
+    count_tokens = FirstPartyMessagesAPI.count_tokens
+    parse = FirstPartyMessagesAPI.parse
+    tool_runner = FirstPartyMessagesAPI.tool_runner
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +40,10 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    stream = FirstPartyAsyncMessagesAPI.stream
+    count_tokens = FirstPartyAsyncMessagesAPI.count_tokens
+    parse = FirstPartyAsyncMessagesAPI.parse
+    tool_runner = FirstPartyAsyncMessagesAPI.tool_runner
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:
@@ -64,6 +72,12 @@ class MessagesWithRawResponse:
         self.create = _legacy_response.to_raw_response_wrapper(
             messages.create,
         )
+        self.count_tokens = _legacy_response.to_raw_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = _legacy_response.to_raw_response_wrapper(
+            messages.parse,
+        )
 
 
 class AsyncMessagesWithRawResponse:
@@ -72,6 +86,12 @@ class AsyncMessagesWithRawResponse:
 
         self.create = _legacy_response.async_to_raw_response_wrapper(
             messages.create,
+        )
+        self.count_tokens = _legacy_response.async_to_raw_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = _legacy_response.async_to_raw_response_wrapper(
+            messages.parse,
         )
 
 
@@ -82,6 +102,12 @@ class MessagesWithStreamingResponse:
         self.create = to_streamed_response_wrapper(
             messages.create,
         )
+        self.count_tokens = to_streamed_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = to_streamed_response_wrapper(
+            messages.parse,
+        )
 
 
 class AsyncMessagesWithStreamingResponse:
@@ -90,4 +116,10 @@ class AsyncMessagesWithStreamingResponse:
 
         self.create = async_to_streamed_response_wrapper(
             messages.create,
+        )
+        self.count_tokens = async_to_streamed_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = async_to_streamed_response_wrapper(
+            messages.parse,
         )

--- a/src/anthropic/lib/vertex/_beta_messages.py
+++ b/src/anthropic/lib/vertex/_beta_messages.py
@@ -15,6 +15,8 @@ class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
     stream = FirstPartyMessagesAPI.stream
     count_tokens = FirstPartyMessagesAPI.count_tokens
+    parse = FirstPartyMessagesAPI.parse
+    tool_runner = FirstPartyMessagesAPI.tool_runner
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -40,6 +42,8 @@ class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
     stream = FirstPartyAsyncMessagesAPI.stream
     count_tokens = FirstPartyAsyncMessagesAPI.count_tokens
+    parse = FirstPartyAsyncMessagesAPI.parse
+    tool_runner = FirstPartyAsyncMessagesAPI.tool_runner
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:
@@ -68,6 +72,12 @@ class MessagesWithRawResponse:
         self.create = _legacy_response.to_raw_response_wrapper(
             messages.create,
         )
+        self.count_tokens = _legacy_response.to_raw_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = _legacy_response.to_raw_response_wrapper(
+            messages.parse,
+        )
 
 
 class AsyncMessagesWithRawResponse:
@@ -76,6 +86,12 @@ class AsyncMessagesWithRawResponse:
 
         self.create = _legacy_response.async_to_raw_response_wrapper(
             messages.create,
+        )
+        self.count_tokens = _legacy_response.async_to_raw_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = _legacy_response.async_to_raw_response_wrapper(
+            messages.parse,
         )
 
 
@@ -86,6 +102,12 @@ class MessagesWithStreamingResponse:
         self.create = to_streamed_response_wrapper(
             messages.create,
         )
+        self.count_tokens = to_streamed_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = to_streamed_response_wrapper(
+            messages.parse,
+        )
 
 
 class AsyncMessagesWithStreamingResponse:
@@ -94,4 +116,10 @@ class AsyncMessagesWithStreamingResponse:
 
         self.create = async_to_streamed_response_wrapper(
             messages.create,
+        )
+        self.count_tokens = async_to_streamed_response_wrapper(
+            messages.count_tokens,
+        )
+        self.parse = async_to_streamed_response_wrapper(
+            messages.parse,
         )


### PR DESCRIPTION
# feat(bedrock/vertex): add parity for beta messages (stream, count_tokens, parse, tool_runner)

This PR adds missing beta method delegations to the `AnthropicBedrock` and `AnthropicVertex` clients, resolving #1120.

## Changes
- Added `stream()`, `count_tokens()`, `parse()`, and `tool_runner()` to `AnthropicBedrock.beta.messages` (sync and async).
- Added `parse() and `tool_runner()` to `AnthropicVertex.beta.messages` (sync and async).
- Added corresponding method delegations to `WithRawResponse` and `WithStreamingResponse` wrappers for both cloud clients.

## Verification
Verified with a reproduction script that checks for the existence and proper delegation of these methods across all cloud client variants (Bedrock/Vertex, Sync/Async).

```python
# Now possible with Bedrock/Vertex:
with client.beta.messages.stream(...) as stream:
    for event in stream:
        ...
```
