### PR TITLE
fix: prevent dict mutation in deepcopy_minimal

### DIFF
--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -181,6 +181,7 @@ def deepcopy_minimal(item: _T) -> _T:
 
     - mappings, e.g. `dict`
     - list
+    - tuple
 
     This is done for performance reasons.
     """
@@ -188,6 +189,8 @@ def deepcopy_minimal(item: _T) -> _T:
         return cast(_T, {k: deepcopy_minimal(v) for k, v in item.items()})
     if is_list(item):
         return cast(_T, [deepcopy_minimal(entry) for entry in item])
+    if is_tuple(item):
+        return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
     return item
 
 

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -41,6 +41,37 @@ def test_nested_list() -> None:
     assert_different_identities(obj1[1], obj2[1])
 
 
+def test_simple_tuple() -> None:
+    obj1 = ("a", "b", "c")
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+
+
+def test_tuple_with_nested_dict() -> None:
+    """Tuples containing dicts should have those dicts deep-copied.
+
+    This is the core fix for issue #1202: FileTypes tuples like
+    (filename, content, content_type, headers_dict) must not share
+    the headers dict reference with the original.
+    """
+    headers = {"X-Custom": "value"}
+    obj1 = ("file.txt", b"content", "text/plain", headers)
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+    # The nested dict inside the tuple must be a separate copy
+    assert_different_identities(obj1[3], obj2[3])
+
+
+def test_dict_with_tuple_value() -> None:
+    """Dicts containing tuples with nested dicts should be fully deep-copied."""
+    inner_dict = {"key": "value"}
+    obj1 = {"file": ("name", b"data", "type", inner_dict)}
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+    assert_different_identities(obj1["file"], obj2["file"])
+    assert_different_identities(obj1["file"][3], obj2["file"][3])
+
+
 class MyObject: ...
 
 
@@ -51,8 +82,3 @@ def test_ignores_other_types() -> None:
     obj2 = deepcopy_minimal(obj1)
     assert_different_identities(obj1, obj2)
     assert obj1["foo"] is my_obj
-
-    # tuples
-    obj3 = ("a", "b")
-    obj4 = deepcopy_minimal(obj3)
-    assert obj3 is obj4


### PR DESCRIPTION
## Summary
Fix `deepcopy_minimal` mutating user-provided dictionaries in place when used in `files.beta.upload`.

The function previously only deep-copied `dict` and `list` types, but ignored `tuple`. Since `FileTypes` values are commonly tuples like `(filename, content, content_type, headers_dict)`, any nested dicts inside these tuples (such as the headers mapping) were shared by reference between the original and the "copy". When `extract_files` subsequently mutated the body dict, it could inadvertently modify the user's original data structures.

This fix adds tuple support to `deepcopy_minimal` so that all nested structures within tuples are properly deep-copied.

Fixes #1202

## Changes
- Add tuple copying support to `deepcopy_minimal` in `src/anthropic/_utils/_utils.py`
- Add tests for tuple deep-copying in `tests/test_deepcopy.py`
- Remove outdated test that asserted tuples should NOT be copied

## Test plan
- [x] New test `test_simple_tuple` verifies tuples are copied
- [x] New test `test_tuple_with_nested_dict` verifies dicts inside tuples get their own identity
- [x] New test `test_dict_with_tuple_value` verifies the full scenario (dict -> tuple -> dict)
- [x] All existing deepcopy tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)