### PR TITLE
fix(models): correctly unwrap Annotated types for RawMessageStreamEvent deserialization

### DIFF
--- a/src/anthropic/_compat.py
+++ b/src/anthropic/_compat.py
@@ -155,7 +155,7 @@ def model_dump(
             exclude_defaults=exclude_defaults,
             # warnings are not supported in Pydantic v1
             warnings=True if PYDANTIC_V1 else warnings,
-            by_alias=by_alias,
+            by_alias=by_alias if by_alias is not None else False,
         )
     return cast(
         "dict[str, Any]",

--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -576,13 +576,13 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         and (issubclass(origin, BaseModel) or issubclass(origin, GenericModel))
     ):
         if is_list(value):
-            return [_type.construct(**entry) if is_mapping(entry) else entry for entry in value]  # type: ignore[arg-type]
+            return [_type.construct(**entry) if is_mapping(entry) else entry for entry in value]  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
         if is_mapping(value):
             if inspect.isclass(_type) and issubclass(_type, BaseModel):
                 return _type.construct(**value)  # type: ignore[arg-type]
 
-            return _type.construct(**value)  # type: ignore[arg-type, return-value]
+            return _type.construct(**value)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
 
     if origin == list:
         if not is_list(value):

--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -509,17 +509,25 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
     # `Literal['value']` will be reported as a type error by type checkers
     type_ = cast("type[object]", type_)
     if is_type_alias_type(type_):
-        original_type = type_  # type: ignore[unreachable]
-        type_ = type_.__value__  # type: ignore[unreachable]
+        original_type = type_
+        type_ = type_.__value__
 
     # unwrap `Annotated[T, ...]` -> `T`
     if metadata is not None and len(metadata) > 0:
         meta: tuple[Any, ...] = tuple(metadata)
-    elif is_annotated_type(type_):
-        meta = get_args(type_)[1:]
-        type_ = extract_type_arg(type_, 0)
     else:
         meta = tuple()
+
+    if is_annotated_type(type_):
+        if not meta:
+            meta = get_args(type_)[1:]
+
+        if original_type is None:
+            original_type = type_
+
+        type_ = extract_type_arg(type_, 0)
+
+
 
     # we need to use the origin class for any types that are subscripted generics
     # e.g. Dict[str, object]

--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -576,13 +576,13 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         and (issubclass(origin, BaseModel) or issubclass(origin, GenericModel))
     ):
         if is_list(value):
-            return [_type.construct(**entry) if is_mapping(entry) else entry for entry in value]
+            return [_type.construct(**entry) if is_mapping(entry) else entry for entry in value]  # type: ignore[arg-type]
 
         if is_mapping(value):
             if inspect.isclass(_type) and issubclass(_type, BaseModel):
                 return _type.construct(**value)  # type: ignore[arg-type]
 
-            return _type.construct(**value)
+            return _type.construct(**value)  # type: ignore[arg-type, return-value]
 
     if origin == list:
         if not is_list(value):

--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -507,15 +507,21 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
     else:
         meta = tuple()
 
+    # we allow `object` as the input type because otherwise, passing things like
+    # `Literal['value']` will be reported as a type error by type checkers
+    type_ = cast(Any, type_)
+
     while is_type_alias_type(type_) or is_annotated_type(type_):
         if is_type_alias_type(type_):
-            type_ = cast("type[object]", type_.__value__)
+            type_ = cast(Any, type_.__value__)
             continue
 
         if is_annotated_type(type_):
             meta = meta + get_args(type_)[1:]
-            type_ = cast("type[object]", extract_type_arg(type_, 0))
+            type_ = cast(Any, extract_type_arg(type_, 0))
             continue
+
+    type_ = cast(Any, type_)
 
     # we need to use the origin class for any types that are subscripted generics
     # e.g. Dict[str, object]

--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -509,8 +509,8 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
     # `Literal['value']` will be reported as a type error by type checkers
     type_ = cast("type[object]", type_)
     if is_type_alias_type(type_):
-        original_type = type_
-        type_ = type_.__value__
+        original_type = type_  # type: ignore[unreachable]
+        type_ = type_.__value__  # type: ignore[unreachable]
 
     # unwrap `Annotated[T, ...]` -> `T`
     if metadata is not None and len(metadata) > 0:

--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -528,7 +528,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
 
     if is_union(origin):
         try:
-            return validate_type(type_=_type, value=value)
+            return validate_type(type_=_type, value=value)  # pyright: ignore[reportUnknownVariableType]
         except Exception:
             pass
 

--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -513,12 +513,12 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
 
     while is_type_alias_type(_type) or is_annotated_type(_type):
         if is_type_alias_type(_type):
-            _type = cast(Any, _type.__value__)
+            _type = _type.__value__
             continue
 
         if is_annotated_type(_type):
             meta = meta + get_args(_type)[1:]
-            _type = cast(Any, extract_type_arg(_type, 0))
+            _type = extract_type_arg(_type, 0)
             continue
 
     # we need to use the origin class for any types that are subscripted generics
@@ -528,7 +528,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
 
     if is_union(origin):
         try:
-            return validate_type(type_=cast(Any, _type), value=value)
+            return validate_type(type_=_type, value=value)
         except Exception:
             pass
 
@@ -546,7 +546,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         #
         # without this block, if the data we get is something like `{'kind': 'bar', 'value': 'foo'}` then
         # we'd end up constructing `FooType` when it should be `BarType`.
