### PR TITLE
Fix issue #1160: Handle None value for by_alias in model_dump

### DIFF
--- a/src/anthropic/_compat.py
+++ b/src/anthropic/_compat.py
@@ -155,7 +155,7 @@ def model_dump(
             exclude_defaults=exclude_defaults,
             # warnings are not supported in Pydantic v1
             warnings=True if PYDANTIC_V1 else warnings,
-            by_alias=by_alias,
+            by_alias=by_alias if by_alias is not None else False,
         )
     return cast(
         "dict[str, Any]",

--- a/test_pydantic_by_alias.py
+++ b/test_pydantic_by_alias.py
@@ -1,0 +1,37 @@
+"""Test for Pydantic by_alias None handling fix."""
+import pydantic
+from anthropic._compat import model_dump
+
+class SimpleModel(pydantic.BaseModel):
+    field_name: str = pydantic.Field(alias="fieldName")
+
+def test_model_dump_with_none_by_alias():
+    """Test that model_dump handles by_alias=None correctly."""
+    model = SimpleModel(fieldName="test_value")
+    
+    # Should not raise TypeError when by_alias is None
+    result = model_dump(model, by_alias=None)
+    assert isinstance(result, dict)
+    assert result["field_name"] == "test_value"
+
+def test_model_dump_with_true_by_alias():
+    """Test that model_dump respects by_alias=True."""
+    model = SimpleModel(fieldName="test_value")
+    
+    result = model_dump(model, by_alias=True)
+    assert isinstance(result, dict)
+    assert "fieldName" in result or "field_name" in result
+
+def test_model_dump_with_false_by_alias():
+    """Test that model_dump respects by_alias=False."""
+    model = SimpleModel(fieldName="test_value")
+    
+    result = model_dump(model, by_alias=False)
+    assert isinstance(result, dict)
+    assert "field_name" in result
+
+if __name__ == "__main__":
+    test_model_dump_with_none_by_alias()
+    test_model_dump_with_true_by_alias()
+    test_model_dump_with_false_by_alias()
+    print("All tests passed!")


### PR DESCRIPTION
## Summary

Fixes TypeError when by_alias=None is passed to model_dump() in Pydantic v2 context.

When the Anthropic SDK is used in a FastAPI application with Pydantic v2, the model_dump() function in _compat.py was passing by_alias=None directly to pydantic's model_dump(), which requires a boolean value. This caused a TypeError in Pydantic-Core.

## Changes

- Updated model_dump() to default by_alias to False when None is passed
- Added test cases to verify the fix works with by_alias=None, True, and False

## Related Issues

Fixes #1160