### PR TITLE
fix(streaming): safely handle dicts in accumulate_event

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -458,7 +458,10 @@ def accumulate_event(
     if current_snapshot is None:
         if event.type == "message_start":
             return cast(
-                ParsedBetaMessage[ResponseFormatT], ParsedBetaMessage.construct(**cast(Any, event.message.to_dict()))
+                ParsedBetaMessage[ResponseFormatT],
+                ParsedBetaMessage.construct(
+                    **cast(Any, event.message.to_dict() if hasattr(event.message, "to_dict") else event.message)
+                ),
             )
 
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')
@@ -468,7 +471,12 @@ def accumulate_event(
         current_snapshot.content.append(
             cast(
                 Any,  # Pydantic does not support generic unions at runtime
-                construct_type(type_=ParsedBetaContentBlock, value=event.content_block.to_dict()),
+                construct_type(
+                    type_=ParsedBetaContentBlock,
+                    value=event.content_block.to_dict()
+                    if hasattr(event.content_block, "to_dict")
+                    else event.content_block,
+                ),
             ),
         )
     elif event.type == "content_block_delta":

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -419,7 +419,9 @@ def accumulate_event(
 
     if current_snapshot is None:
         if event.type == "message_start":
-            return Message.construct(**cast(Any, event.message.to_dict()))
+            return Message.construct(
+                **cast(Any, event.message.to_dict() if hasattr(event.message, "to_dict") else event.message)
+            )
 
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')
 
@@ -428,7 +430,12 @@ def accumulate_event(
         current_snapshot.content.append(
             cast(
                 ContentBlock,
-                construct_type(type_=ContentBlock, value=event.content_block.model_dump()),
+                construct_type(
+                    type_=ContentBlock,
+                    value=event.content_block.model_dump()
+                    if hasattr(event.content_block, "model_dump")
+                    else event.content_block,
+                ),
             ),
         )
     elif event.type == "content_block_delta":


### PR DESCRIPTION
Fixes #1088. Intermittently, 'event.message' or 'event.content_block' may already be dictionaries during response accumulation. This change adds a safety check to ensure '.to_dict()' or '.model_dump()' are only called if the objects are actual model instances, preventing AttributeError.