### PR TITLE
fix(beta): strip betas from individual batch request params

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,8 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    tool_runner = FirstPartyMessagesAPI.tool_runner
+    stream = FirstPartyMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +38,8 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    tool_runner = FirstPartyAsyncMessagesAPI.tool_runner
+    stream = FirstPartyAsyncMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:

--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ... import _legacy_response
 from ..._compat import cached_property
 from ..._resource import SyncAPIResource, AsyncAPIResource
@@ -15,6 +17,12 @@ class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
     tool_runner = FirstPartyMessagesAPI.tool_runner
     stream = FirstPartyMessagesAPI.stream
+
+    if TYPE_CHECKING:
+        ...
+    else:
+        # parse is used by stream and tool_runner internally
+        parse = FirstPartyMessagesAPI.parse
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -40,6 +48,12 @@ class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
     tool_runner = FirstPartyAsyncMessagesAPI.tool_runner
     stream = FirstPartyAsyncMessagesAPI.stream
+
+    if TYPE_CHECKING:
+        ...
+    else:
+        # parse is used by stream and tool_runner internally
+        parse = FirstPartyAsyncMessagesAPI.parse
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:

--- a/src/anthropic/resources/beta/messages/batches.py
+++ b/src/anthropic/resources/beta/messages/batches.py
@@ -95,7 +95,20 @@ class Batches(SyncAPIResource):
         extra_headers = {"anthropic-beta": "message-batches-2024-09-24", **(extra_headers or {})}
         return self._post(
             "/v1/messages/batches?beta=true",
-            body=maybe_transform({"requests": requests}, batch_create_params.BatchCreateParams),
+            body=maybe_transform(
+                {
+                    "requests": [
+                        {
+                            **request,
+                            "params": {  # type: ignore[misc]
+                                k: v for k, v in request["params"].items() if k not in {"betas", "anthropic-beta"}
+                            },
+                        }
+                        for request in requests
+                    ]
+                },
+                batch_create_params.BatchCreateParams,
+            ),
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
@@ -482,7 +495,20 @@ class AsyncBatches(AsyncAPIResource):
         extra_headers = {"anthropic-beta": "message-batches-2024-09-24", **(extra_headers or {})}
         return await self._post(
             "/v1/messages/batches?beta=true",
-            body=await async_maybe_transform({"requests": requests}, batch_create_params.BatchCreateParams),
+            body=await async_maybe_transform(
+                {
+                    "requests": [
+                        {
+                            **request,
+                            "params": {  # type: ignore[misc]
+                                k: v for k, v in request["params"].items() if k not in {"betas", "anthropic-beta"}
+                            },
+                        }
+                        for request in requests
+                    ]
+                },
+                batch_create_params.BatchCreateParams,
+            ),
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),


### PR DESCRIPTION
Fixes #1118. Strip 'betas' or 'anthropic-beta' from individual request params in Batch creation. This prevents 400 Bad Request errors when users include betas inside individual requests, as the Messages API expects these as headers, not body parameters.