### PR TITLE
fix: add missing count_tokens to Bedrock beta.messages

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,7 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    count_tokens = FirstPartyMessagesAPI.count_tokens
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +37,7 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    count_tokens = FirstPartyAsyncMessagesAPI.count_tokens
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:

--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -61,7 +61,7 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     if options.url.startswith("/v1/messages/batches"):
         raise AnthropicError("The Batch API is not supported in Bedrock yet")
 
-    if options.url == "/v1/messages/count_tokens":
+    if options.url in {"/v1/messages/count_tokens", "/v1/messages/count_tokens?beta=true"}:
         raise AnthropicError("Token counting is not supported in Bedrock yet")
 
     return options


### PR DESCRIPTION
## Summary

Calling `client.beta.messages.count_tokens()` on an `AnthropicBedrock` client raises `AttributeError` because the `count_tokens` method alias is missing from the Bedrock beta `Messages` / `AsyncMessages` classes.

This PR:

1. **Adds `count_tokens` aliases** to the Bedrock beta `Messages` and `AsyncMessages` classes in `_beta_messages.py`, matching the pattern already used in the [Vertex beta.messages](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/vertex/_beta_messages.py#L17).

2. **Fixes the `_prepare_options` guard** in `_client.py` to also catch the beta count_tokens URL (`/v1/messages/count_tokens?beta=true`). Previously, only the non-beta URL (`/v1/messages/count_tokens`) was blocked, so a beta `count_tokens` call would bypass the guard and send an unsupported request to the Bedrock API.

After this fix, `client.beta.messages.count_tokens()` raises the existing clear error message — `AnthropicError("Token counting is not supported in Bedrock yet")` — instead of an `AttributeError`.

### Before

```python
client = AnthropicBedrock(...)
client.beta.messages.count_tokens(model="...", messages=[...])
# => AttributeError: 'Messages' object has no attribute 'count_tokens'
```

### After

```python
client = AnthropicBedrock(...)
client.beta.messages.count_tokens(model="...", messages=[...])
# => anthropic.AnthropicError: Token counting is not supported in Bedrock yet
```

## Related

- Fixes #1103

## Files changed

- `src/anthropic/lib/bedrock/_beta_messages.py` — added `count_tokens` aliases
- `src/anthropic/lib/bedrock/_client.py` — extended URL guard to cover beta variant