### PR TITLE
fix: strip schema field from tool definitions to prevent 500 errors

### DIFF
--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -78,6 +78,25 @@ if TYPE_CHECKING:
 __all__ = ["Messages", "AsyncMessages"]
 
 
+def _strip_tools(
+    tools: Iterable[BetaToolUnionParam] | Omit | None,
+) -> Iterable[BetaToolUnionParam] | Omit | None:
+    if tools is omit or tools is None:
+        return tools
+
+    new_tools: list[BetaToolUnionParam] = []
+    for tool in tools:
+        if isinstance(tool, dict) and "input_schema" in tool:
+            # Make a copy to avoid mutating user data
+            tool = tool.copy()  # type: ignore
+            input_schema = tool.get("input_schema")
+            if isinstance(input_schema, dict) and "$schema" in input_schema:
+                tool["input_schema"] = input_schema.copy()  # type: ignore
+                tool["input_schema"].pop("$schema")  # type: ignore
+        new_tools.append(tool)
+    return new_tools
+
+
 class Messages(SyncAPIResource):
     @cached_property
     def batches(self) -> Batches:
@@ -1041,7 +1060,7 @@ class Messages(SyncAPIResource):
                     "temperature": temperature,
                     "thinking": thinking,
                     "tool_choice": tool_choice,
-                    "tools": tools,
+                    "tools": _strip_tools(tools),
                     "top_k": top_k,
                     "top_p": top_p,
                 },
@@ -1158,7 +1177,7 @@ class Messages(SyncAPIResource):
                     "temperature": temperature,
                     "thinking": thinking,
                     "tool_choice": tool_choice,
-                    "tools": tools,
+                    "tools": _strip_tools(tools),
                     "top_k": top_k,
                     "top_p": top_p,
                 },
@@ -2702,7 +2721,7 @@ class AsyncMessages(AsyncAPIResource):
                     "temperature": temperature,
                     "thinking": thinking,
                     "tool_choice": tool_choice,
-                    "tools": tools,
+                    "tools": _strip_tools(tools),
                     "top_k": top_k,
                     "top_p": top_p,
                 },
@@ -2818,7 +2837,7 @@ class AsyncMessages(AsyncAPIResource):
                     "temperature": temperature,
                     "thinking": thinking,
                     "tool_choice": tool_choice,
-                    "tools": tools,
+                    "tools": _strip_tools(tools),
                     "top_k": top_k,
                     "top_p": top_p,
                 },

--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -85,7 +85,7 @@ def _strip_tools(
         return tools
 
     new_tools: list[BetaToolUnionParam] = []
-    for tool in tools:
+    for tool in cast(Iterable[BetaToolUnionParam], tools):
         if isinstance(tool, dict) and "input_schema" in tool:
             # Make a copy to avoid mutating user data
             tool = tool.copy()  # type: ignore

--- a/src/anthropic/resources/messages/messages.py
+++ b/src/anthropic/resources/messages/messages.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Union, Iterable, Optional
+from typing import Union, Iterable, Optional, cast
 from functools import partial
 from typing_extensions import Literal, overload
 
@@ -71,7 +71,7 @@ def _strip_tools(
         return tools
 
     new_tools: list[ToolUnionParam] = []
-    for tool in tools:
+    for tool in cast(Iterable[ToolUnionParam], tools):
         if isinstance(tool, dict) and "input_schema" in tool:
             # Make a copy to avoid mutating user data
             tool = tool.copy()  # type: ignore

--- a/src/anthropic/resources/messages/messages.py
+++ b/src/anthropic/resources/messages/messages.py
@@ -64,6 +64,25 @@ DEPRECATED_MODELS = {
 }
 
 
+def _strip_tools(
+    tools: Iterable[ToolUnionParam] | Omit | None,
+) -> Iterable[ToolUnionParam] | Omit | None:
+    if tools is omit or tools is None:
+        return tools
+
+    new_tools: list[ToolUnionParam] = []
+    for tool in tools:
+        if isinstance(tool, dict) and "input_schema" in tool:
+            # Make a copy to avoid mutating user data
+            tool = tool.copy()  # type: ignore
+            input_schema = tool.get("input_schema")
+            if isinstance(input_schema, dict) and "$schema" in input_schema:
+                tool["input_schema"] = input_schema.copy()  # type: ignore
+                tool["input_schema"].pop("$schema")  # type: ignore
+        new_tools.append(tool)
+    return new_tools
+
+
 class Messages(SyncAPIResource):
     @cached_property
     def batches(self) -> Batches:
@@ -944,7 +963,7 @@ class Messages(SyncAPIResource):
                     "temperature": temperature,
                     "thinking": thinking,
                     "tool_choice": tool_choice,
-                    "tools": tools,
+                    "tools": _strip_tools(tools),
                     "top_k": top_k,
                     "top_p": top_p,
                 },
@@ -2128,7 +2147,7 @@ class AsyncMessages(AsyncAPIResource):
                     "temperature": temperature,
                     "thinking": thinking,
                     "tool_choice": tool_choice,
-                    "tools": tools,
+                    "tools": _strip_tools(tools),
                     "top_k": top_k,
                     "top_p": top_p,
                 },
@@ -2196,7 +2215,7 @@ class AsyncMessages(AsyncAPIResource):
                     "temperature": temperature,
                     "top_k": top_k,
                     "top_p": top_p,
-                    "tools": tools,
+                    "tools": _strip_tools(tools),
                     "thinking": thinking,
                     "tool_choice": tool_choice,
                     "stream": True,
@@ -2420,7 +2439,7 @@ class AsyncMessages(AsyncAPIResource):
                     "system": system,
                     "thinking": thinking,
                     "tool_choice": tool_choice,
-                    "tools": tools,
+                    "tools": _strip_tools(tools),
                 },
                 message_count_tokens_params.MessageCountTokensParams,
             ),


### PR DESCRIPTION
This PR addresses Issue #1001 where including the schema field in tool input_schema caused 500 Internal Server Errors from the API. Changes: Implemented _strip_tools helper and applied it to Messages methods in standard and beta resources.