### PR TITLE
fix(compaction): also filter out server_tool_use blocks before compaction

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -186,12 +186,12 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
         messages = list(self._params["messages"])
 
         if messages[-1]["role"] == "assistant":
-            # Remove tool_use blocks from the last message to avoid 400 error
-            # (tool_use requires tool_result, which we don't have yet)
+            # Remove tool_use and server_tool_use blocks from the last message to avoid 400 error
+            # (tool_use/server_tool_use requires corresponding result blocks, which we don't have yet)
             non_tool_blocks = [
                 block
                 for block in messages[-1]["content"]
-                if isinstance(block, dict) and block.get("type") != "tool_use"
+                if isinstance(block, dict) and block.get("type") not in ("tool_use", "server_tool_use")
             ]
 
             if non_tool_blocks:
@@ -437,12 +437,12 @@ class BaseAsyncToolRunner(
         messages = list(self._params["messages"])
 
         if messages[-1]["role"] == "assistant":
-            # Remove tool_use blocks from the last message to avoid 400 error
-            # (tool_use requires tool_result, which we don't have yet)
+            # Remove tool_use and server_tool_use blocks from the last message to avoid 400 error
+            # (tool_use/server_tool_use requires corresponding result blocks, which we don't have yet)
             non_tool_blocks = [
                 block
                 for block in messages[-1]["content"]
-                if isinstance(block, dict) and block.get("type") != "tool_use"
+                if isinstance(block, dict) and block.get("type") not in ("tool_use", "server_tool_use")
             ]
 
             if non_tool_blocks:

--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -190,8 +190,12 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
         messages = list(self._params["messages"])
 
         # Include current message if provided (contains server tool results not yet appended)
+        # Convert content to dicts so the filter logic below works correctly
         if current_message is not None:
-            messages.append({"role": current_message.role, "content": current_message.content})
+            messages.append({
+                "role": current_message.role,
+                "content": [block.model_dump() for block in current_message.content]
+            })
 
         if messages[-1]["role"] == "assistant":
             # Remove tool_use and server_tool_use blocks from the last message to avoid 400 error
@@ -450,8 +454,12 @@ class BaseAsyncToolRunner(
         messages = list(self._params["messages"])
 
         # Include current message if provided (contains server tool results not yet appended)
+        # Convert content to dicts so the filter logic below works correctly
         if current_message is not None:
-            messages.append({"role": current_message.role, "content": current_message.content})
+            messages.append({
+                "role": current_message.role,
+                "content": [block.model_dump() for block in current_message.content]
+            })
 
         if messages[-1]["role"] == "assistant":
             # Remove tool_use and server_tool_use blocks from the last message to avoid 400 error


### PR DESCRIPTION
## Problem

When compaction is triggered while the last assistant message contains `server_tool_use` blocks (for server-side tools like `web_fetch` or `web_search`), the compaction API call fails with:

```
messages.X: `web_fetch` tool use with id `srvtoolu_XXX` was found without a corresponding `web_fetch_tool_result` block
```

## Root Cause

The compaction code filters out `tool_use` blocks from the last assistant message before making the compaction request (since they require corresponding `tool_result` blocks). However, it wasn't filtering out `server_tool_use` blocks, which also require corresponding result blocks (`web_fetch_tool_result`, `web_search_tool_result`, etc.).

## Solution

Changed the filter from:
```python
block.get("type") != "tool_use"
```

to:
```python
block.get("type") not in ("tool_use", "server_tool_use")
```

## Changes

- Updated `BaseSyncToolRunner._check_and_compact()` to filter out both `tool_use` and `server_tool_use`
- Updated `BaseAsyncToolRunner._check_and_compact()` with the same fix