### PR TITLE
feat(lib): add files_from_zip helper for skill uploads

### DIFF
--- a/examples/skills_from_zip.py
+++ b/examples/skills_from_zip.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S uv run python
+"""Example: Creating a skill using files_from_zip and files_from_dir helpers.
+
+Demonstrates three ways to pass files to `client.beta.skills.create()`:
+
+1. `files_from_dir` — load all files from a local directory
+2. `files_from_zip` — load all files from a zip archive
+3. Manual file tuples — MIME type is optional (2-tuple and 3-tuple can be mixed)
+"""
+
+import anthropic
+from anthropic.lib import files_from_dir, files_from_zip
+
+client = anthropic.Anthropic()
+
+# ── Option 1: Load files from a directory ────────────────────────────────────
+skill = client.beta.skills.create(
+    display_title="Financial Analysis",
+    files=files_from_dir("/path/to/financial_analysis_skill"),
+    betas=["skills-2025-10-02"],
+)
+print(f"Created skill from directory: {skill.id}")
+
+# ── Option 2: Load files from a zip archive ─────────────────────────────────
+skill = client.beta.skills.create(
+    display_title="Financial Analysis",
+    files=files_from_zip("financial_analysis_skill.zip"),
+    betas=["skills-2025-10-02"],
+)
+print(f"Created skill from zip: {skill.id}")
+
+# ── Option 3: Manual file tuples (MIME type is optional) ────────────────────
+#
+# You can freely mix 2-tuples (filename, content) and 3-tuples
+# (filename, content, mime_type). The SDK handles both formats.
+skill = client.beta.skills.create(
+    display_title="Financial Analysis",
+    files=[
+        (
+            "financial_skill/SKILL.md",
+            open("financial_skill/SKILL.md", "rb"),
+            "text/markdown",  # Optional MIME type
+        ),
+        (
+            "financial_skill/analyze.py",
+            open("financial_skill/analyze.py", "rb"),
+            # No MIME type — this is perfectly fine
+        ),
+    ],
+    betas=["skills-2025-10-02"],
+)
+print(f"Created skill from tuples: {skill.id}")

--- a/src/anthropic/lib/__init__.py
+++ b/src/anthropic/lib/__init__.py
@@ -1,1 +1,2 @@
 from ._files import files_from_dir as files_from_dir, async_files_from_dir as async_files_from_dir
+from ._files import files_from_zip as files_from_zip, async_files_from_zip as async_files_from_zip

--- a/src/anthropic/lib/_files.py
+++ b/src/anthropic/lib/_files.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import io
 import os
+import zipfile
 from pathlib import Path
 
 import anyio
