### PR TITLE
fix(tool_runner): propagate container_id for programmatic tool calling

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -246,6 +246,10 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
                 message = self._get_last_message()
                 assert message is not None
 
+                # Update container from response for programmatic tool calling support
+                if message.container is not None:
+                    self._params["container"] = message.container.id
+
             self._iteration_count += 1
 
             # If the compaction was performed, skip tool call generation this iteration
@@ -496,6 +500,10 @@ class BaseAsyncToolRunner(
                 yield item
                 message = await self._get_last_message()
                 assert message is not None
+
+                # Update container from response for programmatic tool calling support
+                if message.container is not None:
+                    self._params["container"] = message.container.id
 
             self._iteration_count += 1
 


### PR DESCRIPTION
## Problem

When using programmatic tool calling (PTC) with `tool_runner`, the API returns a `container_id` in the response that must be passed in subsequent requests. Without this, the API returns:

```
container_id is required when there are pending tool uses generated by code execution with tools.
```

## Solution

Update both sync and async tool runners to extract `message.container.id` from responses and set it in `self._params["container"]` for subsequent API calls.

## Changes

- `BaseSyncToolRunner.__run__()`: Added container propagation after getting message
- `BaseAsyncToolRunner.__run__()`: Added container propagation after getting message (async version)

## Testing

This enables using `tool_runner` with programmatic tool calling where client-side tools are called from within code execution. The container lifecycle is now properly managed across requests.

## Example

```python
runner = client.beta.messages.tool_runner(
    model="claude-sonnet-4-5",
    tools=[
        {"type": "code_execution_20250825", "name": "code_execution"},
        {
            "name": "my_tool",
            "description": "...",
            "input_schema": {...},
            "allowed_callers": ["code_execution_20250825"]
        }
    ],
    messages=[...],
    betas=["advanced-tool-use-2025-11-20"],
)

for message in runner:
    # Now works! Container ID is automatically propagated between requests
    print(message)
```