### PR TITLE
fix: strip betas parameter from batch request params to prevent API error

### DIFF
--- a/src/anthropic/resources/beta/messages/batches.py
+++ b/src/anthropic/resources/beta/messages/batches.py
@@ -93,9 +93,20 @@ class Batches(SyncAPIResource):
             **(extra_headers or {}),
         }
         extra_headers = {"anthropic-beta": "message-batches-2024-09-24", **(extra_headers or {})}
+
+        # Strip 'betas' from individual request params as it should only be at batch level
+        cleaned_requests = []
+        for request in requests:
+            request_dict = dict(request)
+            if "params" in request_dict and isinstance(request_dict["params"], dict):
+                params_copy = dict(request_dict["params"])
+                params_copy.pop("betas", None)
+                request_dict["params"] = params_copy
+            cleaned_requests.append(request_dict)
+
         return self._post(
             "/v1/messages/batches?beta=true",
-            body=maybe_transform({"requests": requests}, batch_create_params.BatchCreateParams),
+            body=maybe_transform({"requests": cleaned_requests}, batch_create_params.BatchCreateParams),
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
@@ -480,9 +491,20 @@ class AsyncBatches(AsyncAPIResource):
             **(extra_headers or {}),
         }
         extra_headers = {"anthropic-beta": "message-batches-2024-09-24", **(extra_headers or {})}
