### PR TITLE
fix: correct typo 'overriden' → 'overridden' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ will result in the client terminating the connection and retrying without receiv
 
 We set a [TCP socket keep-alive](https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html) option in order
 to reduce the impact of idle connection timeouts on some networks.
-This can be [overriden](#Configuring-the-HTTP-client) by passing a `http_client` option to the client.
+This can be [overridden](#Configuring-the-HTTP-client) by passing a `http_client` option to the client.
 
 ## Default Headers
 


### PR DESCRIPTION
Small typo fix in README.md line 664.

- `overriden` → `overridden` (double 'd')