### PR TITLE
fix: handle tuples in `deepcopy_minimal` to prevent mutation of user data

### DIFF
--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -181,6 +181,7 @@ def deepcopy_minimal(item: _T) -> _T:
 
     - mappings, e.g. `dict`
     - list
+    - tuple
 
     This is done for performance reasons.
     """
@@ -188,6 +189,8 @@ def deepcopy_minimal(item: _T) -> _T:
         return cast(_T, {k: deepcopy_minimal(v) for k, v in item.items()})
     if is_list(item):
         return cast(_T, [deepcopy_minimal(entry) for entry in item])
+    if is_tuple(item):
+        return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
     return item
 
 

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -52,7 +52,44 @@ def test_ignores_other_types() -> None:
     assert_different_identities(obj1, obj2)
     assert obj1["foo"] is my_obj
 
-    # tuples
-    obj3 = ("a", "b")
-    obj4 = deepcopy_minimal(obj3)
-    assert obj3 is obj4
+
+def test_simple_tuple() -> None:
+    obj1 = ("a", "b")
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+
+
+def test_tuple_with_mutable_contents() -> None:
+    """Tuples containing mutable objects (like FileTypes headers) must be deep copied."""
+    headers = {"X-Custom": "value"}
+    obj1 = ("test.txt", b"hello", "text/plain", headers)
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+    assert_different_identities(obj1[3], obj2[3])
+    # Mutating the copy must not affect the original
+    obj2[3]["X-Injected"] = "surprise"
+    assert "X-Injected" not in headers
+
+
+def test_dict_containing_tuple() -> None:
+    """Simulates the files.beta.upload body: deepcopy_minimal({'file': file_tuple})."""
+    headers = {"Authorization": "Bearer xyz"}
+    file_tuple = ("doc.pdf", b"data", "application/pdf", headers)
+    body = {"file": file_tuple}
+    body_copy = deepcopy_minimal(body)
+    assert_different_identities(body, body_copy)
+    assert_different_identities(body["file"], body_copy["file"])
+    assert_different_identities(body["file"][3], body_copy["file"][3])
+    # Mutating the copy's headers must not affect the original
+    body_copy["file"][3]["X-Mutated"] = "yes"
+    assert "X-Mutated" not in headers
+
+
+def test_list_of_tuples() -> None:
+    """Simulates the skills/versions.py body: deepcopy_minimal({'files': [file_tuple, ...]})."""
+    headers = {"X-H": "v"}
+    files = [("a.txt", b"data", "text/plain", headers)]
+    body = {"files": files}
+    body_copy = deepcopy_minimal(body)
+    assert_different_identities(body_copy["files"][0], body["files"][0])
+    assert_different_identities(body_copy["files"][0][3], body["files"][0][3])


### PR DESCRIPTION
## Summary

`deepcopy_minimal` copies `dict` and `list` but intentionally skips `tuple` (returning it as-is). When `files.beta.upload()` is called with a 4-element `FileTypes` tuple containing a headers dict, the tuple passes through uncopied. httpx then mutates the user's original headers dict by injecting `Content-Type` during multipart encoding.

```python
headers = {'X-Custom': 'value'}
file = ('test.txt', b'data', 'text/plain', headers)
client.files.beta.upload(file=file)
print(headers)  # {'X-Custom': 'value', 'Content-Type': 'text/plain'} — mutated by httpx
```

Users who reuse file tuples across multiple uploads see their headers silently contaminated.

## Changes

- **`src/anthropic/_utils/_utils.py`** — Add tuple handling to `deepcopy_minimal`, matching the existing pattern for dicts and lists. Tuples are recursively copied so mutable elements (like headers dicts) get independent copies.
- **`tests/test_deepcopy.py`** — Replace the old assertion that tuples pass through uncopied (`assert obj3 is obj4`) with 4 new tests covering: simple tuples, tuples with mutable contents (the bug scenario), dicts containing tuples (`files.beta.upload` pattern), and lists of tuples (`skills/versions` pattern).

**Note on behavioral change:** The previous test explicitly asserted tuples are NOT copied. This was a deliberate scope limitation of `deepcopy_minimal` that did not anticipate the httpx mutation path. This PR intentionally reverses that — tuples are now recursively copied like dicts and lists.

**Note on Stainless:** `_utils/_utils.py` has no codegen header, consistent with hand-maintained utility code. If this change should be applied to the generation template instead, happy to redirect.

## Testing

- 550 existing tests pass, 0 regressions
- 4 new tests verify tuple copying and mutation isolation

Fixes #1202