### PR TITLE
fix: handle tuples in deepcopy_minimal to prevent dict mutation

### DIFF
--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -189,7 +189,7 @@ def deepcopy_minimal(item: _T) -> _T:
         return cast(_T, {k: deepcopy_minimal(v) for k, v in item.items()})
     if is_list(item):
         return cast(_T, [deepcopy_minimal(entry) for entry in item])
-    if isinstance(item, tuple):
+    if is_tuple(item):
         return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
     return item
 

--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -181,6 +181,7 @@ def deepcopy_minimal(item: _T) -> _T:
 
     - mappings, e.g. `dict`
     - list
+    - tuple
 
     This is done for performance reasons.
     """
@@ -188,6 +189,8 @@ def deepcopy_minimal(item: _T) -> _T:
         return cast(_T, {k: deepcopy_minimal(v) for k, v in item.items()})
     if is_list(item):
         return cast(_T, [deepcopy_minimal(entry) for entry in item])
+    if isinstance(item, tuple):
+        return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
     return item
 
 

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -41,6 +41,22 @@ def test_nested_list() -> None:
     assert_different_identities(obj1[1], obj2[1])
 
 
+def test_simple_tuple() -> None:
+    obj1 = ("a", "b")
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+    assert obj1[0] is obj2[0]  # immutable strings are same object
+    assert obj1[1] is obj2[1]
+
+
+def test_nested_tuple() -> None:
+    obj1 = ("a", {"bar": True})
+    obj2 = deepcopy_minimal(obj1)
+    assert_different_identities(obj1, obj2)
+    assert_different_identities(obj1[1], obj2[1])
+    assert obj1[0] is obj2[0]  # immutable string preserved
+
+
 class MyObject: ...
 
 

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -52,7 +52,16 @@ def test_ignores_other_types() -> None:
     assert_different_identities(obj1, obj2)
     assert obj1["foo"] is my_obj
 
-    # tuples
+    # tuples - new tuple created but immutable contents not copied
     obj3 = ("a", "b")
     obj4 = deepcopy_minimal(obj3)
-    assert obj3 is obj4
+    assert obj3 is not obj4  # new tuple created
+    assert obj3[0] is obj4[0]  # but immutable strings are same object
+    assert obj3[1] is obj4[1]
+
+    # tuples with dicts inside - dict should be copied
+    inner_dict = {"bar": True}
+    obj5 = ("a", inner_dict)
+    obj6 = deepcopy_minimal(obj5)
+    assert obj5 is not obj6  # new tuple created
+    assert obj5[1] is not obj6[1]  # dict inside is copied

--- a/tests/test_deepcopy.py
+++ b/tests/test_deepcopy.py
@@ -68,16 +68,18 @@ def test_ignores_other_types() -> None:
     assert_different_identities(obj1, obj2)
     assert obj1["foo"] is my_obj
 
-    # tuples - new tuple created but immutable contents not copied
-    obj3 = ("a", "b")
-    obj4 = deepcopy_minimal(obj3)
-    assert obj3 is not obj4  # new tuple created
-    assert obj3[0] is obj4[0]  # but immutable strings are same object
-    assert obj3[1] is obj4[1]
+    # tuples with lists inside - list should be copied
+    inner_list = [1, {"x": "y"}]
+    obj7 = ("z", inner_list)
+    obj8 = deepcopy_minimal(obj7)
+    assert obj7 is not obj8  # new tuple created
+    assert obj7[1] is not obj8[1]  # list inside is copied
+    assert obj7[1][1] is not obj8[1][1]  # dict inside that list is also copied
 
-    # tuples with dicts inside - dict should be copied
-    inner_dict = {"bar": True}
-    obj5 = ("a", inner_dict)
-    obj6 = deepcopy_minimal(obj5)
-    assert obj5 is not obj6  # new tuple created
-    assert obj5[1] is not obj6[1]  # dict inside is copied
+    # deeply nested: tuple -> dict -> list -> dict
+    obj9 = ({"items": [{"name": "a"}]},)
+    obj10 = deepcopy_minimal(obj9)
+    assert obj9 is not obj10
+    assert obj9[0] is not obj10[0]  # dict in tuple copied
+    assert obj9[0]["items"] is not obj10[0]["items"]  # list in dict copied
+    assert obj9[0]["items"][0] is not obj10[0]["items"][0]  # dict in list copied


### PR DESCRIPTION
## Summary

Fixes an issue where deepcopy_minimal was mutating dicts nested inside tuples.

## Problem

The deepcopy_minimal function in _utils.py only handled dict and list types. When a tuple containing a dict was passed to functions like iles.beta.upload, the dict inside the tuple could be mutated in-place during processing.

## Solution

Added tuple handling to deepcopy_minimal:

`python
if isinstance(item, tuple):
    return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
`

This ensures that any dicts or lists nested inside tuples are properly deep-copied, preventing in-place mutations.

## Changes

- Added tuple handling to deepcopy_minimal function in src/anthropic/_utils/_utils.py
- Updated docstring to document tuple support

Closes #1202