### PR TITLE
fix: use filtered messages in async _check_and_compact()

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -469,7 +469,7 @@ class BaseAsyncToolRunner(
                 messages.pop()
 
         messages = [
-            *self._params["messages"],
+            *messages,
             BetaMessageParam(
                 role="user",
                 content=self._compaction_control.get("summary_prompt", DEFAULT_SUMMARY_PROMPT),


### PR DESCRIPTION
## Summary

Fixes #1205

The async `_check_and_compact()` method was using `self._params['messages']` instead of the filtered local `messages` variable when building the summarization request. This caused `tool_use` blocks to be sent to the API without corresponding `tool_result` blocks, resulting in `BadRequestError`.

## Root Cause

In `src/anthropic/lib/tools/_beta_runner.py`, line 478:

```python
# Before (BUGGY)
messages = [
    *self._params["messages"],  # <-- Uses unfiltered messages
    BetaMessageParam(...)
]
```

The sync version of this method (line 218) correctly uses `*messages` (the filtered variable), but the async version was using the unfiltered `self._params["messages"]`.

## Fix

Changed line 478 to use the filtered `messages` variable:

```python
# After (FIXED)
messages = [
    *messages,  # <-- Uses filtered messages (tool_use blocks removed)
    BetaMessageParam(...)
]
```

## Testing

- The fix aligns the async implementation with the sync implementation
- The filtering logic (lines 459-476) now has its effect preserved when building the summarization request