+
+        # Strip 'betas' from individual request params as it should only be at batch level
+        cleaned_requests = []
+        for request in requests:
+            request_dict = dict(request)
+            if "params" in request_dict and isinstance(request_dict["params"], dict):
+                params_copy = dict(request_dict["params"])
+                params_copy.pop("betas", None)
+                request_dict["params"] = params_copy
+            cleaned_requests.append(request_dict)
+
         return await self._post(
             "/v1/messages/batches?beta=true",
-            body=await async_maybe_transform({"requests": requests}, batch_create_params.BatchCreateParams),
+            body=await async_maybe_transform({"requests": cleaned_requests}, batch_create_params.BatchCreateParams),
             options=make_request_options(
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),

--- a/tests/api_resources/beta/messages/test_batch_betas_stripping.py
+++ b/tests/api_resources/beta/messages/test_batch_betas_stripping.py
@@ -1,0 +1,262 @@
+# Test for issue #1118: Batch + Structured Outputs - betas parameter bug
+# Tests that betas in MessageCreateParamsNonStreaming are stripped when used in batch requests
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+from respx import MockRouter
+
+from anthropic import Anthropic, AsyncAnthropic
+from anthropic.types.beta.messages import BetaMessageBatch
+
+
+class TestBatchBetasStripping:
+    """Test that betas parameter is stripped from individual request params in batch processing."""
+
+    @pytest.mark.respx
+    def test_betas_stripped_from_request_params(self, respx_mock: MockRouter) -> None:
+        """Test that betas in request params are stripped before sending to API."""
+        client = Anthropic(api_key="test-key", base_url="http://127.0.0.1:4010")
+
+        # Mock the API response
+        respx_mock.post("/v1/messages/batches?beta=true").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "batch_123",
+                    "type": "message_batch",
+                    "processing_status": "in_progress",
+                    "request_counts": {
+                        "processing": 1,
+                        "succeeded": 0,
+                        "errored": 0,
+                        "canceled": 0,
+                        "expired": 0,
+                    },
+                    "ended_at": None,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "expires_at": "2024-01-02T00:00:00Z",
+                    "cancel_initiated_at": None,
+                    "results_url": None,
+                },
+            )
+        )
+
+        # Create a batch with betas in both batch-level and request params
+        batch = client.beta.messages.batches.create(
+            betas=["structured-outputs-2025-11-13"],
+            requests=[
+                {
+                    "custom_id": "test-1",
+                    "params": {
+                        "model": "claude-sonnet-4-5",
+                        "max_tokens": 1024,
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        # This should be stripped
+                        "betas": ["structured-outputs-2025-11-13"],
+                        "output_format": {
+                            "type": "json_schema",
+                            "schema": {"type": "object", "properties": {"name": {"type": "string"}}},
+                        },
+                    },
+                }
+            ],
+        )
+
+        assert batch.id == "batch_123"
+
+        # Verify the request body doesn't contain betas in params
+        assert len(respx_mock.calls) == 1
+        request = respx_mock.calls[0].request
+        body = json.loads(request.content.decode())
+
+        # Check that the request params don't have betas
+        assert "requests" in body
+        assert len(body["requests"]) == 1
+        assert "params" in body["requests"][0]
+        assert "betas" not in body["requests"][0]["params"], "betas should be stripped from request params"
+        assert "output_format" in body["requests"][0]["params"], "output_format should still be present"
+
+        # Check that the header has the beta
+        assert "anthropic-beta" in request.headers
+        assert "structured-outputs-2025-11-13" in request.headers["anthropic-beta"]
+        assert "message-batches-2024-09-24" in request.headers["anthropic-beta"]
+
+    @pytest.mark.respx
+    async def test_async_betas_stripped_from_request_params(self, respx_mock: MockRouter) -> None:
+        """Test that betas in request params are stripped in async client."""
+        client = AsyncAnthropic(api_key="test-key", base_url="http://127.0.0.1:4010")
+
+        # Mock the API response
+        respx_mock.post("/v1/messages/batches?beta=true").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "batch_456",
+                    "type": "message_batch",
+                    "processing_status": "in_progress",
+                    "request_counts": {
+                        "processing": 1,
+                        "succeeded": 0,
+                        "errored": 0,
+                        "canceled": 0,
+                        "expired": 0,
+                    },
+                    "ended_at": None,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "expires_at": "2024-01-02T00:00:00Z",
+                    "cancel_initiated_at": None,
+                    "results_url": None,
+                },
+            )
+        )
+
+        # Create a batch with betas in request params
+        batch = await client.beta.messages.batches.create(
+            betas=["structured-outputs-2025-11-13"],
+            requests=[
+                {
+                    "custom_id": "test-2",
+                    "params": {
+                        "model": "claude-sonnet-4-5",
+                        "max_tokens": 1024,
+                        "messages": [{"role": "user", "content": "Hello async"}],
+                        # This should be stripped
+                        "betas": ["structured-outputs-2025-11-13"],
+                        "output_format": {
+                            "type": "json_schema",
+                            "schema": {"type": "object", "properties": {"email": {"type": "string"}}},
+                        },
+                    },
+                }
+            ],
+        )
+
+        assert batch.id == "batch_456"
+
+        # Verify the request body doesn't contain betas in params
+        assert len(respx_mock.calls) == 1
+        request = respx_mock.calls[0].request
+        body = json.loads(request.content.decode())
+
+        # Check that the request params don't have betas
+        assert "betas" not in body["requests"][0]["params"], "betas should be stripped from request params"
+
+    @pytest.mark.respx
+    def test_multiple_requests_with_betas_all_stripped(self, respx_mock: MockRouter) -> None:
+        """Test that betas are stripped from all requests in a batch."""
+        client = Anthropic(api_key="test-key", base_url="http://127.0.0.1:4010")
+
+        respx_mock.post("/v1/messages/batches?beta=true").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "batch_789",
+                    "type": "message_batch",
+                    "processing_status": "in_progress",
+                    "request_counts": {
+                        "processing": 2,
+                        "succeeded": 0,
+                        "errored": 0,
+                        "canceled": 0,
+                        "expired": 0,
+                    },
+                    "ended_at": None,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "expires_at": "2024-01-02T00:00:00Z",
+                    "cancel_initiated_at": None,
+                    "results_url": None,
+                },
+            )
+        )
+
+        # Create a batch with multiple requests, each with betas
+        batch = client.beta.messages.batches.create(
+            betas=["structured-outputs-2025-11-13"],
+            requests=[
+                {
+                    "custom_id": "test-3",
+                    "params": {
+                        "model": "claude-sonnet-4-5",
+                        "max_tokens": 1024,
+                        "messages": [{"role": "user", "content": "First"}],
+                        "betas": ["structured-outputs-2025-11-13"],
+                    },
+                },
+                {
+                    "custom_id": "test-4",
+                    "params": {
+                        "model": "claude-sonnet-4-5",
+                        "max_tokens": 1024,
+                        "messages": [{"role": "user", "content": "Second"}],
+                        "betas": ["structured-outputs-2025-11-13"],
+                    },
+                },
+            ],
+        )
+
+        assert batch.id == "batch_789"
+
+        # Verify both requests have betas stripped
+        request = respx_mock.calls[0].request
+        body = json.loads(request.content.decode())
+
+        assert len(body["requests"]) == 2
+        for req in body["requests"]:
+            assert "betas" not in req["params"], "betas should be stripped from all request params"
+
+    @pytest.mark.respx
+    def test_request_without_betas_unchanged(self, respx_mock: MockRouter) -> None:
+        """Test that requests without betas field are not affected."""
+        client = Anthropic(api_key="test-key", base_url="http://127.0.0.1:4010")
+
+        respx_mock.post("/v1/messages/batches?beta=true").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "batch_abc",
+                    "type": "message_batch",
+                    "processing_status": "in_progress",
+                    "request_counts": {
+                        "processing": 1,
+                        "succeeded": 0,
+                        "errored": 0,
+                        "canceled": 0,
+                        "expired": 0,
+                    },
+                    "ended_at": None,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "expires_at": "2024-01-02T00:00:00Z",
+                    "cancel_initiated_at": None,
+                    "results_url": None,
+                },
+            )
+        )
+
+        # Create a batch without betas in request params
+        batch = client.beta.messages.batches.create(
+            betas=["structured-outputs-2025-11-13"],
+            requests=[
+                {
+                    "custom_id": "test-5",
+                    "params": {
+                        "model": "claude-sonnet-4-5",
+                        "max_tokens": 1024,
+                        "messages": [{"role": "user", "content": "No betas here"}],
+                    },
+                }
+            ],
+        )
+
+        assert batch.id == "batch_abc"
+
+        # Verify the request is processed normally
+        request = respx_mock.calls[0].request
+        body = json.loads(request.content.decode())
+
+        assert "model" in body["requests"][0]["params"]
+        assert "max_tokens" in body["requests"][0]["params"]


