### PR TITLE
fix: pass aws_profile to boto3.Session() in _infer_region()

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -67,7 +67,7 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     return options
 
 
-def _infer_region() -> str:
+def _infer_region(aws_profile: str | None = None) -> str:
     """
     Infer the AWS region from the environment variables or
     from the boto3 session if available.
@@ -77,7 +77,7 @@ def _infer_region() -> str:
         try:
             import boto3
 
-            session = boto3.Session()
+            session = boto3.Session(profile_name=aws_profile)
             if session.region_name:
                 aws_region = session.region_name
         except ImportError:
@@ -161,8 +161,8 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
         self.aws_profile = aws_profile
+        self.aws_region = _infer_region(aws_profile=aws_profile) if aws_region is None else aws_region
 
         self.aws_session_token = aws_session_token
 
@@ -303,8 +303,8 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
         self.aws_profile = aws_profile
+        self.aws_region = _infer_region(aws_profile=aws_profile) if aws_region is None else aws_region
 
         self.aws_session_token = aws_session_token
 


### PR DESCRIPTION
## Summary

- Fixes #892: `AnthropicBedrock(aws_profile='my-profile')` now correctly infers the AWS region from the specified profile's config instead of ignoring it and falling back to `us-east-1`
- `_infer_region()` now accepts an optional `aws_profile` parameter and passes it as `profile_name` to `boto3.Session()`
- Both `AnthropicBedrock` and `AsyncAnthropicBedrock` constructors now pass `aws_profile` through to `_infer_region()`

## Changes

In `src/anthropic/lib/bedrock/_client.py`:
1. Updated `_infer_region()` signature to accept `aws_profile: str | None = None`
2. Changed `boto3.Session()` to `boto3.Session(profile_name=aws_profile)` so the session respects the profile's configured region
3. Updated both sync and async constructor call sites to pass `aws_profile` to `_infer_region()`
4. Moved `self.aws_profile = aws_profile` before the `_infer_region()` call for clarity

## Test plan

- [ ] Verify with an AWS profile that has a non-default region configured (e.g., `us-west-2`) and confirm `AnthropicBedrock(aws_profile='my-profile').aws_region` returns that region
- [ ] Verify that when no `aws_profile` is passed, behavior is unchanged (falls back to default profile, then `us-east-1`)
- [ ] Verify that explicitly passing `aws_region` still takes precedence over profile-based inference

🤖 Generated with [Claude Code](https://claude.com/claude-code)