### PR TITLE
fix: handle None by_alias in model_dump for FastAPI contexts

### DIFF
--- a/src/anthropic/_compat.py
+++ b/src/anthropic/_compat.py
@@ -155,7 +155,7 @@ def model_dump(
             exclude_defaults=exclude_defaults,
             # warnings are not supported in Pydantic v1
             warnings=True if PYDANTIC_V1 else warnings,
-            by_alias=by_alias,
+            by_alias=by_alias if by_alias is not None else False,
         )
     return cast(
         "dict[str, Any]",


### PR DESCRIPTION
When calling `model_dump` with `by_alias=None` (the default), the pydantic-core serializer in certain async contexts (like FastAPI) can fail with `'NoneType' cannot be converted to 'PyBool'`.

This applies the same pattern already used in `_models.py` where `by_alias` is explicitly converted:
```python
by_alias=by_alias if by_alias is not None else False
```

Fixes #1160