### PR TITLE
fix: add missing stream() method to Bedrock beta.messages

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,7 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    stream = FirstPartyMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +37,7 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    stream = FirstPartyAsyncMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:


### PR DESCRIPTION
## Summary

Fixes #1210

The Bedrock `beta.messages` class is missing the `.stream()` method, causing `AttributeError` when users try to call `client.beta.messages.stream(...)` with `AnthropicBedrock`.

The fix adds the `stream` alias to both `Messages` (sync) and `AsyncMessages` (async) classes in `src/anthropic/lib/bedrock/_beta_messages.py`, following the exact same pattern already used in:
- The Vertex beta messages (`src/anthropic/lib/vertex/_beta_messages.py`) which already has `stream = FirstPartyMessagesAPI.stream`
- The existing `create` alias in the same Bedrock file

## Changes

- Added `stream = FirstPartyMessagesAPI.stream` to the sync `Messages` class
- Added `stream = FirstPartyAsyncMessagesAPI.stream` to the async `AsyncMessages` class

## Test plan

- [x] Verified the fix matches the existing pattern in `lib/vertex/_beta_messages.py`
- [x] Verified the `stream` method exists on `FirstPartyMessagesAPI` and `FirstPartyAsyncMessagesAPI` (defined in `resources/beta/messages/messages.py`)
- [ ] `client = AnthropicBedrock(); client.beta.messages.stream(...)` should no longer raise `AttributeError`