### PR TITLE
fix: handle None value for by_alias parameter in FastAPI context

### DIFF
--- a/src/anthropic/_compat.py
+++ b/src/anthropic/_compat.py
@@ -148,6 +148,8 @@ def model_dump(
     by_alias: bool | None = None,
 ) -> dict[str, Any]:
     if (not PYDANTIC_V1) or hasattr(model, "model_dump"):
+        # Convert None to False explicitly to avoid TypeError in Pydantic v2
+        by_alias_value = by_alias if by_alias is not None else False
         return model.model_dump(
             mode=mode,
             exclude=exclude,
@@ -155,7 +157,7 @@ def model_dump(
             exclude_defaults=exclude_defaults,
             # warnings are not supported in Pydantic v1
             warnings=True if PYDANTIC_V1 else warnings,
-            by_alias=by_alias,
+            by_alias=by_alias_value,
         )
     return cast(
         "dict[str, Any]",


### PR DESCRIPTION
## Summary
Fixes #1160 - TypeError when using the SDK in FastAPI context due to `by_alias=None` being passed to Pydantic's `model_dump()`.

## Problem
When the Anthropic SDK is used within a FastAPI application, it fails with:
```
TypeError: argument 'by_alias': 'NoneType' object cannot be converted to 'PyBool'
```

This occurs in `src/anthropic/_compat.py` at line 158 where `by_alias=None` is passed directly to `model.model_dump()`. Pydantic v2's Rust-based serializer cannot handle `None` for boolean parameters in certain contexts (specifically when FastAPI is involved).

## Solution
Convert `None` to `False` explicitly before passing to `model_dump()`:
```python
by_alias_value = by_alias if by_alias is not None else False
```

This ensures the parameter is always a boolean value, maintaining backward compatibility while fixing the FastAPI incompatibility.

## Testing
- Direct CLI usage: Works (already working)
- FastAPI context: Should now work (previously failing)
- The fix preserves existing behavior when `by_alias` is explicitly set to `True` or `False`

## Impact
- Minimal change to the `model_dump()` compatibility wrapper
- No breaking changes - default behavior remains the same (None → False)
- Fixes SDK usage in FastAPI applications without affecting other use cases