### PR TITLE
fix(vertex): raise clear error when using structured outputs on Vertex AI

### DIFF
--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -392,6 +392,12 @@ def _prepare_options(input_options: FinalRequestOptions, *, project_id: str | No
         if not is_dict(options.json_data):
             raise RuntimeError("Expected json data to be a dictionary for post /v1/messages")
 
+        if "output_config" in options.json_data:
+            raise AnthropicError(
+                "Structured outputs (output_config) is not supported in the Vertex AI client yet. "
+                "Use the standard Anthropic client instead, or parse the model's JSON response manually."
+            )
+
         model = options.json_data.pop("model")
         stream = options.json_data.get("stream", False)
         specifier = "streamRawPredict" if stream else "rawPredict"

--- a/tests/lib/test_vertex.py
+++ b/tests/lib/test_vertex.py
@@ -8,7 +8,10 @@ import httpx
 import pytest
 from respx import MockRouter
 
+from pydantic import BaseModel
+
 from anthropic import AnthropicVertex, AsyncAnthropicVertex
+from anthropic._exceptions import AnthropicError
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -144,6 +147,21 @@ class TestAnthropicVertex:
             base_url="https://test.googleapis.com/v1",
         )
         assert str(client.base_url).rstrip("/") == "https://test.googleapis.com/v1"
+
+    def test_structured_outputs_raises_error(self) -> None:
+        """Vertex AI does not support output_config, so parse() should raise a clear error."""
+
+        class ContactInfo(BaseModel):
+            name: str
+            email: str
+
+        with pytest.raises(AnthropicError, match="Structured outputs.*not supported.*Vertex"):
+            self.client.messages.parse(
+                model="claude-sonnet-4-6",
+                max_tokens=1024,
+                messages=[{"role": "user", "content": "Name: Alice, email: alice@example.com"}],
+                output_format=ContactInfo,
+            )
 
 
 class TestAsyncAnthropicVertex:


### PR DESCRIPTION
## Summary

Calling `messages.parse()` with an `AnthropicVertex` client sends `output_config` in the request body, but Vertex AI's Claude proxy doesn't support this parameter. The result is a confusing 400 error from Google:

```
BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error',
'message': 'output_config.format: Extra inputs are not permitted'}}
```

This adds a check in the Vertex client's `_prepare_options` to detect `output_config` and raise an `AnthropicError` with a clear message before the request goes out. Follows the same pattern as the existing batch API check on line 410 of the same file.

The error message suggests using the standard Anthropic client or manually parsing JSON responses as a workaround until Google adds `output_config` support to their proxy.

Added a test that verifies `parse()` raises `AnthropicError` on the Vertex client. All 19 vertex tests pass.

Fixes #1188