### PR TITLE
fix: handle tuples in `deepcopy_minimal` to prevent in-place mutation

### DIFF
--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -181,6 +181,7 @@ def deepcopy_minimal(item: _T) -> _T:
 
     - mappings, e.g. `dict`
     - list
+    - tuple
 
     This is done for performance reasons.
     """
@@ -188,6 +189,8 @@ def deepcopy_minimal(item: _T) -> _T:
         return cast(_T, {k: deepcopy_minimal(v) for k, v in item.items()})
     if is_list(item):
         return cast(_T, [deepcopy_minimal(entry) for entry in item])
+    if is_tuple(item):
+        return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
     return item
 
 

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -52,7 +52,50 @@ def test_ignores_other_types() -> None:
     assert_different_identities(obj1, obj2)
     assert obj1["foo"] is my_obj
 
-    # tuples
+    # tuples (immutable contents only — still creates new tuple object)
     obj3 = ("a", "b")
     obj4 = deepcopy_minimal(obj3)
-    assert obj3 is obj4
+    assert obj3 is not obj4
+    assert obj3 == obj4
+
+
+def test_tuple_with_mutable_contents() -> None:
+    """Tuples containing mutable objects (like dicts) should have their contents copied.
+
+    This prevents in-place mutation of the original data when the copy is modified.
+    See: https://github.com/anthropics/anthropic-sdk-python/issues/1202
+    """
+    inner_dict = {"content-type": "application/json"}
+    obj1 = ("filename.txt", b"content", "application/json", inner_dict)
+    obj2 = deepcopy_minimal(obj1)
+    assert obj1 == obj2
+    # The tuple itself should be a new object
+    assert obj1 is not obj2
+    # The inner dict should be a different object (deep copied)
+    assert obj1[3] is not obj2[3]
+    assert obj1[3] == obj2[3]
+    # Mutating the copy should not affect the original
+    obj2[3]["x-custom"] = "value"
+    assert "x-custom" not in obj1[3]
+
+
+def test_nested_tuple_in_dict() -> None:
+    """Tuples nested inside dicts should also have their mutable contents copied."""
+    inner_dict = {"key": "value"}
+    obj1 = {"file": ("name.txt", b"data", "text/plain", inner_dict)}
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+    # The tuple should be a new object
+    assert obj1["file"] is not obj2["file"]
+    # The inner dict should be a new object
+    assert obj1["file"][3] is not obj2["file"][3]
+
+
+def test_tuple_in_list() -> None:
+    """Tuples inside lists should also be deep copied."""
+    inner_dict = {"header": "value"}
+    obj1 = [("file.txt", b"content", "text/plain", inner_dict)]
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+    assert obj1[0] is not obj2[0]
+    assert obj1[0][3] is not obj2[0][3]


### PR DESCRIPTION
## Summary

Fixes #1202.

`deepcopy_minimal` only recurses into `dict` and `list`, returning all other types (including `tuple`) as-is. This causes mutable objects nested inside tuples to be shared by reference between the original and the "copy", leading to unexpected in-place mutation of the caller's data.

The most common case is `FileTypes` values of the form `(filename, content, content_type, headers_dict)` passed to `files.beta.upload()`. The headers dict (4th tuple element) is not copied, so the SDK's internal processing mutates the caller's original dict.

## Changes

- **`src/anthropic/_utils/_utils.py`**: Add `tuple` handling to `deepcopy_minimal` using the existing `is_tuple()` helper, so mutable contents within tuples are properly deep-copied.
- **`tests/test_deepcopy.py`**: Add three test cases covering:
  - Tuples with mutable dict contents (the reported bug scenario)
  - Tuples nested inside dicts
  - Tuples nested inside lists

## Before / After

```python
inner_dict = {"content-type": "application/json"}
file_tuple = ("file.txt", b"content", "application/json", inner_dict)
copied = deepcopy_minimal(file_tuple)

# BEFORE: inner_dict is shared — mutation leaks back
copied[3]["x-new"] = "value"
assert "x-new" in inner_dict  # True — bug!

# AFTER: inner_dict is properly copied — no mutation leak
copied[3]["x-new"] = "value"
assert "x-new" not in inner_dict  # True — fixed!
```

---

> **Transparency note:** This PR was authored by an AI (Claude Opus 4.6) as part of an effort to demonstrate value through open-source contributions. The fix and tests were written after careful analysis of the issue report and source code.