### PR TITLE
fix: use async_maybe_transform in AsyncMessages.stream() to avoid blocking event loop

### DIFF
--- a/src/anthropic/resources/beta/messages/messages.py
+++ b/src/anthropic/resources/beta/messages/messages.py
@@ -3035,7 +3035,7 @@ class AsyncMessages(AsyncAPIResource):
 
         return await self._post(
             "/v1/messages?beta=true",
-            body=maybe_transform(
+            body=await async_maybe_transform(
                 {
                     "max_tokens": max_tokens,
                     "messages": messages,
@@ -3387,44 +3387,46 @@ class AsyncMessages(AsyncAPIResource):
 
         merged_output_config = _merge_output_configs(output_config, transformed_output_format)
 
-        request = self._post(
-            "/v1/messages?beta=true",
-            body=maybe_transform(
-                {
-                    "max_tokens": max_tokens,
-                    "messages": messages,
-                    "model": model,
-                    "cache_control": cache_control,
-                    "metadata": metadata,
-                    "output_config": merged_output_config,
-                    "output_format": omit,
-                    "container": container,
-                    "context_management": context_management,
-                    "inference_geo": inference_geo,
-                    "mcp_servers": mcp_servers,
-                    "service_tier": service_tier,
-                    "speed": speed,
-                    "stop_sequences": stop_sequences,
-                    "system": system,
-                    "temperature": temperature,
-                    "thinking": thinking,
-                    "top_k": top_k,
-                    "top_p": top_p,
-                    "tools": tools,
-                    "tool_choice": tool_choice,
-                    "stream": True,
-                },
-                message_create_params.MessageCreateParams,
-            ),
-            options=make_request_options(
-                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
-            ),
-            cast_to=BetaMessage,
-            stream=True,
-            stream_cls=AsyncStream[BetaRawMessageStreamEvent],
-        )
+        async def make_request() -> AsyncStream[BetaRawMessageStreamEvent]:
+            return await self._post(
+                "/v1/messages?beta=true",
+                body=await async_maybe_transform(
+                    {
+                        "max_tokens": max_tokens,
+                        "messages": messages,
+                        "model": model,
+                        "cache_control": cache_control,
+                        "metadata": metadata,
+                        "output_config": merged_output_config,
+                        "output_format": omit,
+                        "container": container,
+                        "context_management": context_management,
+                        "inference_geo": inference_geo,
+                        "mcp_servers": mcp_servers,
+                        "service_tier": service_tier,
+                        "speed": speed,
+                        "stop_sequences": stop_sequences,
+                        "system": system,
+                        "temperature": temperature,
+                        "thinking": thinking,
+                        "top_k": top_k,
+                        "top_p": top_p,
+                        "tools": tools,
+                        "tool_choice": tool_choice,
+                        "stream": True,
+                    },
+                    message_create_params.MessageCreateParams,
+                ),
+                options=make_request_options(
+                    extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                ),
+                cast_to=BetaMessage,
+                stream=True,
+                stream_cls=AsyncStream[BetaRawMessageStreamEvent],
+            )
+
         return BetaAsyncMessageStreamManager(
-            request,
+            make_request(),
             output_format=NOT_GIVEN if is_dict(output_format) else cast(ResponseFormatT, output_format),
         )
 

--- a/src/anthropic/resources/messages/messages.py
+++ b/src/anthropic/resources/messages/messages.py
@@ -2552,40 +2552,42 @@ class AsyncMessages(AsyncAPIResource):
         elif is_given(output_config):
             merged_output_config = output_config
 
-        request = self._post(
-            "/v1/messages",
-            body=maybe_transform(
-                {
-                    "max_tokens": max_tokens,
-                    "messages": messages,
-                    "model": model,
-                    "cache_control": cache_control,
-                    "inference_geo": inference_geo,
-                    "metadata": metadata,
-                    "output_config": merged_output_config,
-                    "container": container,
-                    "service_tier": service_tier,
-                    "stop_sequences": stop_sequences,
-                    "system": system,
-                    "temperature": temperature,
-                    "top_k": top_k,
-                    "top_p": top_p,
-                    "tools": tools,
-                    "thinking": thinking,
-                    "tool_choice": tool_choice,
-                    "stream": True,
-                },
-                message_create_params.MessageCreateParams,
-            ),
-            options=make_request_options(
-                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
-            ),
-            cast_to=Message,
-            stream=True,
-            stream_cls=AsyncStream[RawMessageStreamEvent],
-        )
+        async def make_request() -> AsyncStream[RawMessageStreamEvent]:
+            return await self._post(
+                "/v1/messages",
+                body=await async_maybe_transform(
+                    {
+                        "max_tokens": max_tokens,
+                        "messages": messages,
+                        "model": model,
+                        "cache_control": cache_control,
+                        "inference_geo": inference_geo,
+                        "metadata": metadata,
+                        "output_config": merged_output_config,
+                        "container": container,
+                        "service_tier": service_tier,
+                        "stop_sequences": stop_sequences,
+                        "system": system,
+                        "temperature": temperature,
+                        "top_k": top_k,
+                        "top_p": top_p,
+                        "tools": tools,
+                        "thinking": thinking,
+                        "tool_choice": tool_choice,
+                        "stream": True,
+                    },
+                    message_create_params.MessageCreateParams,
+                ),
+                options=make_request_options(
+                    extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+                ),
+                cast_to=Message,
+                stream=True,
+                stream_cls=AsyncStream[RawMessageStreamEvent],
+            )
+
         return AsyncMessageStreamManager(
-            request,
+            make_request(),
             output_format=NOT_GIVEN if is_dict(output_format) else cast(ResponseFormatT, output_format),
         )
 


### PR DESCRIPTION
## Summary

Fixes #1195

`AsyncMessages.stream()` calls the synchronous `maybe_transform()` instead of `async_maybe_transform()`, causing `_transform_recursive` to block the event loop. This is especially impactful for large message payloads in async contexts (e.g., FastAPI gateways), where profiling shows ~5-8% CPU time spent in the blocking recursive walk.

### Changes

- **`src/anthropic/resources/messages/messages.py`** — `AsyncMessages.stream()`: Wrapped the `_post` call in an inner `async def make_request()` coroutine that uses `await async_maybe_transform()`. The coroutine object is passed to `AsyncMessageStreamManager` (which accepts any `Awaitable`), so the public API is unchanged — callers still use `async with client.messages.stream(...) as stream:` without needing `await`.

- **`src/anthropic/resources/beta/messages/messages.py`** — Same fix for `AsyncMessages.stream()`, plus a fix for `AsyncMessages.parse()` which had the same sync `maybe_transform` issue.

### Why the inner coroutine approach?

The `stream()` method is intentionally a non-async `def` that returns an `AsyncMessageStreamManager`. Making it `async def` would break the public API (users would need `async with await client.messages.stream(...)` instead of `async with client.messages.stream(...)`). By wrapping the transform + post in an inner `async def make_request()`, we defer both the transform and the HTTP call to the `__aenter__` phase of the context manager, keeping the API unchanged while ensuring the transform runs asynchronously.

### Note for maintainers

This is Stainless-generated code. The fix should be ported to the codegen template so it persists across regenerations. Specifically, the stream helper template for async classes should use `async_maybe_transform` instead of `maybe_transform`.

## Test plan

- [ ] Verify `async with client.messages.stream(...)` still works without `await`
- [ ] Verify the transform runs on the event loop (not blocking) by profiling with large payloads
- [ ] Run existing test suite to confirm no regressions