### PR DESCRIPTION
Fixes #1118

## Problem

When using batch processing with structured outputs, passing the `betas` parameter in `MessageCreateParamsNonStreaming` causes an "Extra inputs are not permitted" API error. According to the issue report and [structured outputs documentation](https://platform.claude.com/docs/en/build-with-claude/structured-outputs#feature-compatibility), structured outputs should work with batch processing, but the `betas` parameter must be at the batch level, not in individual request params.

## Root Cause

The `betas` field in `MessageCreateParamsBase` (line 320-321 of `message_create_params.py`) has `PropertyInfo(alias="anthropic-beta")`, which is meant for HTTP headers. However, when included in `MessageCreateParamsNonStreaming` and passed as `params` in a batch Request, it gets serialized into the request body during the transformation process, causing the API to reject it.

## Solution

Strip the `betas` field from individual request params in the `Batches.create()` method before sending to the API. The batch-level `betas` parameter is correctly handled in the header (lines 85-95 of `batches.py`) and continues to work as expected.

Changes:
- Strip `betas` from request params in both sync and async `create()` methods  
- Add comprehensive tests for betas stripping behavior
- Verify that other request fields remain unchanged

## Testing

Added test file `test_batch_betas_stripping.py` with 4 test cases:
- `test_betas_stripped_from_request_params` - Verifies betas are removed from params
- `test_async_betas_stripped_from_request_params` - Same for async client  
- `test_multiple_requests_with_betas_all_stripped` - All requests are cleaned
- `test_request_without_betas_unchanged` - Requests without betas are unaffected

## Result

Users can now safely use structured outputs with batch processing by passing `betas` at the batch level:

```python
# This now works correctly
client.beta.messages.batches.create(
    betas=["structured-outputs-2025-11-13"],  # Batch-level betas
    requests=[
        Request(
            custom_id="test-1",
            params=MessageCreateParamsNonStreaming(
                model="claude-sonnet-4-5",
                max_tokens=1024,
                messages=[...],
                output_format=BetaJSONOutputFormatParam(
                    type="json_schema",
                    schema=transform_schema(ContactInfo)
                )
            )
        )
    ]
)
```

Even if users accidentally include `betas` in the request params (e.g., for IDE type checking), it will be automatically stripped and only applied at the batch level.