### PR TITLE
fix: resolve subscripted generics in _build_discriminated_union_meta (pydantic v1)

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -686,7 +686,11 @@ def _build_discriminated_union_meta(*, union: type, meta_annotations: tuple[Any,
         variant = strip_annotated_type(variant)
         if is_basemodel_type(variant):
             if PYDANTIC_V1:
-                field_info = cast("dict[str, FieldInfo]", variant.__fields__).get(discriminator_field_name)  # pyright: ignore[reportDeprecated, reportUnnecessaryCast]
+                # Use get_origin() to resolve subscripted generics (e.g.
+                # ParsedBetaTextBlock[ResponseFormatT]) to their origin class,
+                # since _GenericAlias objects don't have __fields__.
+                origin = get_origin(variant) or variant
+                field_info = cast("dict[str, FieldInfo]", origin.__fields__).get(discriminator_field_name)  # pyright: ignore[reportDeprecated, reportUnnecessaryCast]
                 if not field_info:
                     continue
 


### PR DESCRIPTION
## Problem

`_build_discriminated_union_meta` in `_models.py` accesses `variant.__fields__` directly on each Union variant. When a variant is a subscripted generic like `ParsedBetaTextBlock[ResponseFormatT]` (from `ParsedBetaContentBlock`), it is a `typing._GenericAlias` — not a class — so `.__fields__` raises `AttributeError` on Python 3.12.

This crashes streaming (`client.beta.messages.stream()`) because `accumulate_event` calls `construct_type(type_=ParsedBetaContentBlock, ...)` on every `content_block_start` event, and when pydantic v1's `validate_type` fails to parse the block, it falls through to `_build_discriminated_union_meta` which hits this bug.

Only the pydantic v1 code path is affected. Pydantic v2 uses `_extract_field_schema_pv2` which handles subscripted generics correctly.

## Fix

Use `get_origin(variant) or variant` before accessing `.__fields__`, matching the pattern the SDK's own `is_basemodel_type` already uses (line 460):

```python
# Before (crashes on subscripted generics):
field_info = cast(..., variant.__fields__).get(discriminator_field_name)

# After:
origin = get_origin(variant) or variant
field_info = cast(..., origin.__fields__).get(discriminator_field_name)
```

## Repro

```python
# With pydantic v1 installed:
client = anthropic.Anthropic()
with client.beta.messages.stream(
    model="claude-sonnet-4-6",
    max_tokens=1024,
    messages=[{"role": "user", "content": "hello"}],
    betas=["..."],
) as stream:
    for event in stream:  # AttributeError: __fields__
        pass
```

```
AttributeError: __fields__
  File "anthropic/lib/streaming/_beta_messages.py", line 133, in __stream__
    self.__final_message_snapshot = accumulate_event(...)
  File "anthropic/lib/streaming/_beta_messages.py", line 481, in accumulate_event
    construct_type(type_=ParsedBetaContentBlock, value=event.content_block.to_dict())
  File "anthropic/_models.py", line 549, in construct_type
    discriminator = _build_discriminated_union_meta(union=type_, meta_annotations=meta)
  File "anthropic/_models.py", line 689, in _build_discriminated_union_meta
    field_info = cast(..., variant.__fields__).get(discriminator_field_name)
  File "typing.py", line 1186, in __getattr__
    raise AttributeError(attr)
```

Made with [Cursor](https://cursor.com)