-        discriminator = _build_discriminated_union_meta(union=cast(Any, _type), meta_annotations=meta)
+        discriminator = _build_discriminated_union_meta(union=_type, meta_annotations=meta)
         if discriminator and is_mapping(value):
             variant_value = value.get(discriminator.field_alias_from or discriminator.field_name)
             if variant_value and isinstance(variant_value, str):
@@ -576,13 +576,13 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         and (issubclass(origin, BaseModel) or issubclass(origin, GenericModel))
     ):
         if is_list(value):
-            return [cast(Any, _type).construct(**entry) if is_mapping(entry) else entry for entry in value]
+            return [_type.construct(**entry) if is_mapping(entry) else entry for entry in value]
 
         if is_mapping(value):
             if inspect.isclass(_type) and issubclass(_type, BaseModel):
                 return _type.construct(**value)  # type: ignore[arg-type]
 
-            return cast(Any, _type).construct(**value)
+            return _type.construct(**value)
 
     if origin == list:
         if not is_list(value):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -48,6 +48,8 @@ DiscriminatedUnionAnnotated = Annotated[DiscriminatedUnionA, PropertyInfo(discri
 DiscriminatedUnionC = Union[Union[UnwrappingVariantA, UnwrappingVariantB], UnwrappingVariantB]  # Adjusted for test
 # Actually let's use the ones already in the tests if possible, but move them up.
 
+TestAlias = TypeAliasType("TestAlias", str)
+
 
 @pytest.mark.parametrize("value", ["hello", 1], ids=["correct type", "mismatched"])
 def test_basic(value: object) -> None:
@@ -868,11 +870,9 @@ def test_discriminated_unions_invalid_data_uses_cache() -> None:
 
 @pytest.mark.skipif(PYDANTIC_V1, reason="TypeAliasType is not supported in Pydantic v1")
 def test_type_alias_type() -> None:
-    Alias = TypeAliasType("Alias", str)  # pyright: ignore
-
     class Model(BaseModel):
-        alias: Alias
-        union: Union[int, Alias]
+        alias: TestAlias
+        union: Union[int, TestAlias]
 
     m = construct_type(value={"alias": "foo", "union": "bar"}, type_=Model)
     assert isinstance(m, Model)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -961,3 +961,69 @@ def test_extra_properties() -> None:
     assert model.a.prop == 1
     assert isinstance(model.a, Item)
     assert model.other == "foo"
+
+
+def test_type_alias_annotated_unwrapping() -> None:
+    class VariantA(BaseModel):
+        type: Literal["a"]
+        value: str
+
+    class VariantB(BaseModel):
+        type: Literal["b"]
+        value: int
+
+    # Case 1: TypeAliasType of Annotated Union
+    # This is similar to how RawMessageStreamEvent might be defined in some environments
+    DiscriminatedUnion = Annotated[Union[VariantA, VariantB], PropertyInfo(discriminator="type")]
+    Alias = TypeAliasType("Alias", DiscriminatedUnion)
+
+    # Test deserialization via Alias
+    data = {"type": "a", "value": "foo"}
+    m = construct_type(type_=Alias, value=data)
+    assert isinstance(m, VariantA)
+    assert m.type == "a"
+    assert m.value == "foo"
+
+    data = {"type": "b", "value": 123}
+    m = construct_type(type_=Alias, value=data)
+    assert isinstance(m, VariantB)
+    assert m.type == "b"
+    assert m.value == 123
+
+
+def test_annotated_type_alias_unwrapping() -> None:
+    class VariantA(BaseModel):
+        type: Literal["a"]
+        value: str
+
+    class VariantB(BaseModel):
+        type: Literal["b"]
+        value: int
+
+    # Case 2: Annotated of TypeAliasType of Union
+    UnionAlias = TypeAliasType("UnionAlias", Union[VariantA, VariantB])
+    AnnotatedAlias = Annotated[UnionAlias, PropertyInfo(discriminator="type")]
+
+    data = {"type": "a", "value": "foo"}
+    m = construct_type(type_=AnnotatedAlias, value=data)
+    assert isinstance(m, VariantA)
+    assert m.type == "a"
+    assert m.value == "foo"
+
+
+def test_deeply_nested_unwrapping() -> None:
+    class VariantA(BaseModel):
+        type: Literal["a"]
+        value: str
+
+    # Case 3: Deeply nested TypeAliasType and Annotated
+    UnionAlias = TypeAliasType("UnionAlias", Union[VariantA])
+    Annotated1 = Annotated[UnionAlias, "some metadata"]
+    Alias1 = TypeAliasType("Alias1", Annotated1)
+    Annotated2 = Annotated[Alias1, PropertyInfo(discriminator="type")]
+    Alias2 = TypeAliasType("Alias2", Annotated2)
+
+    data = {"type": "a", "value": "foo"}
+    m = construct_type(type_=Alias2, value=data)
+    assert isinstance(m, VariantA)
+    assert m.value == "foo"


### PR DESCRIPTION
This PR fixes a bug where construct_type failed to correctly unwrap Annotated types when they were wrapped in TypeAlias (common in newer Python versions/setups) or when metadata was explicitly provided. This ensures that discriminated unions like RawMessageStreamEvent are correctly processed, preventing intermittent Unexpected event runtime type errors during streaming (fixes #941).