### PR TITLE
fix: raise ValueError when model is None in Bedrock client

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -51,6 +51,8 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
             raise RuntimeError("Expected dictionary json_data for post /completions endpoint")
 
         model = options.json_data.pop("model", None)
+        if model is None:
+            raise ValueError("model is required for Bedrock API calls")
         model = urllib.parse.quote(str(model), safe=":")
         stream = options.json_data.pop("stream", False)
         if stream:


### PR DESCRIPTION
## Summary

When using the Bedrock client, if `model` is not provided in the request body, `options.json_data.pop("model", None)` returns `None`. This `None` is then passed to `str()`, producing the literal string `"None"`, which gets URL-encoded and used in the Bedrock API URL (e.g., `/model/None/invoke`). This causes a confusing error from the Bedrock API rather than a clear client-side error.

**Before this fix:**
```
# model not provided → silent conversion to string "None"
# API call to /model/None/invoke → confusing Bedrock error
```

**After this fix:**
```
# model not provided → immediate ValueError: "model is required for Bedrock API calls"
```

## Changes

- Added an explicit `None` check after popping the model from `json_data` in `_prepare_options()` in `src/anthropic/lib/bedrock/_client.py`
- Raises `ValueError` with a clear message when model is missing

## Context

The Vertex client (`src/anthropic/lib/vertex/_client.py`) already handles this correctly by using `.pop("model")` without a default value, which raises a `KeyError` if model is missing. This fix brings the Bedrock client in line with that behavior by providing a clear, descriptive error.

## Test plan

- [x] Verified the fix raises `ValueError` when `model` is `None`
- [x] Verified normal operation is unaffected when `model` is provided
- [x] Confirmed the Vertex client already handles this case (no default value on `.pop()`)