### PR TITLE
Fix async compaction using unfiltered messages instead of local copy

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -469,7 +469,7 @@ class BaseAsyncToolRunner(
                 messages.pop()
 
         messages = [
-            *self._params["messages"],
+            *messages,
             BetaMessageParam(
                 role="user",
                 content=self._compaction_control.get("summary_prompt", DEFAULT_SUMMARY_PROMPT),


### PR DESCRIPTION
## Summary

- **Bug**: `BaseAsyncToolRunner._check_and_compact()` uses `*self._params["messages"]` instead of the locally-filtered `*messages` when constructing the messages list for the compaction API call
- **Impact**: The async compaction path sends unfiltered messages to the API, potentially including orphaned `tool_use` blocks without corresponding `tool_result` blocks, which causes a 400 error from the API
- **Fix**: Replace `*self._params["messages"]` with `*messages` on line 472, aligning the async version with the sync version which already correctly uses `*messages`

## Details

In `_check_and_compact()`, lines 455-469 copy `self._params["messages"]` to a local `messages` list and filter out `tool_use` blocks from the last assistant message (or remove the entire message if all blocks are `tool_use`). This filtering is necessary because `tool_use` blocks require corresponding `tool_result` blocks, and sending them without results causes a 400 API error.

However, line 472 in the async version (`BaseAsyncToolRunner`) incorrectly discards this filtered copy by spreading from the original `self._params["messages"]` instead of the local `messages`.

The sync version (`BaseSyncToolRunner._check_and_compact()`, line 211) correctly uses `*messages`.

## Test plan

- [ ] Verify that async tool runner compaction works correctly when the last message contains `tool_use` blocks
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)).