@@ -40,3 +42,34 @@ async def _async_collect_files(directory: anyio.Path, relative_to: anyio.Path, f
             continue
 
         files.append((path.relative_to(relative_to).as_posix(), await path.read_bytes()))
+
+
+def files_from_zip(zip_path: str | os.PathLike[str]) -> list[FileTypes]:
+    """Read all files from a zip archive and return them as a list of file tuples.
+
+    Each entry is returned as a ``(filename, content)`` tuple compatible with
+    the ``files`` parameter accepted by :meth:`Skills.create` and similar APIs.
+
+    Directories and macOS resource fork entries (``__MACOSX/``) are
+    automatically skipped.
+    """
+    path = Path(zip_path)
+    return _read_zip(path.read_bytes())
+
+
+async def async_files_from_zip(zip_path: str | os.PathLike[str]) -> list[FileTypes]:
+    """Async variant of :func:`files_from_zip`."""
+    path = anyio.Path(zip_path)
+    return _read_zip(await path.read_bytes())
+
+
+def _read_zip(data: bytes) -> list[FileTypes]:
+    files: list[FileTypes] = []
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        for entry in zf.infolist():
+            if entry.is_dir():
+                continue
+            if entry.filename.startswith("__MACOSX/"):
+                continue
+            files.append((entry.filename, zf.read(entry)))
+    return files

--- a/tests/lib/test_files.py
+++ b/tests/lib/test_files.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from anthropic.lib import files_from_zip, async_files_from_zip
+
+
+def _make_zip(tmp_path: Path, entries: dict[str, bytes]) -> Path:
+    """Helper to create a zip file with the given entries."""
+    zip_path = tmp_path / "test.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+    return zip_path
+
+
+class TestFilesFromZip:
+    def test_basic(self, tmp_path: Path) -> None:
+        zip_path = _make_zip(
+            tmp_path,
+            {
+                "my_skill/SKILL.md": b"# My Skill",
+                "my_skill/analyze.py": b"print('hello')",
+            },
+        )
+        files = files_from_zip(zip_path)
+        names = {f[0] for f in files}
+        assert names == {"my_skill/SKILL.md", "my_skill/analyze.py"}
+
+        contents = {f[0]: f[1] for f in files}
+        assert contents["my_skill/SKILL.md"] == b"# My Skill"
+        assert contents["my_skill/analyze.py"] == b"print('hello')"
+
+    def test_skips_directories(self, tmp_path: Path) -> None:
+        zip_path = _make_zip(
+            tmp_path,
+            {
+                "my_skill/SKILL.md": b"# Skill",
+            },
+        )
+        # Manually add a directory entry
+        with zipfile.ZipFile(zip_path, "a") as zf:
+            zf.mkdir("my_skill/subdir")
+
+        files = files_from_zip(zip_path)
+        assert len(files) == 1
+        assert files[0][0] == "my_skill/SKILL.md"
+
+    def test_skips_macosx_metadata(self, tmp_path: Path) -> None:
+        zip_path = _make_zip(
+            tmp_path,
+            {
+                "my_skill/SKILL.md": b"# Skill",
+                "__MACOSX/my_skill/._SKILL.md": b"macos metadata",
+                "__MACOSX/._my_skill": b"more metadata",
+            },
+        )
+        files = files_from_zip(zip_path)
+        assert len(files) == 1
+        assert files[0][0] == "my_skill/SKILL.md"
+
+    def test_nested_directories(self, tmp_path: Path) -> None:
+        zip_path = _make_zip(
+            tmp_path,
+            {
+                "skill/SKILL.md": b"# Root",
+                "skill/lib/helpers.py": b"def helper(): ...",
+                "skill/lib/utils/common.py": b"CONST = 1",
+            },
+        )
+        files = files_from_zip(zip_path)
+        names = sorted(f[0] for f in files)
+        assert names == [
+            "skill/SKILL.md",
+            "skill/lib/helpers.py",
+            "skill/lib/utils/common.py",
+        ]
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        zip_path = _make_zip(tmp_path, {"SKILL.md": b"content"})
+        files = files_from_zip(str(zip_path))
+        assert len(files) == 1
+
+    def test_nonexistent_file(self) -> None:
+        with pytest.raises((FileNotFoundError, OSError)):
+            files_from_zip("/nonexistent/path.zip")
+
+    def test_invalid_zip(self, tmp_path: Path) -> None:
+        bad_file = tmp_path / "bad.zip"
+        bad_file.write_bytes(b"not a zip file")
+        with pytest.raises(zipfile.BadZipFile):
+            files_from_zip(bad_file)
+
+
+class TestAsyncFilesFromZip:
+    @pytest.mark.anyio
+    async def test_basic(self, tmp_path: Path) -> None:
+        zip_path = _make_zip(
+            tmp_path,
+            {
+                "my_skill/SKILL.md": b"# Skill",
+                "my_skill/code.py": b"x = 1",
+            },
+        )
+        files = await async_files_from_zip(zip_path)
+        names = {f[0] for f in files}
+        assert names == {"my_skill/SKILL.md", "my_skill/code.py"}
+
+    @pytest.mark.anyio
+    async def test_skips_macosx(self, tmp_path: Path) -> None:
+        zip_path = _make_zip(
+            tmp_path,
+            {
+                "SKILL.md": b"content",
+                "__MACOSX/._SKILL.md": b"meta",
+            },
+        )
+        files = await async_files_from_zip(zip_path)
+        assert len(files) == 1
+        assert files[0][0] == "SKILL.md"
+
+
+class TestMixedTupleFormats:
+    """Verify that the SDK's file processing pipeline handles both
+    2-tuple (no MIME type) and 3-tuple (with MIME type) entries,
+    confirming that MIME type is truly optional."""
+
+    def test_mixed_tuples_are_valid_file_types(self) -> None:
+        """Both 2-tuple and 3-tuple entries should be accepted as FileTypes."""
+        from anthropic._files import _transform_file
+
+        # 2-tuple: (filename, content) — no MIME type
+        result_2 = _transform_file(("analyze.py", b"print('hi')"))
+        assert result_2[0] == "analyze.py"
+        assert result_2[1] == b"print('hi')"
+
+        # 3-tuple: (filename, content, mime_type)
+        result_3 = _transform_file(("SKILL.md", b"# Skill", "text/markdown"))
+        assert result_3[0] == "SKILL.md"
+        assert result_3[1] == b"# Skill"
+        assert result_3[2] == "text/markdown"
+
+    def test_mixed_list_through_to_httpx_files(self) -> None:
+        """A list mixing 2-tuple and 3-tuple entries should pass through
+        to_httpx_files without error."""
+        from anthropic._files import to_httpx_files
+
+        mixed_files = [
+            ("files[]", ("SKILL.md", b"# Skill", "text/markdown")),
+            ("files[]", ("code.py", b"x = 1")),
+        ]
+        result = to_httpx_files(mixed_files)
+        assert len(result) == 2


### PR DESCRIPTION
## Summary

Adds `files_from_zip()` and `async_files_from_zip()` helper functions to `anthropic.lib`, complementing the existing `files_from_dir()` helper.

## Motivation

Currently, uploading a skill from a zip archive requires manually constructing file tuples:

```python
skill = client.beta.skills.create(
    files=[("skill.zip", open("skill.zip", "rb"))],
    ...
)
```

With this change, users can use a dedicated helper that extracts individual files from the zip:

```python
from anthropic.lib import files_from_zip

skill = client.beta.skills.create(
    files=files_from_zip("financial_analysis_skill.zip"),
    ...
)
```

## Changes

- **`src/anthropic/lib/_files.py`** — Added `files_from_zip()`, `async_files_from_zip()`, and internal `_read_zip()` helper
  - Returns `list[FileTypes]` (2-tuples) consistent with `files_from_dir()`
  - Automatically skips directory entries and `__MACOSX/` metadata
- **`src/anthropic/lib/__init__.py`** — Exported the new functions
- **`tests/lib/test_files.py`** — 11 tests covering sync/async, edge cases, and mixed tuple format validation
- **`examples/skills_from_zip.py`** — Usage example showing all three file upload patterns, including that the MIME type is optional in file tuples

All changes are in `lib/`, `tests/`, and `examples/` — directories not affected by the code generator.
