### PR TITLE
feat: add thinking_tokens to usage models and streaming accumulation

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -536,5 +536,7 @@ def accumulate_event(
             current_snapshot.usage.cache_read_input_tokens = event.usage.cache_read_input_tokens
         if event.usage.server_tool_use is not None:
             current_snapshot.usage.server_tool_use = event.usage.server_tool_use
+        if event.usage.thinking_tokens is not None:
+            current_snapshot.usage.thinking_tokens = event.usage.thinking_tokens
 
     return current_snapshot

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -480,5 +480,7 @@ def accumulate_event(
             current_snapshot.usage.cache_read_input_tokens = event.usage.cache_read_input_tokens
         if event.usage.server_tool_use is not None:
             current_snapshot.usage.server_tool_use = event.usage.server_tool_use
+        if event.usage.thinking_tokens is not None:
+            current_snapshot.usage.thinking_tokens = event.usage.thinking_tokens
 
     return current_snapshot

--- a/src/anthropic/types/beta/beta_message_delta_usage.py
+++ b/src/anthropic/types/beta/beta_message_delta_usage.py
@@ -23,3 +23,6 @@ class BetaMessageDeltaUsage(BaseModel):
 
     server_tool_use: Optional[BetaServerToolUsage] = None
     """The number of server tool requests."""
+
+    thinking_tokens: Optional[int] = None
+    """The cumulative number of tokens used for thinking."""

--- a/src/anthropic/types/beta/beta_usage.py
+++ b/src/anthropic/types/beta/beta_usage.py
@@ -29,5 +29,8 @@ class BetaUsage(BaseModel):
     server_tool_use: Optional[BetaServerToolUsage] = None
     """The number of server tool requests."""
 
+    thinking_tokens: Optional[int] = None
+    """The number of tokens used for thinking."""
+
     service_tier: Optional[Literal["standard", "priority", "batch"]] = None
     """If the request used the priority, standard, or batch tier."""

--- a/src/anthropic/types/message_delta_usage.py
+++ b/src/anthropic/types/message_delta_usage.py
@@ -23,3 +23,6 @@ class MessageDeltaUsage(BaseModel):
 
     server_tool_use: Optional[ServerToolUsage] = None
     """The number of server tool requests."""
+
+    thinking_tokens: Optional[int] = None
+    """The cumulative number of tokens used for thinking."""

--- a/src/anthropic/types/usage.py
+++ b/src/anthropic/types/usage.py
@@ -29,5 +29,8 @@ class Usage(BaseModel):
     server_tool_use: Optional[ServerToolUsage] = None
     """The number of server tool requests."""
 
+    thinking_tokens: Optional[int] = None
+    """The number of tokens used for thinking."""
+
     service_tier: Optional[Literal["standard", "priority", "batch"]] = None
     """If the request used the priority, standard, or batch tier."""

--- a/uv.lock
+++ b/uv.lock
@@ -185,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.75.0"
+version = "0.76.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This PR adds support for granular reporting of thinking tokens, addressing Feature Request #1017. Changes: Added thinking_tokens field to Usage models and updated accumulation logic.