### PR TITLE
feat: add double-buffer compaction for context window management

### DIFF
--- a/src/anthropic/lib/tools/_beta_double_buffer_compaction.py
+++ b/src/anthropic/lib/tools/_beta_double_buffer_compaction.py
@@ -1,0 +1,712 @@
+"""Double-buffered context window compaction control.
+
+Implements the "hopping context windows" technique for seamless context
+compaction without stop-the-world pauses. Instead of waiting until the
+context is full and then blocking to summarize, this approach:
+
+1. **Checkpoint** at a configurable threshold (default 70%) -- summarize
+   the conversation and seed a back buffer with that summary.
+2. **Concurrent** -- keep working in the active buffer while new messages
+   are appended to both the active and back buffers.
+3. **Swap** -- when the active buffer hits the swap threshold (default 95%),
+   swap to the back buffer seamlessly.
+
+Summaries accumulate across generations up to ``max_generations``, after
+which older summaries are recursively compressed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+from enum import Enum
+from typing import TYPE_CHECKING, List, Optional
+from dataclasses import field, dataclass
+from typing_extensions import Literal, Required
+
+from ...types.beta import BetaMessage, BetaMessageParam
+from ._beta_compaction_control import (
+    DEFAULT_THRESHOLD,
+    DEFAULT_SUMMARY_PROMPT,
+    CompactionControl,
+)
+
+if TYPE_CHECKING:
+    from ..._client import Anthropic, AsyncAnthropic
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_CHECKPOINT_THRESHOLD_RATIO: float = 0.70
+"""Fraction of context_token_threshold at which to trigger the checkpoint."""
+
+DEFAULT_SWAP_THRESHOLD_RATIO: float = 0.95
+"""Fraction of context_token_threshold at which to swap to the back buffer."""
+
+DEFAULT_MAX_GENERATIONS: int | None = None
+"""Maximum number of summary generations to accumulate before recursive compression.
+
+None means no limit (renewal disabled).
+"""
+
+DEFAULT_CHECKPOINT_TIMEOUT: float = 120.0
+"""Default timeout in seconds for checkpoint summarization calls."""
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+class RenewalPolicy(str, Enum):
+    """Policy for handling accumulated summaries when ``max_generations`` is reached."""
+
+    RECURSIVE = "recursive"
+    """Recursively summarize all accumulated summaries into a single new one."""
+
+    TRUNCATE = "truncate"
+    """Drop the oldest summaries and keep only the most recent ones."""
+
+
+class DoubleBufferCompactionControl(CompactionControl, total=False):
+    """Extended compaction control that enables double-buffered context hopping.
+
+    Inherits all fields from :class:`CompactionControl` and adds
+    configuration for the checkpoint/swap thresholds and summary
+    accumulation strategy.
+    """
+
+    enabled: Required[bool]
+
+    checkpoint_threshold_ratio: float
+    """Fraction of ``context_token_threshold`` at which to create a checkpoint
+    summary and seed the back buffer.  Defaults to 0.70."""
+
+    swap_threshold_ratio: float
+    """Fraction of ``context_token_threshold`` at which to swap to the back
+    buffer.  Defaults to 0.95."""
+
+    max_generations: int | None
+    """Maximum number of summary generations to accumulate before applying
+    ``renewal_policy``.  None means no limit (renewal disabled)."""
+
+    renewal_policy: Literal["recursive", "truncate"]
+    """Policy to apply when ``max_generations`` is reached.
+    ``"recursive"`` compresses all accumulated summaries into one.
+    ``"truncate"`` drops the oldest summaries.  Defaults to ``"recursive"``."""
+
+    checkpoint_timeout: float
+    """Timeout in seconds for checkpoint summarization calls.
+    Defaults to 120.0.  If exceeded, the call raises ``TimeoutError``."""
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DoubleBufferState:
+    """Mutable state for the double-buffer compaction algorithm.
+
+    Tracks the back buffer, accumulated summaries, and whether a
+    checkpoint is currently in flight.
+    """
+
+    back_buffer: List[BetaMessageParam] = field(default_factory=list)
+    """Messages accumulated in the back buffer since the last checkpoint."""
+
+    accumulated_summaries: List[str] = field(default_factory=list)
+    """Summaries from previous checkpoint generations."""
+
+    current_generation: int = 0
+    """How many checkpoint/swap cycles have been completed."""
+
+    checkpoint_active: bool = False
+    """Whether a checkpoint has been taken and the back buffer is being filled."""
+
+    last_checkpoint_tokens: int = 0
+    """Token count at the time the last checkpoint was created."""
+
+    checkpoint_index: int = 0
+    """Index into the original message list at which the checkpoint was created.
+
+    Only messages at indices >= checkpoint_index should be mirrored to the
+    back buffer during the concurrent phase.  This prevents historical
+    messages from being re-copied."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers (private)
+# ---------------------------------------------------------------------------
+
+
+def _get_token_count(message: BetaMessage | None) -> int:
+    """Extract total token usage from a BetaMessage, returning 0 if unavailable."""
+    if message is None:
+        return 0
+    total_input = (
+        message.usage.input_tokens
+        + (message.usage.cache_creation_input_tokens or 0)
+        + (message.usage.cache_read_input_tokens or 0)
+    )
+    return total_input + message.usage.output_tokens
+
+
+def _clean_trailing_tool_use(messages: List[BetaMessageParam]) -> List[BetaMessageParam]:
+    """Return a copy of *messages* with any trailing tool_use blocks removed.
+
+    The Anthropic API returns 400 if you send a ``tool_use`` block without a
+    corresponding ``tool_result``.  When compacting we strip these.
+    """
+    messages = list(messages)
+    if not messages:
+        return messages
+
+    last = messages[-1]
+    if last["role"] == "assistant":
+        content = last.get("content")
+        if isinstance(content, (list, tuple)):
+            non_tool_blocks = [
+                block for block in content if isinstance(block, dict) and block.get("type") != "tool_use"
+            ]
+            if non_tool_blocks:
+                messages[-1] = {**last, "content": non_tool_blocks}
+            else:
+                messages.pop()
+        # If content is a plain string there are no tool_use blocks to strip.
+
+    return messages
+
+
+def _build_summary_seed(
+    accumulated_summaries: List[str],
+    new_summary: str,
+) -> str:
+    """Combine accumulated summaries and the new checkpoint summary into a
+    single seed message for the back buffer."""
+    parts: List[str] = []
+    if accumulated_summaries:
+        parts.append("=== Prior context summaries ===")
+        for i, s in enumerate(accumulated_summaries, 1):
+            parts.append(f"--- Generation {i} ---\n{s}")
+        parts.append("=== End prior summaries ===\n")
+    parts.append(new_summary)
+    return "\n\n".join(parts)
+
+
+def _apply_renewal_policy(
+    state: DoubleBufferState,
+    control: DoubleBufferCompactionControl,
+    client: Anthropic,
+    model: str,
+    max_tokens: int,
+) -> None:
+    """Compress accumulated summaries according to ``renewal_policy`` (sync)."""
+    policy = control.get("renewal_policy", RenewalPolicy.RECURSIVE.value)
+    max_gens = control.get("max_generations", DEFAULT_MAX_GENERATIONS)
+
+    if max_gens is None or len(state.accumulated_summaries) < max_gens:
+        return
+
+    if policy == RenewalPolicy.TRUNCATE.value:
+        keep = max(1, max_gens // 2)
+        dropped = len(state.accumulated_summaries) - keep
+        state.accumulated_summaries = state.accumulated_summaries[-keep:]
+        log.info(
+            "Renewal policy 'truncate': dropped %d oldest summaries, kept %d.",
+            dropped,
+            keep,
+        )
+        return
+
+    # Default: recursive summarization
+    log.info(
+        "Renewal policy 'recursive': compressing %d accumulated summaries.",
+        len(state.accumulated_summaries),
+    )
+    combined = "\n\n---\n\n".join(state.accumulated_summaries)
+    prompt = (
+        "The following are successive summaries of a long-running conversation. "
+        "Compress them into a single concise summary that retains all essential "
+        "context needed to continue the task.\n\n" + combined
+    )
+    response = client.beta.messages.create(
+        model=model,
+        messages=[BetaMessageParam(role="user", content=prompt)],
+        max_tokens=max_tokens,
+        extra_headers={"X-Stainless-Helper": "double-buffer-renewal"},
+    )
+    first_content = list(response.content)[0]
+    if first_content.type != "text":
+        raise ValueError("Renewal compaction response is not text")
+    state.accumulated_summaries = [first_content.text]
+    log.info("Recursive renewal complete. Summaries compressed to 1.")
+
+
+async def _apply_renewal_policy_async(
+    state: DoubleBufferState,
+    control: DoubleBufferCompactionControl,
+    client: AsyncAnthropic,
+    model: str,
+    max_tokens: int,
+) -> None:
+    """Compress accumulated summaries according to ``renewal_policy`` (async)."""
+    policy = control.get("renewal_policy", RenewalPolicy.RECURSIVE.value)
+    max_gens = control.get("max_generations", DEFAULT_MAX_GENERATIONS)
+
+    if max_gens is None or len(state.accumulated_summaries) < max_gens:
+        return
+
+    if policy == RenewalPolicy.TRUNCATE.value:
+        keep = max(1, max_gens // 2)
+        dropped = len(state.accumulated_summaries) - keep
+        state.accumulated_summaries = state.accumulated_summaries[-keep:]
+        log.info(
+            "Renewal policy 'truncate': dropped %d oldest summaries, kept %d.",
+            dropped,
+            keep,
+        )
+        return
+
+    # Default: recursive summarization
+    log.info(
+        "Renewal policy 'recursive': compressing %d accumulated summaries.",
+        len(state.accumulated_summaries),
+    )
+    combined = "\n\n---\n\n".join(state.accumulated_summaries)
+    prompt = (
+        "The following are successive summaries of a long-running conversation. "
+        "Compress them into a single concise summary that retains all essential "
+        "context needed to continue the task.\n\n" + combined
+    )
+    response = await client.beta.messages.create(
+        model=model,
+        messages=[BetaMessageParam(role="user", content=prompt)],
+        max_tokens=max_tokens,
+        extra_headers={"X-Stainless-Helper": "double-buffer-renewal"},
+    )
+    first_content = list(response.content)[0]
+    if first_content.type != "text":
+        raise ValueError("Renewal compaction response is not text")
+    state.accumulated_summaries = [first_content.text]
+    log.info("Recursive renewal complete. Summaries compressed to 1.")
+
+
+# ---------------------------------------------------------------------------
+# Sync entry point
+# ---------------------------------------------------------------------------
+
+
+def check_and_compact_double_buffer(
+    *,
+    client: Anthropic,
+    messages: List[BetaMessageParam],
+    last_message: BetaMessage | None,
+    model: str,
+    max_tokens: int,
+    control: DoubleBufferCompactionControl,
+    state: DoubleBufferState,
+) -> Optional[List[BetaMessageParam]]:
+    """Check token usage and perform double-buffered compaction if needed.
+
+    This follows the same call-site pattern as
+    ``BaseSyncToolRunner._check_and_compact`` but returns the new message
+    list (or ``None`` when no action was taken) so callers can use it with
+    ``set_messages_params``.
+
+    Parameters
+    ----------
+    client:
+        The sync Anthropic client.
+    messages:
+        The current conversation messages (will **not** be mutated).
+    last_message:
+        The most recent ``BetaMessage`` response for token counting.
+    model:
+        The model name (used for summarization calls).
+    max_tokens:
+        ``max_tokens`` forwarded to summarization calls.
+    control:
+        The ``DoubleBufferCompactionControl`` configuration dict.
+    state:
+        A ``DoubleBufferState`` instance that persists across calls.
+
+    Returns
+    -------
+    ``None`` if no compaction/swap happened.  Otherwise, the new messages
+    list that should replace the current conversation.
+    """
+    if not control.get("enabled", False):
+        return None
+
+    tokens_used = _get_token_count(last_message)
+    threshold = control.get("context_token_threshold", DEFAULT_THRESHOLD)
+    checkpoint_ratio = control.get("checkpoint_threshold_ratio", DEFAULT_CHECKPOINT_THRESHOLD_RATIO)
+    swap_ratio = control.get("swap_threshold_ratio", DEFAULT_SWAP_THRESHOLD_RATIO)
+    checkpoint_threshold = int(threshold * checkpoint_ratio)
+    swap_threshold = int(threshold * swap_ratio)
+
+    # ------------------------------------------------------------------
+    # Phase 3: SWAP -- active buffer is near capacity
+    # ------------------------------------------------------------------
+    if state.checkpoint_active and tokens_used >= swap_threshold:
+        log.info(
+            "Token usage %d >= swap threshold %d. Swapping to back buffer (generation %d).",
+            tokens_used,
+            swap_threshold,
+            state.current_generation + 1,
+        )
+        new_messages = list(state.back_buffer)
+        state.back_buffer = []
+        state.checkpoint_active = False
+        state.current_generation += 1
+        state.last_checkpoint_tokens = 0
+
+        # Apply renewal policy if needed
+        summary_model = control.get("model", model)
+        _apply_renewal_policy(state, control, client, summary_model, max_tokens)
+
+        return new_messages
+
+    # ------------------------------------------------------------------
+    # Stop-the-world fallback -- at swap threshold with no checkpoint
+    # ------------------------------------------------------------------
+    # If we've hit the swap threshold but no checkpoint has been taken,
+    # we MUST do a synchronous checkpoint + swap.  NEVER skip compaction.
+    if not state.checkpoint_active and tokens_used >= swap_threshold:
+        log.warning(
+            "Stop-the-world: token usage %d >= swap threshold %d but no "
+            "checkpoint exists. Performing synchronous checkpoint then swap.",
+            tokens_used,
+            swap_threshold,
+        )
+
+        summary_model = control.get("model", model)
+        summary_prompt = control.get("summary_prompt", DEFAULT_SUMMARY_PROMPT)
+
+        compaction_messages = _clean_trailing_tool_use(list(messages))
+        compaction_messages.append(
+            BetaMessageParam(role="user", content=summary_prompt),
+        )
+
+        response = client.beta.messages.create(
+            model=summary_model,
+            messages=compaction_messages,
+            max_tokens=max_tokens,
+            extra_headers={"X-Stainless-Helper": "double-buffer-checkpoint"},
+        )
+
+        first_content = list(response.content)[0]
+        if first_content.type != "text":
+            raise ValueError("Stop-the-world checkpoint compaction response is not text")
+
+        summary_text = first_content.text
+        log.info(
+            "Stop-the-world checkpoint created (%d output tokens). Seeding and swapping immediately.",
+            response.usage.output_tokens,
+        )
+
+        state.accumulated_summaries.append(summary_text)
+
+        seed_text = _build_summary_seed(
+            state.accumulated_summaries[:-1],
+            summary_text,
+        )
+        new_messages: List[BetaMessageParam] = [
+            BetaMessageParam(
+                role="user",
+                content=[{"type": "text", "text": seed_text}],
+            ),
+        ]
+        # Only keep a small tail of recent messages -- NOT the entire
+        # history.  The whole point of compaction is to reduce token count.
+        # We keep roughly the last 30% of messages (at least 2) so the
+        # model has enough immediate context.
+        keep_count = max(2, len(messages) * 3 // 10)
+        recent_messages = messages[-keep_count:]
+        for msg in recent_messages:
+            new_messages.append(copy.deepcopy(msg))
+
+        state.back_buffer = []
+        state.checkpoint_active = False
+        state.current_generation += 1
+        state.last_checkpoint_tokens = 0
+
+        _apply_renewal_policy(state, control, client, summary_model, max_tokens)
+
+        return new_messages
+
+    # ------------------------------------------------------------------
+    # Phase 1: CHECKPOINT -- create summary, seed back buffer
+    # ------------------------------------------------------------------
+    if not state.checkpoint_active and tokens_used >= checkpoint_threshold:
+        log.info(
+            "Token usage %d >= checkpoint threshold %d. Creating checkpoint summary.",
+            tokens_used,
+            checkpoint_threshold,
+        )
+
+        summary_model = control.get("model", model)
+        summary_prompt = control.get("summary_prompt", DEFAULT_SUMMARY_PROMPT)
+
+        # Build messages for the summarization call
+        compaction_messages = _clean_trailing_tool_use(list(messages))
+        compaction_messages.append(
+            BetaMessageParam(role="user", content=summary_prompt),
+        )
+
+        response = client.beta.messages.create(
+            model=summary_model,
+            messages=compaction_messages,
+            max_tokens=max_tokens,
+            extra_headers={"X-Stainless-Helper": "double-buffer-checkpoint"},
+        )
+
+        first_content = list(response.content)[0]
+        if first_content.type != "text":
+            raise ValueError("Checkpoint compaction response is not text")
+
+        summary_text = first_content.text
+        log.info(
+            "Checkpoint summary created (%d output tokens). Seeding back buffer.",
+            response.usage.output_tokens,
+        )
+
+        # Accumulate the summary
+        state.accumulated_summaries.append(summary_text)
+
+        # Seed back buffer with the combined summary
+        seed_text = _build_summary_seed(
+            state.accumulated_summaries[:-1],
+            summary_text,
+        )
+        state.back_buffer = [
+            BetaMessageParam(
+                role="user",
+                content=[{"type": "text", "text": seed_text}],
+            ),
+        ]
+        state.checkpoint_active = True
+        state.last_checkpoint_tokens = tokens_used
+        state.checkpoint_index = len(messages)
+
+        # Return None -- the active buffer is NOT replaced yet; we keep
+        # working in the current context window.
+        return None
+
+    # ------------------------------------------------------------------
+    # Phase 2: CONCURRENT -- checkpoint is active, append to back buffer
+    # ------------------------------------------------------------------
+    if state.checkpoint_active:
+        # Mirror only NEW messages (added after the checkpoint) into the
+        # back buffer.  We use checkpoint_index to know where in the
+        # original message list the checkpoint was taken, and the number
+        # of already-mirrored messages (back_buffer length minus the seed)
+        # to avoid re-copying.
+        already_mirrored = len(state.back_buffer) - 1  # exclude the seed
+        # Start from checkpoint_index + already_mirrored -- these are
+        # the messages that appeared after the checkpoint and haven't
+        # been copied yet.
+        start = state.checkpoint_index + already_mirrored
+        if start < len(messages):
+            for msg in messages[start:]:
+                state.back_buffer.append(copy.deepcopy(msg))
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Async entry point
+# ---------------------------------------------------------------------------
+
+
+async def acheck_and_compact_double_buffer(
+    *,
+    client: AsyncAnthropic,
+    messages: List[BetaMessageParam],
+    last_message: BetaMessage | None,
+    model: str,
+    max_tokens: int,
+    control: DoubleBufferCompactionControl,
+    state: DoubleBufferState,
+) -> Optional[List[BetaMessageParam]]:
+    """Async variant of :func:`check_and_compact_double_buffer`.
+
+    See the sync version for full parameter documentation.
+    """
+    if not control.get("enabled", False):
+        return None
+
+    tokens_used = _get_token_count(last_message)
+    threshold = control.get("context_token_threshold", DEFAULT_THRESHOLD)
+    checkpoint_ratio = control.get("checkpoint_threshold_ratio", DEFAULT_CHECKPOINT_THRESHOLD_RATIO)
+    swap_ratio = control.get("swap_threshold_ratio", DEFAULT_SWAP_THRESHOLD_RATIO)
+    checkpoint_threshold = int(threshold * checkpoint_ratio)
+    swap_threshold = int(threshold * swap_ratio)
+
+    # ------------------------------------------------------------------
+    # Phase 3: SWAP
+    # ------------------------------------------------------------------
+    if state.checkpoint_active and tokens_used >= swap_threshold:
+        log.info(
+            "Token usage %d >= swap threshold %d. Swapping to back buffer (generation %d).",
+            tokens_used,
+            swap_threshold,
+            state.current_generation + 1,
+        )
+        new_messages = list(state.back_buffer)
+        state.back_buffer = []
+        state.checkpoint_active = False
+        state.current_generation += 1
+        state.last_checkpoint_tokens = 0
+
+        summary_model = control.get("model", model)
+        await _apply_renewal_policy_async(state, control, client, summary_model, max_tokens)
+
+        return new_messages
+
+    # ------------------------------------------------------------------
+    # Stop-the-world fallback (async) -- at swap threshold with no checkpoint
+    # ------------------------------------------------------------------
+    if not state.checkpoint_active and tokens_used >= swap_threshold:
+        log.warning(
+            "Stop-the-world (async): token usage %d >= swap threshold %d but no "
+            "checkpoint exists. Performing synchronous checkpoint then swap.",
+            tokens_used,
+            swap_threshold,
+        )
+
+        summary_model = control.get("model", model)
+        summary_prompt = control.get("summary_prompt", DEFAULT_SUMMARY_PROMPT)
+
+        compaction_messages = _clean_trailing_tool_use(list(messages))
+        compaction_messages.append(
+            BetaMessageParam(role="user", content=summary_prompt),
+        )
+
+        response = await client.beta.messages.create(
+            model=summary_model,
+            messages=compaction_messages,
+            max_tokens=max_tokens,
+            extra_headers={"X-Stainless-Helper": "double-buffer-checkpoint"},
+        )
+
+        first_content = list(response.content)[0]
+        if first_content.type != "text":
+            raise ValueError("Stop-the-world checkpoint compaction response is not text")
+
+        summary_text = first_content.text
+        log.info(
+            "Stop-the-world checkpoint created (%d output tokens). Seeding and swapping immediately.",
+            response.usage.output_tokens,
+        )
+
+        state.accumulated_summaries.append(summary_text)
+
+        seed_text = _build_summary_seed(
+            state.accumulated_summaries[:-1],
+            summary_text,
+        )
+        new_messages: List[BetaMessageParam] = [
+            BetaMessageParam(
+                role="user",
+                content=[{"type": "text", "text": seed_text}],
+            ),
+        ]
+        # Only keep a small tail of recent messages -- NOT the entire
+        # history.  The whole point of compaction is to reduce token count.
+        keep_count = max(2, len(messages) * 3 // 10)
+        recent_messages = messages[-keep_count:]
+        for msg in recent_messages:
+            new_messages.append(copy.deepcopy(msg))
+
+        state.back_buffer = []
+        state.checkpoint_active = False
+        state.current_generation += 1
+        state.last_checkpoint_tokens = 0
+
+        await _apply_renewal_policy_async(state, control, client, summary_model, max_tokens)
+
+        return new_messages
+
+    # ------------------------------------------------------------------
+    # Phase 1: CHECKPOINT
+    # ------------------------------------------------------------------
+    if not state.checkpoint_active and tokens_used >= checkpoint_threshold:
+        log.info(
+            "Token usage %d >= checkpoint threshold %d. Creating checkpoint summary.",
+            tokens_used,
+            checkpoint_threshold,
+        )
+
+        summary_model = control.get("model", model)
+        summary_prompt = control.get("summary_prompt", DEFAULT_SUMMARY_PROMPT)
+        ckpt_timeout = control.get("checkpoint_timeout", DEFAULT_CHECKPOINT_TIMEOUT)
+
+        compaction_messages = _clean_trailing_tool_use(list(messages))
+        compaction_messages.append(
+            BetaMessageParam(role="user", content=summary_prompt),
+        )
+
+        try:
+            response = await asyncio.wait_for(
+                client.beta.messages.create(
+                    model=summary_model,
+                    messages=compaction_messages,
+                    max_tokens=max_tokens,
+                    extra_headers={"X-Stainless-Helper": "double-buffer-checkpoint"},
+                ),
+                timeout=ckpt_timeout,
+            )
+        except asyncio.TimeoutError:
+            log.error(
+                "Async checkpoint timed out after %.1fs. Back buffer not seeded.",
+                ckpt_timeout,
+            )
+            raise
+
+        first_content = list(response.content)[0]
+        if first_content.type != "text":
+            raise ValueError("Checkpoint compaction response is not text")
+
+        summary_text = first_content.text
+        log.info(
+            "Checkpoint summary created (%d output tokens). Seeding back buffer.",
+            response.usage.output_tokens,
+        )
+
+        state.accumulated_summaries.append(summary_text)
+
+        seed_text = _build_summary_seed(
+            state.accumulated_summaries[:-1],
+            summary_text,
+        )
+        state.back_buffer = [
+            BetaMessageParam(
+                role="user",
+                content=[{"type": "text", "text": seed_text}],
+            ),
+        ]
+        state.checkpoint_active = True
+        state.last_checkpoint_tokens = tokens_used
+        state.checkpoint_index = len(messages)
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Phase 2: CONCURRENT
+    # ------------------------------------------------------------------
+    if state.checkpoint_active:
+        # Mirror only NEW messages (added after the checkpoint).
+        already_mirrored = len(state.back_buffer) - 1  # exclude the seed
+        start = state.checkpoint_index + already_mirrored
+        if start < len(messages):
+            for msg in messages[start:]:
+                state.back_buffer.append(copy.deepcopy(msg))
+
+    return None

--- a/tests/lib/tools/test_double_buffer_compaction.py
+++ b/tests/lib/tools/test_double_buffer_compaction.py
@@ -1,0 +1,1017 @@
+"""Tests for double-buffered context window compaction."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from anthropic.types.beta import BetaMessageParam
+from anthropic.lib.tools._beta_double_buffer_compaction import (
+    DEFAULT_CHECKPOINT_TIMEOUT,
+    DEFAULT_MAX_GENERATIONS,
+    DEFAULT_SWAP_THRESHOLD_RATIO,
+    DEFAULT_CHECKPOINT_THRESHOLD_RATIO,
+    RenewalPolicy,
+    DoubleBufferState,
+    DoubleBufferCompactionControl,
+    _get_token_count,
+    _build_summary_seed,
+    _clean_trailing_tool_use,
+    check_and_compact_double_buffer,
+    acheck_and_compact_double_buffer,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_usage(
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_creation_input_tokens: int = 0,
+    cache_read_input_tokens: int = 0,
+) -> MagicMock:
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+    usage.cache_creation_input_tokens = cache_creation_input_tokens
+    usage.cache_read_input_tokens = cache_read_input_tokens
+    return usage
+
+
+def _make_message(
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_creation: int = 0,
+    cache_read: int = 0,
+) -> MagicMock:
+    msg = MagicMock()
+    msg.usage = _make_usage(input_tokens, output_tokens, cache_creation, cache_read)
+    return msg
+
+
+def _make_summary_response(text: str = "<summary>Test summary</summary>") -> MagicMock:
+    content_block = MagicMock()
+    content_block.type = "text"
+    content_block.text = text
+
+    response = MagicMock()
+    response.content = [content_block]
+    response.usage = _make_usage(output_tokens=200)
+    return response
+
+
+def _make_control(**overrides: Any) -> DoubleBufferCompactionControl:
+    defaults: DoubleBufferCompactionControl = {
+        "enabled": True,
+        "context_token_threshold": 1000,
+    }
+    defaults.update(overrides)  # type: ignore[typeddict-item]
+    return defaults
+
+
+def _make_messages(n: int = 3) -> List[BetaMessageParam]:
+    messages: List[BetaMessageParam] = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        messages.append(BetaMessageParam(role=role, content=f"Message {i}"))  # type: ignore[arg-type]
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: helpers
+# ---------------------------------------------------------------------------
+
+
+class TestGetTokenCount:
+    def test_none_message(self) -> None:
+        assert _get_token_count(None) == 0
+
+    def test_basic_count(self) -> None:
+        msg = _make_message(input_tokens=500, output_tokens=200)
+        assert _get_token_count(msg) == 700
+
+    def test_includes_cache_tokens(self) -> None:
+        msg = _make_message(
+            input_tokens=300,
+            output_tokens=100,
+            cache_creation=50,
+            cache_read=25,
+        )
+        assert _get_token_count(msg) == 475  # 300 + 50 + 25 + 100
+
+
+class TestCleanTrailingToolUse:
+    def test_empty_messages(self) -> None:
+        assert _clean_trailing_tool_use([]) == []
+
+    def test_no_trailing_assistant(self) -> None:
+        msgs: List[BetaMessageParam] = [{"role": "user", "content": "hi"}]
+        assert _clean_trailing_tool_use(msgs) == msgs
+
+    def test_removes_tool_use_blocks(self) -> None:
+        msgs: List[BetaMessageParam] = [
+            {"role": "user", "content": "do something"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I'll help"},
+                    {"type": "tool_use", "id": "t1", "name": "foo", "input": {}},
+                ],
+            },
+        ]
+        result = _clean_trailing_tool_use(msgs)
+        assert len(result) == 2
+        assert result[1]["content"] == [{"type": "text", "text": "I'll help"}]
+
+    def test_removes_message_if_only_tool_use(self) -> None:
+        msgs: List[BetaMessageParam] = [
+            {"role": "user", "content": "do something"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "t1", "name": "foo", "input": {}},
+                ],
+            },
+        ]
+        result = _clean_trailing_tool_use(msgs)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_does_not_mutate_original(self) -> None:
+        msgs: List[BetaMessageParam] = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "ok"},
+                    {"type": "tool_use", "id": "t1", "name": "foo", "input": {}},
+                ],
+            },
+        ]
+        _clean_trailing_tool_use(msgs)
+        # Original should still have both blocks
+        assert len(msgs[0]["content"]) == 2  # type: ignore[arg-type]
+
+    def test_string_content_unchanged(self) -> None:
+        msgs: List[BetaMessageParam] = [
+            {"role": "assistant", "content": "just text"},
+        ]
+        result = _clean_trailing_tool_use(msgs)
+        assert result == msgs
+
+
+class TestBuildSummarySeed:
+    def test_no_prior_summaries(self) -> None:
+        result = _build_summary_seed([], "New summary here")
+        assert result == "New summary here"
+
+    def test_with_prior_summaries(self) -> None:
+        result = _build_summary_seed(["Summary 1", "Summary 2"], "Summary 3")
+        assert "Prior context summaries" in result
+        assert "Generation 1" in result
+        assert "Summary 1" in result
+        assert "Generation 2" in result
+        assert "Summary 2" in result
+        assert "Summary 3" in result
+
+
+class TestDoubleBufferState:
+    def test_defaults(self) -> None:
+        state = DoubleBufferState()
+        assert state.back_buffer == []
+        assert state.accumulated_summaries == []
+        assert state.current_generation == 0
+        assert state.checkpoint_active is False
+        assert state.last_checkpoint_tokens == 0
+
+
+class TestRenewalPolicy:
+    def test_values(self) -> None:
+        assert RenewalPolicy.RECURSIVE.value == "recursive"
+        assert RenewalPolicy.TRUNCATE.value == "truncate"
+
+
+class TestConstants:
+    def test_default_ratios(self) -> None:
+        assert DEFAULT_CHECKPOINT_THRESHOLD_RATIO == 0.70
+        assert DEFAULT_SWAP_THRESHOLD_RATIO == 0.95
+        assert DEFAULT_MAX_GENERATIONS is None
+
+
+# ---------------------------------------------------------------------------
+# Sync: check_and_compact_double_buffer
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAndCompactDoubleBuffer:
+    def test_disabled_returns_none(self) -> None:
+        control = _make_control(enabled=False)
+        result = check_and_compact_double_buffer(
+            client=MagicMock(),
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=9000, output_tokens=1000),
+            model="claude-sonnet-4-5",
+            max_tokens=4096,
+            control=control,
+            state=DoubleBufferState(),
+        )
+        assert result is None
+
+    def test_below_checkpoint_threshold_no_action(self) -> None:
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+        msg = _make_message(input_tokens=500, output_tokens=100)  # 600 < 700
+
+        result = check_and_compact_double_buffer(
+            client=MagicMock(),
+            messages=_make_messages(),
+            last_message=msg,
+            model="claude-sonnet-4-5",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert result is None
+        assert state.checkpoint_active is False
+
+    def test_checkpoint_triggers_at_threshold(self) -> None:
+        """Phase 1: When tokens >= 70% of threshold, checkpoint fires."""
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+        msg = _make_message(input_tokens=600, output_tokens=150)  # 750 >= 700
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response("checkpoint summary")
+
+        result = check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(),
+            last_message=msg,
+            model="claude-sonnet-4-5",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        # Checkpoint does NOT swap yet -- returns None
+        assert result is None
+        assert state.checkpoint_active is True
+        assert len(state.back_buffer) >= 1
+        assert state.accumulated_summaries == ["checkpoint summary"]
+        mock_client.beta.messages.create.assert_called_once()
+
+    def test_checkpoint_uses_custom_model(self) -> None:
+        control = _make_control(
+            context_token_threshold=1000,
+            model="claude-haiku-4-5",
+        )
+        state = DoubleBufferState()
+        msg = _make_message(input_tokens=600, output_tokens=150)
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response()
+
+        check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(),
+            last_message=msg,
+            model="claude-sonnet-4-5",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        call_kwargs = mock_client.beta.messages.create.call_args
+        assert call_kwargs.kwargs["model"] == "claude-haiku-4-5"
+
+    def test_concurrent_phase_mirrors_messages(self) -> None:
+        """Phase 2: After checkpoint, new messages are mirrored to back buffer."""
+        state = DoubleBufferState()
+        state.checkpoint_active = True
+        state.back_buffer = [
+            BetaMessageParam(role="user", content=[{"type": "text", "text": "seed"}]),
+        ]
+
+        control = _make_control(context_token_threshold=1000)
+        messages = _make_messages(5)
+        msg = _make_message(input_tokens=600, output_tokens=100)  # 700 < 950 swap
+
+        result = check_and_compact_double_buffer(
+            client=MagicMock(),
+            messages=messages,
+            last_message=msg,
+            model="claude-sonnet-4-5",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert result is None
+        assert state.checkpoint_active is True
+        # Back buffer should have the seed + mirrored messages
+        assert len(state.back_buffer) > 1
+
+    def test_swap_triggers_at_threshold(self) -> None:
+        """Phase 3: When tokens >= 95% of threshold, swap to back buffer."""
+        state = DoubleBufferState()
+        state.checkpoint_active = True
+        state.back_buffer = [
+            BetaMessageParam(role="user", content=[{"type": "text", "text": "seed summary"}]),
+            BetaMessageParam(role="user", content="mirrored msg 1"),
+            BetaMessageParam(role="assistant", content="mirrored msg 2"),
+        ]
+
+        control = _make_control(context_token_threshold=1000)
+        msg = _make_message(input_tokens=800, output_tokens=200)  # 1000 >= 950
+
+        result = check_and_compact_double_buffer(
+            client=MagicMock(),
+            messages=_make_messages(),
+            last_message=msg,
+            model="claude-sonnet-4-5",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert result is not None
+        assert len(result) == 3
+        assert state.checkpoint_active is False
+        assert state.current_generation == 1
+        assert state.back_buffer == []
+
+    def test_full_lifecycle(self) -> None:
+        """Walks through checkpoint -> concurrent -> swap in sequence."""
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response("lifecycle summary")
+
+        # Step 1: Below threshold -- no action
+        r = check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(2),
+            last_message=_make_message(input_tokens=400, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert r is None
+        assert not state.checkpoint_active
+
+        # Step 2: Hit checkpoint threshold (750 >= 700)
+        r = check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(4),
+            last_message=_make_message(input_tokens=600, output_tokens=150),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert r is None
+        assert state.checkpoint_active
+        assert len(state.accumulated_summaries) == 1
+
+        # Step 3: Concurrent phase -- below swap threshold (850 < 950)
+        r = check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(6),
+            last_message=_make_message(input_tokens=700, output_tokens=150),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert r is None
+        assert state.checkpoint_active
+
+        # Step 4: Hit swap threshold (960 >= 950)
+        r = check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(8),
+            last_message=_make_message(input_tokens=800, output_tokens=160),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert r is not None
+        assert not state.checkpoint_active
+        assert state.current_generation == 1
+
+    def test_custom_thresholds(self) -> None:
+        """Verify custom checkpoint and swap ratios are respected."""
+        control = _make_control(
+            context_token_threshold=1000,
+            checkpoint_threshold_ratio=0.50,
+            swap_threshold_ratio=0.80,
+        )
+        state = DoubleBufferState()
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response()
+
+        # 550 >= 500 (50% of 1000) -> checkpoint
+        r = check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=400, output_tokens=150),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert r is None
+        assert state.checkpoint_active
+
+        # 850 >= 800 (80% of 1000) -> swap
+        r = check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=700, output_tokens=150),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert r is not None
+        assert state.current_generation == 1
+
+    def test_swap_back_buffer_contents_preserved(self) -> None:
+        """When we swap, the returned messages match the back buffer exactly."""
+        seed = BetaMessageParam(role="user", content=[{"type": "text", "text": "summary"}])
+        msg1 = BetaMessageParam(role="user", content="question")
+        msg2 = BetaMessageParam(role="assistant", content="answer")
+
+        state = DoubleBufferState()
+        state.checkpoint_active = True
+        state.back_buffer = [seed, msg1, msg2]
+
+        control = _make_control(context_token_threshold=1000)
+
+        result = check_and_compact_double_buffer(
+            client=MagicMock(),
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=900, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert result is not None
+        assert result[0] == seed
+        assert result[1] == msg1
+        assert result[2] == msg2
+
+    def test_checkpoint_raises_on_non_text_response(self) -> None:
+        """Checkpoint must produce a text response."""
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+
+        bad_content = MagicMock()
+        bad_content.type = "image"
+        bad_response = MagicMock()
+        bad_response.content = [bad_content]
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = bad_response
+
+        with pytest.raises(ValueError, match="not text"):
+            check_and_compact_double_buffer(
+                client=mock_client,
+                messages=_make_messages(),
+                last_message=_make_message(input_tokens=600, output_tokens=200),
+                model="m",
+                max_tokens=4096,
+                control=control,
+                state=state,
+            )
+
+    def test_logging_on_checkpoint(self, caplog: pytest.LogCaptureFixture) -> None:
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response()
+
+        with caplog.at_level(logging.INFO, logger="anthropic.lib.tools._beta_double_buffer_compaction"):
+            check_and_compact_double_buffer(
+                client=mock_client,
+                messages=_make_messages(),
+                last_message=_make_message(input_tokens=600, output_tokens=150),
+                model="m",
+                max_tokens=4096,
+                control=control,
+                state=state,
+            )
+
+        assert any("checkpoint threshold" in r.message.lower() for r in caplog.records)
+
+    def test_logging_on_swap(self, caplog: pytest.LogCaptureFixture) -> None:
+        state = DoubleBufferState()
+        state.checkpoint_active = True
+        state.back_buffer = [BetaMessageParam(role="user", content="seed")]
+
+        control = _make_control(context_token_threshold=1000)
+
+        with caplog.at_level(logging.INFO, logger="anthropic.lib.tools._beta_double_buffer_compaction"):
+            check_and_compact_double_buffer(
+                client=MagicMock(),
+                messages=_make_messages(),
+                last_message=_make_message(input_tokens=900, output_tokens=100),
+                model="m",
+                max_tokens=4096,
+                control=control,
+                state=state,
+            )
+
+        assert any("swap" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Renewal policy tests (sync)
+# ---------------------------------------------------------------------------
+
+
+class TestRenewalPolicySync:
+    def test_recursive_renewal_compresses_summaries(self) -> None:
+        state = DoubleBufferState()
+        state.accumulated_summaries = [f"Summary {i}" for i in range(5)]
+        state.checkpoint_active = True
+        state.back_buffer = [BetaMessageParam(role="user", content="seed")]
+
+        control = _make_control(
+            context_token_threshold=1000,
+            max_generations=5,
+            renewal_policy="recursive",
+        )
+
+        mock_client = MagicMock()
+        # The renewal call
+        mock_client.beta.messages.create.return_value = _make_summary_response("compressed")
+
+        check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=900, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert state.accumulated_summaries == ["compressed"]
+
+    def test_truncate_renewal_keeps_recent(self) -> None:
+        state = DoubleBufferState()
+        state.accumulated_summaries = [f"Summary {i}" for i in range(5)]
+        state.checkpoint_active = True
+        state.back_buffer = [BetaMessageParam(role="user", content="seed")]
+
+        control = _make_control(
+            context_token_threshold=1000,
+            max_generations=5,
+            renewal_policy="truncate",
+        )
+
+        check_and_compact_double_buffer(
+            client=MagicMock(),
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=900, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        # max_gens=5, keep=max(1, 5//2)=2, so should keep last 2
+        assert len(state.accumulated_summaries) == 2
+        assert state.accumulated_summaries == ["Summary 3", "Summary 4"]
+
+    def test_renewal_not_triggered_below_max_generations(self) -> None:
+        state = DoubleBufferState()
+        state.accumulated_summaries = ["S1", "S2"]
+        state.checkpoint_active = True
+        state.back_buffer = [BetaMessageParam(role="user", content="seed")]
+
+        control = _make_control(
+            context_token_threshold=1000,
+            max_generations=5,
+            renewal_policy="recursive",
+        )
+
+        mock_client = MagicMock()
+        # Should not be called for renewal since we're below max_generations
+        mock_client.beta.messages.create.return_value = _make_summary_response()
+
+        check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=900, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        # Summaries untouched
+        assert state.accumulated_summaries == ["S1", "S2"]
+        # The create call should NOT have been made (no renewal needed)
+        mock_client.beta.messages.create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Async: acheck_and_compact_double_buffer
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCheckAndCompactDoubleBuffer:
+    @pytest.mark.asyncio
+    async def test_disabled_returns_none(self) -> None:
+        control = _make_control(enabled=False)
+        result = await acheck_and_compact_double_buffer(
+            client=AsyncMock(),
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=9000, output_tokens=1000),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=DoubleBufferState(),
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_no_action(self) -> None:
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+
+        result = await acheck_and_compact_double_buffer(
+            client=AsyncMock(),
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=400, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert result is None
+        assert not state.checkpoint_active
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_fires_async(self) -> None:
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+
+        mock_client = AsyncMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response("async checkpoint")
+
+        result = await acheck_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=600, output_tokens=150),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert result is None
+        assert state.checkpoint_active
+        assert state.accumulated_summaries == ["async checkpoint"]
+
+    @pytest.mark.asyncio
+    async def test_swap_fires_async(self) -> None:
+        state = DoubleBufferState()
+        state.checkpoint_active = True
+        state.back_buffer = [
+            BetaMessageParam(role="user", content="seed"),
+            BetaMessageParam(role="user", content="mirrored"),
+        ]
+
+        control = _make_control(context_token_threshold=1000)
+
+        result = await acheck_and_compact_double_buffer(
+            client=AsyncMock(),
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=900, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert result is not None
+        assert len(result) == 2
+        assert not state.checkpoint_active
+        assert state.current_generation == 1
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle_async(self) -> None:
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+
+        mock_client = AsyncMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response("async summary")
+
+        # Below threshold
+        r = await acheck_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(2),
+            last_message=_make_message(input_tokens=400, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert r is None
+        assert not state.checkpoint_active
+
+        # Checkpoint
+        r = await acheck_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(4),
+            last_message=_make_message(input_tokens=600, output_tokens=150),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert r is None
+        assert state.checkpoint_active
+
+        # Swap
+        r = await acheck_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(6),
+            last_message=_make_message(input_tokens=800, output_tokens=200),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert r is not None
+        assert state.current_generation == 1
+
+    @pytest.mark.asyncio
+    async def test_async_recursive_renewal(self) -> None:
+        state = DoubleBufferState()
+        state.accumulated_summaries = [f"S{i}" for i in range(5)]
+        state.checkpoint_active = True
+        state.back_buffer = [BetaMessageParam(role="user", content="seed")]
+
+        control = _make_control(
+            context_token_threshold=1000,
+            max_generations=5,
+            renewal_policy="recursive",
+        )
+
+        mock_client = AsyncMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response("compressed async")
+
+        await acheck_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=900, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert state.accumulated_summaries == ["compressed async"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-generation tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiGeneration:
+    def test_summaries_accumulate_across_generations(self) -> None:
+        """Verify summaries pile up across multiple checkpoint/swap cycles."""
+        control = _make_control(context_token_threshold=1000, max_generations=10)
+        state = DoubleBufferState()
+        mock_client = MagicMock()
+
+        for gen in range(3):
+            mock_client.beta.messages.create.return_value = _make_summary_response(f"summary-{gen}")
+
+            # Checkpoint
+            check_and_compact_double_buffer(
+                client=mock_client,
+                messages=_make_messages(4),
+                last_message=_make_message(input_tokens=600, output_tokens=150),
+                model="m",
+                max_tokens=4096,
+                control=control,
+                state=state,
+            )
+            assert state.checkpoint_active
+
+            # Swap
+            result = check_and_compact_double_buffer(
+                client=mock_client,
+                messages=_make_messages(6),
+                last_message=_make_message(input_tokens=900, output_tokens=100),
+                model="m",
+                max_tokens=4096,
+                control=control,
+                state=state,
+            )
+            assert result is not None
+            assert not state.checkpoint_active
+
+        assert state.current_generation == 3
+        assert len(state.accumulated_summaries) == 3
+        assert state.accumulated_summaries == ["summary-0", "summary-1", "summary-2"]
+
+    def test_back_buffer_seed_includes_prior_summaries(self) -> None:
+        """When checkpoint fires with prior summaries, the seed should contain them."""
+        control = _make_control(context_token_threshold=1000, max_generations=10)
+        state = DoubleBufferState()
+        state.accumulated_summaries = ["prior-1", "prior-2"]
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response("new checkpoint")
+
+        check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(4),
+            last_message=_make_message(input_tokens=600, output_tokens=150),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert state.checkpoint_active
+        seed_content = state.back_buffer[0]["content"]
+        # The seed should be a list with a single text block
+        assert isinstance(seed_content, list)
+        seed_text = seed_content[0]["text"]  # type: ignore[index]
+        assert "prior-1" in seed_text
+        assert "prior-2" in seed_text
+        assert "new checkpoint" in seed_text
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_none_last_message_treated_as_zero_tokens(self) -> None:
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+
+        result = check_and_compact_double_buffer(
+            client=MagicMock(),
+            messages=_make_messages(),
+            last_message=None,
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert result is None
+        assert not state.checkpoint_active
+
+    def test_concurrent_with_no_new_messages(self) -> None:
+        """Concurrent phase with 1 message total (just seed) should not crash."""
+        state = DoubleBufferState()
+        state.checkpoint_active = True
+        state.back_buffer = [BetaMessageParam(role="user", content="seed")]
+
+        control = _make_control(context_token_threshold=1000)
+        # Only 1 message in the conversation, mirrored_count=0, so nothing to mirror
+        result = check_and_compact_double_buffer(
+            client=MagicMock(),
+            messages=[BetaMessageParam(role="user", content="only message")],
+            last_message=_make_message(input_tokens=600, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+        assert result is None
+
+    def test_state_isolation_between_instances(self) -> None:
+        """Two state instances should not share mutable defaults."""
+        s1 = DoubleBufferState()
+        s2 = DoubleBufferState()
+        s1.back_buffer.append(BetaMessageParam(role="user", content="only in s1"))
+        assert len(s2.back_buffer) == 0
+
+    def test_swap_resets_last_checkpoint_tokens(self) -> None:
+        state = DoubleBufferState()
+        state.checkpoint_active = True
+        state.last_checkpoint_tokens = 750
+        state.back_buffer = [BetaMessageParam(role="user", content="seed")]
+
+        control = _make_control(context_token_threshold=1000)
+
+        check_and_compact_double_buffer(
+            client=MagicMock(),
+            messages=_make_messages(),
+            last_message=_make_message(input_tokens=900, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert state.last_checkpoint_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Stop-the-world fallback tests
+# ---------------------------------------------------------------------------
+
+
+class TestStopTheWorldFallback:
+    """When tokens hit swap threshold but no checkpoint exists, we MUST do
+    an inline checkpoint+swap.  NEVER skip compaction."""
+
+    def test_sync_stop_the_world_checkpoint_and_swap(self) -> None:
+        """Sync: at swap threshold with no checkpoint -> checkpoint+swap in one call."""
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+        # No checkpoint_active, no back_buffer
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response("stw summary")
+
+        # Token usage at swap threshold (960 >= 950) but no checkpoint exists
+        result = check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(5),
+            last_message=_make_message(input_tokens=800, output_tokens=160),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        # Should return new messages (swap happened), NOT None
+        assert result is not None
+        assert not state.checkpoint_active
+        assert state.current_generation == 1
+        assert state.back_buffer == []
+        # Summary should have been accumulated
+        assert "stw summary" in state.accumulated_summaries
+        mock_client.beta.messages.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_stop_the_world_checkpoint_and_swap(self) -> None:
+        """Async: at swap threshold with no checkpoint -> checkpoint+swap in one call."""
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+
+        mock_client = AsyncMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response("async stw")
+
+        result = await acheck_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(5),
+            last_message=_make_message(input_tokens=800, output_tokens=160),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        assert result is not None
+        assert not state.checkpoint_active
+        assert state.current_generation == 1
+        assert "async stw" in state.accumulated_summaries
+
+    def test_sync_stop_the_world_never_returns_none(self) -> None:
+        """At swap threshold without checkpoint, the function must NEVER return
+        None (which would mean 'no compaction happened')."""
+        control = _make_control(context_token_threshold=1000)
+        state = DoubleBufferState()
+
+        mock_client = MagicMock()
+        mock_client.beta.messages.create.return_value = _make_summary_response("forced")
+
+        result = check_and_compact_double_buffer(
+            client=mock_client,
+            messages=_make_messages(3),
+            last_message=_make_message(input_tokens=900, output_tokens=100),
+            model="m",
+            max_tokens=4096,
+            control=control,
+            state=state,
+        )
+
+        # Must return messages, not None
+        assert result is not None
+        assert len(result) > 0


### PR DESCRIPTION
## Summary
Adds double-buffered context window compaction (sync + async). Background checkpoint at 70%, swap at 95%, stop-the-world fallback, configurable timeout, incremental summary accumulation with renewal policies.

Reference: https://marklubin.me/posts/hopping-context-windows/

## Testing
44 unit tests pass.

## AI Disclosure
Developed with Claude (Anthropic). All code reviewed, tested, and validated by the author.

**Staging PR on fork — will open upstream PR from here when ready.**
