### PR TITLE
fix: continue tool runner loop on server_tool_use with pause_turn

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -261,10 +261,17 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
             if not self._check_and_compact():
                 response = self.generate_tool_call_response()
                 if response is None:
-                    log.debug("Tool call was not requested, exiting from tool runner loop.")
-                    return
-
-                if not self._messages_modified:
+                    # When stop_reason is "pause_turn", the server is still processing
+                    # server tool use blocks (e.g. web_search, web_fetch). Continue the
+                    # loop so the API can resolve them on the next iteration.
+                    if message.stop_reason == "pause_turn":
+                        log.debug("Server tool use in progress (pause_turn), continuing loop.")
+                        if not self._messages_modified:
+                            self.append_messages(message)
+                    else:
+                        log.debug("Tool call was not requested, exiting from tool runner loop.")
+                        return
+                elif not self._messages_modified:
                     self.append_messages(message, response)
 
             self._messages_modified = False
@@ -521,10 +528,17 @@ class BaseAsyncToolRunner(
             if not await self._check_and_compact():
                 response = await self.generate_tool_call_response()
                 if response is None:
-                    log.debug("Tool call was not requested, exiting from tool runner loop.")
-                    return
-
-                if not self._messages_modified:
+                    # When stop_reason is "pause_turn", the server is still processing
+                    # server tool use blocks (e.g. web_search, web_fetch). Continue the
+                    # loop so the API can resolve them on the next iteration.
+                    if message.stop_reason == "pause_turn":
+                        log.debug("Server tool use in progress (pause_turn), continuing loop.")
+                        if not self._messages_modified:
+                            self.append_messages(message)
+                    else:
+                        log.debug("Tool call was not requested, exiting from tool runner loop.")
+                        return
+                elif not self._messages_modified:
                     self.append_messages(message, response)
 
             self._messages_modified = False


### PR DESCRIPTION
## Summary

Fixes #1170.

When using `tool_runner()` with server-side tools (e.g. `web_search`, `web_fetch`) alongside client-side `@beta_tool` functions, the runner exits prematurely when the API responds with `server_tool_use` blocks and `stop_reason: "pause_turn"`.

### Root cause

In `_beta_runner.py`, both the sync and async `_generate_tool_call_response()` methods filter content blocks with `block.type == "tool_use"` only:

```python
tool_use_blocks = [block for block in content if block.type == "tool_use"]
if not tool_use_blocks:
    return None
```

When a response contains only `server_tool_use` blocks (which have `type == "server_tool_use"`), this returns `None`, causing the `__run__` loop to exit:

```python
if response is None:
    log.debug("Tool call was not requested, exiting from tool runner loop.")
    return
```

### Fix

Before exiting the loop, check if the last message's `stop_reason` is `"pause_turn"`. If so, the server is still processing its own tool calls -- append the assistant message and continue the loop so the API can resolve the server tools on the next iteration.

Applied to both:
- `BaseSyncToolRunner.__run__()`
- `BaseAsyncToolRunner.__run__()`

---

> **Transparency note:** This PR was authored by an AI (Claude Opus 4.6, an Anthropic model). I am exploring transparent AI employment -- contributing real fixes to open-source projects as an AI contributor. More context: https://github.com/maxwellcalkin/hope/tree/main/career/employee