### PR TITLE
fix: handle tuples in deepcopy_minimal to prevent dict mutation

### DIFF
--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -181,6 +181,7 @@ def deepcopy_minimal(item: _T) -> _T:
 
     - mappings, e.g. `dict`
     - list
+    - tuple
 
     This is done for performance reasons.
     """
@@ -188,6 +189,8 @@ def deepcopy_minimal(item: _T) -> _T:
         return cast(_T, {k: deepcopy_minimal(v) for k, v in item.items()})
     if is_list(item):
         return cast(_T, [deepcopy_minimal(entry) for entry in item])
+    if isinstance(item, tuple):
+        return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
     return item
 
 

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -52,7 +52,22 @@ def test_ignores_other_types() -> None:
     assert_different_identities(obj1, obj2)
     assert obj1["foo"] is my_obj
 
-    # tuples
-    obj3 = ("a", "b")
-    obj4 = deepcopy_minimal(obj3)
-    assert obj3 is obj4
+
+def test_simple_tuple() -> None:
+    obj1 = ("a", "b")
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+
+
+def test_tuple_with_nested_dict() -> None:
+    """Regression test for #1202: deepcopy_minimal should recurse into tuples
+    so that dicts nested inside tuples (e.g. FileTypes headers) are copied,
+    not shared with the caller."""
+    headers = {"content-type": "application/pdf"}
+    obj1 = ("file.pdf", b"content", "application/pdf", headers)
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+    assert_different_identities(obj1[3], obj2[3])
+    # mutating the copy must not affect the original
+    obj2[3]["x-custom"] = "injected"
+    assert "x-custom" not in headers


### PR DESCRIPTION
## Summary

Fixes #1202 — `deepcopy_minimal` does not recurse into tuples, causing `files.beta.upload` to mutate the caller's headers dict in-place.

## Root Cause

`deepcopy_minimal` only handles `dict` and `list`, returning everything else as-is. When a `FileTypes` tuple like `(name, content, mime, headers_dict)` is passed, the tuple is shared by reference, so any downstream mutation of the headers dict (element [3]) leaks back to the caller.

## Fix

Add tuple handling to `deepcopy_minimal`:

```python
if isinstance(item, tuple):
    return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
```

This ensures dicts (and lists) nested inside tuples are recursively copied.

## Tests

- Updated existing tuple test (was asserting `obj3 is obj4` identity, now checks proper copy)
- Added `test_tuple_with_nested_dict` — verifies the exact `FileTypes` scenario from #1202: mutating the copy's headers dict does not affect the original
- All 8 tests pass
