### PR TITLE
fix(client): AsyncAnthropic._make_status_error missing 529 and 413 cases

### DIFF
--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -513,11 +513,17 @@ class AsyncAnthropic(AsyncAPIClient):
         if response.status_code == 409:
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
+        if response.status_code == 413:
+            return _exceptions.RequestTooLargeError(err_msg, response=response, body=body)
+
         if response.status_code == 422:
             return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
 
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
+
+        if response.status_code == 529:
+            return _exceptions.OverloadedError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -112,6 +112,22 @@ def _get_open_connections(client: Anthropic | AsyncAnthropic) -> int:
     return len(pool._requests)
 
 
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 409, 413, 422, 429, 500, 503, 529])
+def test_make_status_error_sync_async_parity(status_code: int) -> None:
+    # Anthropic._make_status_error and AsyncAnthropic._make_status_error are
+    # separate manually-maintained copies; this guards against them drifting.
+    sync_client = Anthropic(base_url=base_url, api_key=api_key, _strict_response_validation=True)
+    async_client = AsyncAnthropic(base_url=base_url, api_key=api_key, _strict_response_validation=True)
+    response = httpx.Response(status_code, request=httpx.Request("GET", "/"))
+
+    sync_err = sync_client._make_status_error("msg", body=None, response=response)
+    async_err = async_client._make_status_error("msg", body=None, response=response)
+
+    assert type(sync_err) is type(async_err), (
+        f"sync returned {type(sync_err).__name__}, async returned {type(async_err).__name__}"
+    )
+
+
 class TestAnthropic:
     @pytest.mark.respx(base_url=base_url)
     def test_raw_response(self, respx_mock: MockRouter, client: Anthropic) -> None:


### PR DESCRIPTION
## What

`AsyncAnthropic._make_status_error` is missing the `529 → OverloadedError` and `413 → RequestTooLargeError` cases that the sync `Anthropic._make_status_error` has. So for async users:

- HTTP 529 raises `InternalServerError` (falls through to the `>= 500` catch-all) instead of `OverloadedError`
- HTTP 413 raises the base `APIStatusError` instead of `RequestTooLargeError`

This PR copies the two missing `if` arms from the sync method into the async one, and adds a parametrized parity test so the two copies can't drift silently again.

## Origin

#854 (commit b87dcf12, merged 2025-02-19) added these two cases to the sync client at `_client.py` L257. The diff in that PR is a single hunk touching only the sync method — the async copy further down in the same file was missed. Still the case on `main` today:

```
sync   L285: if response.status_code == 529: return OverloadedError(...)
async  L522: if response.status_code >= 500: return InternalServerError(...)   # no 529 check
```

## Verification

Ran the new parity test against current `main` — it fails on exactly 413 and 529:

```
FAIL 413: sync=RequestTooLargeError         async=APIStatusError
FAIL 529: sync=OverloadedError              async=InternalServerError
```

and passes with the fix applied.
