### PR TITLE
fix(tools): continue tool_runner loop on pause_turn with server_tool_use blocks

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -259,13 +259,21 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
 
             # If the compaction was performed, skip tool call generation this iteration
             if not self._check_and_compact():
-                response = self.generate_tool_call_response()
-                if response is None:
-                    log.debug("Tool call was not requested, exiting from tool runner loop.")
-                    return
+                # When the last API response has stop_reason="pause_turn" and
+                # contains server_tool_use blocks (e.g. web_search, web_fetch),
+                # the server is still processing.  Skip tool-call generation
+                # entirely and re-invoke the API without appending any new
+                # user turn — the server will resume on the next call.
+                if self._has_pause_turn_server_tools():
+                    log.debug("Received pause_turn with server_tool_use blocks; continuing without client tool response.")
+                else:
+                    response = self.generate_tool_call_response()
+                    if response is None:
+                        log.debug("Tool call was not requested, exiting from tool runner loop.")
+                        return
 
-                if not self._messages_modified:
-                    self.append_messages(message, response)
+                    if not self._messages_modified:
+                        self.append_messages(message, response)
 
             self._messages_modified = False
             self._cached_tool_call_response = None
@@ -362,6 +370,19 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
             return None
 
         return last_message.content
+
+    def _has_pause_turn_server_tools(self) -> bool:
+        """Return True when the last message has stop_reason='pause_turn' and
+        contains server_tool_use blocks (web_search, web_fetch, etc.).
+
+        In this case the server is still processing the request; the runner
+        must continue the loop without adding a client-side tool_result message.
+        """
+        last_message = self._get_last_message()
+        if last_message is None or last_message.stop_reason != "pause_turn":
+            return False
+        content = last_message.content or []
+        return any(getattr(block, "type", None) == "server_tool_use" for block in content)
 
 
 class BetaToolRunner(BaseSyncToolRunner[ParsedBetaMessage[ResponseFormatT], ResponseFormatT]):
@@ -519,13 +540,21 @@ class BaseAsyncToolRunner(
 
             # If the compaction was performed, skip tool call generation this iteration
             if not await self._check_and_compact():
-                response = await self.generate_tool_call_response()
-                if response is None:
-                    log.debug("Tool call was not requested, exiting from tool runner loop.")
-                    return
+                # When the last API response has stop_reason="pause_turn" and
+                # contains server_tool_use blocks (e.g. web_search, web_fetch),
+                # the server is still processing.  Skip tool-call generation
+                # entirely and re-invoke the API without appending any new
+                # user turn — the server will resume on the next call.
+                if await self._has_pause_turn_server_tools():
+                    log.debug("Received pause_turn with server_tool_use blocks; continuing without client tool response.")
+                else:
+                    response = await self.generate_tool_call_response()
+                    if response is None:
+                        log.debug("Tool call was not requested, exiting from tool runner loop.")
+                        return
 
-                if not self._messages_modified:
-                    self.append_messages(message, response)
+                    if not self._messages_modified:
+                        self.append_messages(message, response)
 
             self._messages_modified = False
             self._cached_tool_call_response = None
@@ -566,6 +595,18 @@ class BaseAsyncToolRunner(
             return None
 
         return last_message.content
+
+    async def _has_pause_turn_server_tools(self) -> bool:
+        """Async variant of the same helper in BaseSyncToolRunner.
+
+        Return True when the last message has stop_reason='pause_turn' and
+        contains server_tool_use blocks (web_search, web_fetch, etc.).
+        """
+        last_message = await self._get_last_message()
+        if last_message is None or last_message.stop_reason != "pause_turn":
+            return False
+        content = last_message.content or []
+        return any(getattr(block, "type", None) == "server_tool_use" for block in content)
 
     async def _generate_tool_call_response(self) -> BetaMessageParam | None:
         content = await self._get_last_assistant_message_content()


### PR DESCRIPTION
## Problem

When using `client.beta.messages.tool_runner()` with server-side tools (`web_search`, `web_fetch`) alongside `@beta_tool` client functions, the runner exits prematurely when the API responds with `stop_reason="pause_turn"` and `server_tool_use` blocks.

`until_done()` then returns a message whose last content block is a `BetaServerToolUseBlock` instead of text, causing `AttributeError: 'BetaServerToolUseBlock' object has no attribute 'text'`.

Closes #1170

## Root Cause

`_generate_tool_call_response()` filters content for `type == "tool_use"` blocks. When the response contains only `server_tool_use` blocks, this filter returns nothing and the method returns `None`:

```python
tool_use_blocks = [block for block in content if block.type == "tool_use"]
if not tool_use_blocks:
    return None   # ← exits here
```

The `__run__` loop then sees `None` and exits:

```python
response = self.generate_tool_call_response()
if response is None:
    log.debug("Tool call was not requested, exiting from tool runner loop.")
    return   # ← premature exit
```

## Fix

Add `_has_pause_turn_server_tools()` to both `BaseSyncToolRunner` and `BaseAsyncToolRunner`. In `__run__` (sync and async), check this helper **before** deciding to exit. When it returns `True`:
- Skip `generate_tool_call_response()` entirely
- Continue the loop **without appending a new user turn** — the server will resume on the next API call

```python
if self._has_pause_turn_server_tools():
    log.debug("Received pause_turn with server_tool_use blocks; continuing...")
else:
    response = self.generate_tool_call_response()
    if response is None:
        return   # only exit when there are genuinely no tools
```
