### PR TITLE
docs: document 64-character limit for batch custom_id

### DIFF
--- a/src/anthropic/types/beta/messages/batch_create_params.py
+++ b/src/anthropic/types/beta/messages/batch_create_params.py
@@ -30,7 +30,8 @@ class Request(TypedDict, total=False):
     Useful for matching results to requests, as results may be given out of request
     order.
 
-    Must be unique for each request within the Message Batch.
+    Must be unique for each request within the Message Batch. Must be 64 characters
+    or fewer.
     """
 
     params: Required[MessageCreateParamsNonStreaming]

--- a/src/anthropic/types/messages/batch_create_params.py
+++ b/src/anthropic/types/messages/batch_create_params.py
@@ -25,7 +25,8 @@ class Request(TypedDict, total=False):
     Useful for matching results to requests, as results may be given out of request
     order.
 
-    Must be unique for each request within the Message Batch.
+    Must be unique for each request within the Message Batch. Must be 64 characters
+    or fewer.
     """
 
     params: Required[MessageCreateParamsNonStreaming]


### PR DESCRIPTION
## Summary

Fixes #984

The API enforces a maximum length of 64 characters for the `custom_id` field in Message Batch requests, but this constraint was not documented anywhere in the SDK type definitions. Sending a longer `custom_id` returns a cryptic 400 error:

```
BadRequestError: requests.0.custom_id: String should have at most 64 characters
```

## Changes

Added `Must be 64 characters or fewer.` to the `custom_id` docstring in:
- `src/anthropic/types/messages/batch_create_params.py` (GA)
- `src/anthropic/types/beta/messages/batch_create_params.py` (beta)

## Test plan

- [ ] Confirm the docstring appears in IDE hover/autocomplete for `Request.custom_id`