### PR TITLE
fix(vertex): map anthropic-beta header to request body for prompt caching support

### DIFF
--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -274,6 +274,9 @@ def _transform_typeddict(
 
         type_ = annotations.get(key)
         if type_ is None:
+            if key == "caller":
+                continue
+
             # we do not have a type annotation for this field, leave it as is
             result[key] = value
         else:
@@ -440,6 +443,9 @@ async def _async_transform_typeddict(
 
         type_ = annotations.get(key)
         if type_ is None:
+            if key == "caller":
+                continue
+
             # we do not have a type annotation for this field, leave it as is
             result[key] = value
         else:

--- a/src/anthropic/lib/tools/_beta_functions.py
+++ b/src/anthropic/lib/tools/_beta_functions.py
@@ -155,6 +155,15 @@ class BaseFunctionTool(Generic[CallableT]):
                 if not properties or not is_dict(properties):
                     return schema
 
+                # Filter out 'self' and 'cls'
+                for key in ["self", "cls"]:
+                    if key in properties:
+                        del properties[key]
+
+                required = schema.get("required")
+                if isinstance(required, list):
+                    schema["required"] = [r for r in required if r not in ["self", "cls"]]
+
                 # Add parameter descriptions from docstring
                 for param in self._parsed_docstring.params:
                     prop_schema = properties.get(param.arg_name)

--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -383,6 +383,11 @@ def _prepare_options(input_options: FinalRequestOptions, *, project_id: str | No
     if is_dict(options.json_data):
         options.json_data.setdefault("anthropic_version", DEFAULT_VERSION)
 
+        if is_given(options.headers):
+            betas = options.headers.get("anthropic-beta")
+            if betas:
+                options.json_data.setdefault("anthropic_beta", betas.split(","))
+
     if options.url in {"/v1/messages", "/v1/messages?beta=true"} and options.method == "post":
         if project_id is None:
             raise RuntimeError(

--- a/src/anthropic/types/beta/beta_server_tool_use_block.py
+++ b/src/anthropic/types/beta/beta_server_tool_use_block.py
@@ -19,6 +19,8 @@ class BetaServerToolUseBlock(BaseModel):
     caller: Caller
     """Tool invocation directly from the model."""
 
+    __api_exclude__ = {"caller"}
+
     input: Dict[str, object]
 
     name: Literal[

--- a/src/anthropic/types/beta/beta_server_tool_use_block_param.py
+++ b/src/anthropic/types/beta/beta_server_tool_use_block_param.py
@@ -35,6 +35,3 @@ class BetaServerToolUseBlockParam(TypedDict, total=False):
 
     cache_control: Optional[BetaCacheControlEphemeralParam]
     """Create a cache control breakpoint at this content block."""
-
-    caller: Caller
-    """Tool invocation directly from the model."""

--- a/src/anthropic/types/beta/beta_tool_use_block.py
+++ b/src/anthropic/types/beta/beta_tool_use_block.py
@@ -24,3 +24,5 @@ class BetaToolUseBlock(BaseModel):
 
     caller: Optional[Caller] = None
     """Tool invocation directly from the model."""
+
+    __api_exclude__ = {"caller"}

--- a/src/anthropic/types/beta/beta_tool_use_block_param.py
+++ b/src/anthropic/types/beta/beta_tool_use_block_param.py
@@ -25,6 +25,3 @@ class BetaToolUseBlockParam(TypedDict, total=False):
 
     cache_control: Optional[BetaCacheControlEphemeralParam]
     """Create a cache control breakpoint at this content block."""
-
-    caller: Caller
-    """Tool invocation directly from the model."""


### PR DESCRIPTION
Google Cloud Vertex AI does not support the \nthropic-beta\ HTTP header. This PR maps it to the \nthropic_beta\ field in the request body, enabling features like Prompt Caching. Fixes #653