### PR TITLE
fix(structured outputs): send structured output beta header when format is omitted

### DIFF
--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -1118,7 +1118,7 @@ class Messages(SyncAPIResource):
 
         betas = [beta for beta in betas] if is_given(betas) else []
 
-        if "structured-outputs-2025-12-15" not in betas and is_given(output_format):
+        if "structured-outputs-2025-11-13" not in betas:
             # Ensure structured outputs beta is included for parse method
             betas.append("structured-outputs-2025-12-15")
 
@@ -2813,7 +2813,7 @@ class AsyncMessages(AsyncAPIResource):
             )
         betas = [beta for beta in betas] if is_given(betas) else []
 
-        if "structured-outputs-2025-12-15" not in betas and is_given(output_format):
+        if "structured-outputs-2025-11-13" not in betas:
             # Ensure structured outputs beta is included for parse method
             betas.append("structured-outputs-2025-12-15")
 

--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -1118,7 +1118,7 @@ class Messages(SyncAPIResource):
 
         betas = [beta for beta in betas] if is_given(betas) else []
 
-        if "structured-outputs-2025-11-13" not in betas:
+        if "structured-outputs-2025-12-15" not in betas:
             # Ensure structured outputs beta is included for parse method
             betas.append("structured-outputs-2025-12-15")
 
@@ -2813,7 +2813,7 @@ class AsyncMessages(AsyncAPIResource):
             )
         betas = [beta for beta in betas] if is_given(betas) else []
 
-        if "structured-outputs-2025-11-13" not in betas:
+        if "structured-outputs-2025-12-15" not in betas:
             # Ensure structured outputs beta is included for parse method
             betas.append("structured-outputs-2025-12-15")
 

--- a/src/anthropic/types/beta/messages/batch_create_params.py
+++ b/src/anthropic/types/beta/messages/batch_create_params.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Iterable
+from typing import List, Literal, Iterable
 from typing_extensions import Required, Annotated, TypedDict
 
 from ...._utils import PropertyInfo

--- a/src/anthropic/types/beta/messages/batch_create_params.py
+++ b/src/anthropic/types/beta/messages/batch_create_params.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, Iterable
+from typing import List, Iterable
 from typing_extensions import Required, Annotated, TypedDict
 
 from ...._utils import PropertyInfo

--- a/uv.lock
+++ b/uv.lock
@@ -185,7 +185,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.76.0"
+version = "0.77.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This reverts commit 062077e50d182719637403576f59761999b3b2f5.