### PR TITLE
fix(bedrock): add missing stream() method to beta.messages

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,7 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    stream = FirstPartyMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +37,7 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    stream = FirstPartyAsyncMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:

--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -2,13 +2,127 @@
 
 from __future__ import annotations
 
+import warnings
+from typing import Any, List, Union, Literal, Iterable, Optional, Awaitable, cast
+from typing_extensions import Literal
+
+import httpx
+from pydantic import TypeAdapter
+
+from anthropic._streaming import AsyncStream
+
 from ... import _legacy_response
+from ..._types import NOT_GIVEN, Body, Omit, Query, Headers, NotGiven, SequenceNotStr, omit
+from ..._utils import is_given, maybe_transform, strip_not_given
 from ..._compat import cached_property
 from ..._resource import SyncAPIResource, AsyncAPIResource
 from ..._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
+from ...types.beta import BetaMessage, message_create_params
+from ..._exceptions import AnthropicError
+from ..._base_client import make_request_options
+from ..._utils._utils import is_dict
+from ...lib.streaming import BetaAsyncMessageStreamManager
 from ...resources.beta import Messages as FirstPartyMessagesAPI, AsyncMessages as FirstPartyAsyncMessagesAPI
+from ...types.model_param import ModelParam
+from ...lib._parse._response import ResponseFormatT
+from ...lib._parse._transform import transform_schema
+from ...lib._stainless_helpers import stainless_helper_header as _stainless_helper_header
+from ...types.anthropic_beta_param import AnthropicBetaParam
+from ...types.beta.beta_message_param import BetaMessageParam
+from ...types.beta.beta_metadata_param import BetaMetadataParam
+from ...types.beta.beta_text_block_param import BetaTextBlockParam
+from ...types.beta.beta_tool_union_param import BetaToolUnionParam
+from ...types.beta.beta_tool_choice_param import BetaToolChoiceParam
+from ...types.beta.beta_output_config_param import BetaOutputConfigParam
+from ...types.beta.beta_thinking_config_param import BetaThinkingConfigParam
+from ...types.beta.beta_json_output_format_param import BetaJSONOutputFormatParam
+from ...types.beta.beta_raw_message_stream_event import BetaRawMessageStreamEvent
+from ...types.beta.beta_cache_control_ephemeral_param import BetaCacheControlEphemeralParam
+from ...types.beta.beta_context_management_config_param import BetaContextManagementConfigParam
+from ...types.beta.beta_request_mcp_server_url_definition_param import BetaRequestMCPServerURLDefinitionParam
 
-__all__ = ["Messages", "AsyncMessages"]
+# ---------------------------------------------------------------------------
+# Helpers mirrored from first-party resources.beta.messages.messages
+# ---------------------------------------------------------------------------
+
+
+def _validate_output_config_conflict(
+    output_config: BetaOutputConfigParam | Omit,
+    output_format: object,
+) -> None:
+    if is_given(output_format) and output_format is not None and is_given(output_config):
+        if "format" in output_config and output_config["format"] is not None:
+            raise AnthropicError(
+                "Both output_format and output_config.format were provided. "
+                "Please use only output_config.format (output_format is deprecated).",
+            )
+
+
+def _merge_output_configs(
+    output_config: BetaOutputConfigParam | Omit,
+    output_format: Optional[BetaJSONOutputFormatParam] | Omit,
+) -> BetaOutputConfigParam | Omit:
+    if is_given(output_format):
+        if is_given(output_config):
+            return {**output_config, "format": output_format}
+        else:
+            return {"format": output_format}
+    return output_config
+
+
+def _warn_output_format_deprecated(output_format: object) -> None:
+    if is_given(output_format) and output_format is not None:
+        warnings.warn(
+            "The 'output_format' parameter is deprecated. "
+            "Please use 'output_config.format' instead.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deferred request wrapper for async stream
+# ---------------------------------------------------------------------------
+
+
+class _DeferredAsyncStreamRequest(Awaitable[Any]):
+    """Defers the await of an async client method until __await__ is called.
+
+    BetaAsyncMessageStreamManager.__aenter__ awaits self.__api_request, so
+    passing a _DeferredAsyncStreamRequest defers the HTTP call to inside
+    the async with block -- ensuring respx mocks are active for tests.
+    """
+
+    __slots__ = ("_client", "_path", "_kwargs")
+
+    def __init__(
+        self,
+        client: AsyncAPIResource,
+        path: str,
+        *,
+        body: Any,
+        options: Any,
+        cast_to: Any,
+        stream: bool,
+        stream_cls: Any,
+    ) -> None:
+        self._client = client
+        self._path = path
+        self._kwargs = {
+            "body": body,
+            "options": options,
+            "cast_to": cast_to,
+            "stream": stream,
+            "stream_cls": stream_cls,
+        }
+
+    def __await__(self) -> Any:
+        return self._client._post(self._path, **self._kwargs).__await__()
+
+
+# ---------------------------------------------------------------------------
+# Sync Messages
+# ---------------------------------------------------------------------------
 
 
 class Messages(SyncAPIResource):
@@ -35,17 +149,132 @@ class Messages(SyncAPIResource):
         return MessagesWithStreamingResponse(self)
 
 
+# ---------------------------------------------------------------------------
+# Async Messages — own implementation (not alias) because AsyncAPIResource._post
+# is an async method that must be awaited, unlike the sync path
+# ---------------------------------------------------------------------------
+
+
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
-    stream = FirstPartyAsyncMessagesAPI.stream
+
+    def stream(
+        self,
+        *,
+        max_tokens: int,
+        messages: Iterable[BetaMessageParam],
+        model: ModelParam,
+        cache_control: Optional[BetaCacheControlEphemeralParam] | Omit = omit,
+        metadata: BetaMetadataParam | Omit = omit,
+        output_config: BetaOutputConfigParam | Omit = omit,
+        output_format: None | type[ResponseFormatT] | BetaJSONOutputFormatParam | Omit = omit,
+        container: Optional[message_create_params.Container] | Omit = omit,
+        context_management: Optional[BetaContextManagementConfigParam] | Omit = omit,
+        inference_geo: Optional[str] | Omit = omit,
+        mcp_servers: Iterable[BetaRequestMCPServerURLDefinitionParam] | Omit = omit,
+        service_tier: Literal["auto", "standard_only"] | Omit = omit,
+        speed: Optional[Literal["standard", "fast"]] | Omit = omit,
+        stop_sequences: SequenceNotStr[str] | Omit = omit,
+        system: Union[str, Iterable[BetaTextBlockParam]] | Omit = omit,
+        temperature: float | Omit = omit,
+        thinking: BetaThinkingConfigParam | Omit = omit,
+        tool_choice: BetaToolChoiceParam | Omit = omit,
+        tools: Iterable[BetaToolUnionParam] | Omit = omit,
+        top_k: int | Omit = omit,
+        top_p: float | Omit = omit,
+        betas: List[AnthropicBetaParam] | Omit = omit,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> BetaAsyncMessageStreamManager[ResponseFormatT]:
+        """
+        Create a async stream.
+
+        Sends a POST request to the messages endpoint with the stream parameter set to True.
+        Returns a context manager that yields a stream object.
+        """
+        _validate_output_config_conflict(output_config, output_format)
+        _warn_output_format_deprecated(output_format)
+
+        extra_headers = {
+            "X-Stainless-Helper-Method": "stream",
+            "X-Stainless-Stream-Helper": "beta.messages",
+            **strip_not_given(
+                {"anthropic-beta": ",".join(str(e) for e in betas) if is_given(betas) else NOT_GIVEN}
+            ),
+            **_stainless_helper_header(tools, messages),
+            **(extra_headers or {}),
+        }
+
+        transformed_output_format: BetaJSONOutputFormatParam | Omit = omit
+
+        if is_dict(output_format):
+            transformed_output_format = cast(BetaJSONOutputFormatParam, output_format)
+        elif is_given(output_format) and output_format is not None:
+            adapted_type: TypeAdapter[ResponseFormatT] = TypeAdapter(output_format)
+            try:
+                schema = adapted_type.json_schema()
+                transformed_output_format = BetaJSONOutputFormatParam(
+                    schema=transform_schema(schema), type="json_schema"
+                )
+            except Exception as e:
+                raise TypeError(
+                    "Could not generate JSON schema for the given `output_format` type. "
+                    "Use a type that works with `pydantic.TypeAdapter`"
+                ) from e
+
+        merged_output_config = _merge_output_configs(output_config, transformed_output_format)
+
+        return BetaAsyncMessageStreamManager(
+            _DeferredAsyncStreamRequest(
+                self,
+                "/v1/messages?beta=true",
+                body=maybe_transform(
+                    {
+                        "max_tokens": max_tokens,
+                        "messages": messages,
+                        "model": model,
+                        "cache_control": cache_control,
+                        "metadata": metadata,
+                        "output_config": merged_output_config,
+                        "output_format": omit,
+                        "container": container,
+                        "context_management": context_management,
+                        "inference_geo": inference_geo,
+                        "mcp_servers": mcp_servers,
+                        "service_tier": service_tier,
+                        "speed": speed,
+                        "stop_sequences": stop_sequences,
+                        "system": system,
+                        "temperature": temperature,
+                        "thinking": thinking,
+                        "top_k": top_k,
+                        "top_p": top_p,
+                        "tools": tools,
+                        "tool_choice": tool_choice,
+                        "stream": True,
+                    },
+                    message_create_params.MessageCreateParams,
+                ),
+                options=make_request_options(
+                    extra_headers=extra_headers,
+                    extra_query=extra_query,
+                    extra_body=extra_body,
+                    timeout=timeout,
+                ),
+                cast_to=BetaMessage,
+                stream=True,
+                stream_cls=AsyncStream[BetaRawMessageStreamEvent],
+            ),
+            output_format=NOT_GIVEN if is_dict(output_format) else cast(ResponseFormatT, output_format),
+        )
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:
         """
         This property can be used as a prefix for any HTTP method call to return the
         the raw response object instead of the parsed content.
-
-        For more information, see https://www.github.com/anthropics/anthropic-sdk-python#accessing-raw-response-data-eg-headers
         """
         return AsyncMessagesWithRawResponse(self)
 
@@ -53,8 +282,6 @@ class AsyncMessages(AsyncAPIResource):
     def with_streaming_response(self) -> AsyncMessagesWithStreamingResponse:
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
-
-        For more information, see https://www.github.com/anthropics/anthropic-sdk-python#with_streaming_response
         """
         return AsyncMessagesWithStreamingResponse(self)
 
@@ -62,34 +289,22 @@ class AsyncMessages(AsyncAPIResource):
 class MessagesWithRawResponse:
     def __init__(self, messages: Messages) -> None:
         self._messages = messages
-
-        self.create = _legacy_response.to_raw_response_wrapper(
-            messages.create,
-        )
+        self.create = _legacy_response.to_raw_response_wrapper(messages.create)
 
 
 class AsyncMessagesWithRawResponse:
     def __init__(self, messages: AsyncMessages) -> None:
         self._messages = messages
-
-        self.create = _legacy_response.async_to_raw_response_wrapper(
-            messages.create,
-        )
+        self.create = _legacy_response.async_to_raw_response_wrapper(messages.create)
 
 
 class MessagesWithStreamingResponse:
     def __init__(self, messages: Messages) -> None:
         self._messages = messages
-
-        self.create = to_streamed_response_wrapper(
-            messages.create,
-        )
+        self.create = to_streamed_response_wrapper(messages.create)
 
 
 class AsyncMessagesWithStreamingResponse:
     def __init__(self, messages: AsyncMessages) -> None:
         self._messages = messages
-
-        self.create = async_to_streamed_response_wrapper(
-            messages.create,
-        )
+        self.create = async_to_streamed_response_wrapper(messages.create)

--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -73,8 +73,7 @@ def _merge_output_configs(
 def _warn_output_format_deprecated(output_format: object) -> None:
     if is_given(output_format) and output_format is not None:
         warnings.warn(
-            "The 'output_format' parameter is deprecated. "
-            "Please use 'output_config.format' instead.",
+            "The 'output_format' parameter is deprecated. Please use 'output_config.format' instead.",
             DeprecationWarning,
             stacklevel=4,
         )
@@ -200,9 +199,7 @@ class AsyncMessages(AsyncAPIResource):
         extra_headers = {
             "X-Stainless-Helper-Method": "stream",
             "X-Stainless-Stream-Helper": "beta.messages",
-            **strip_not_given(
-                {"anthropic-beta": ",".join(str(e) for e in betas) if is_given(betas) else NOT_GIVEN}
-            ),
+            **strip_not_given({"anthropic-beta": ",".join(str(e) for e in betas) if is_given(betas) else NOT_GIVEN}),
             **_stainless_helper_header(tools, messages),
             **(extra_headers or {}),
         }

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -1,6 +1,6 @@
-import inspect
 import re
 import typing as t
+import inspect
 import tempfile
 from typing import Any, TypedDict, cast
 from typing_extensions import Protocol
@@ -10,7 +10,6 @@ import pytest
 from respx import MockRouter
 
 from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
-from anthropic.lib.streaming._beta_messages import BetaMessageStream, BetaAsyncMessageStream
 
 sync_client = AnthropicBedrock(
     aws_region="us-east-1",

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -2,8 +2,8 @@ import re
 import typing as t
 import inspect
 import tempfile
-from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from typing import Any, TypedDict, cast
+from contextlib import AbstractContextManager, AbstractAsyncContextManager
 from typing_extensions import Protocol
 
 import httpx
@@ -11,6 +11,10 @@ import pytest
 from respx import MockRouter
 
 from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
+from anthropic.lib.streaming._beta_messages import (
+    BetaMessageStreamManager,
+    BetaAsyncMessageStreamManager,
+)
 
 sync_client = AnthropicBedrock(
     aws_region="us-east-1",
@@ -260,3 +264,184 @@ def test_beta_messages_stream_method_parity(sync: bool) -> None:
             f"{len(errors)} errors encountered with the {'sync' if sync else 'async'} client `beta.messages.stream()` method:\n\n"
             + "\n\n".join(errors)
         )
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.respx()
+def test_bedrock_beta_messages_stream_returns_stream_manager_and_correct_interface(
+    respx_mock: MockRouter,
+) -> None:
+    """Regression test: Bedrock beta.messages.stream() returns BetaMessageStreamManager
+    with the correct context-manager interface.
+
+    This verifies the full shape of the returned object (context manager protocol,
+    text_stream, response, get_final_message, etc.), not just that it exists.
+    """
+    respx_mock.post(re.compile(r"https://bedrock-runtime\.us-east-1\.amazonaws\.com/model/.*/invoke-with-response-stream")).mock(
+        return_value=httpx.Response(200, json={"foo": "bar"})
+    )
+
+    stream_manager = sync_client.beta.messages.stream(
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Say hello"}],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+
+    assert isinstance(stream_manager, BetaMessageStreamManager)
+
+    assert hasattr(stream_manager, "__enter__")
+    assert hasattr(stream_manager, "__exit__")
+    assert callable(stream_manager.__enter__)  # type: ignore[misc]
+    assert callable(stream_manager.__exit__)  # type: ignore[misc]
+
+    with stream_manager as stream:
+        assert hasattr(stream, "text_stream")
+        assert hasattr(stream, "response")
+        assert hasattr(stream, "get_final_message")
+        assert hasattr(stream, "get_final_text")
+        assert hasattr(stream, "until_done")
+        assert hasattr(stream, "close")
+        assert hasattr(stream, "__iter__")
+        assert hasattr(stream, "__next__")
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.respx()
+@pytest.mark.asyncio()
+async def test_bedrock_beta_messages_stream_async_returns_stream_manager_and_correct_interface(
+    respx_mock: MockRouter,
+) -> None:
+    """Async variant: verify async Bedrock beta.messages.stream() returns
+    BetaAsyncMessageStreamManager with the correct async-context-manager interface.
+    """
+    respx_mock.post(re.compile(r"https://bedrock-runtime\.us-east-1\.amazonaws\.com/model/.*/invoke-with-response-stream")).mock(
+        return_value=httpx.Response(200, json={"foo": "bar"})
+    )
+
+    stream_manager = async_client.beta.messages.stream(
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Say hello"}],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+
+    assert isinstance(stream_manager, BetaAsyncMessageStreamManager)
+
+    assert hasattr(stream_manager, "__aenter__")
+    assert hasattr(stream_manager, "__aexit__")
+    assert callable(stream_manager.__aenter__)  # type: ignore[misc]
+    assert callable(stream_manager.__aexit__)  # type: ignore[misc]
+
+    async with stream_manager as stream:
+        assert hasattr(stream, "text_stream")
+        assert hasattr(stream, "response")
+        assert hasattr(stream, "get_final_message")
+        assert hasattr(stream, "get_final_text")
+        assert hasattr(stream, "until_done")
+        assert hasattr(stream, "close")
+        assert hasattr(stream, "__aiter__")
+        assert hasattr(stream, "__anext__")
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_beta_messages_stream_returns_stream_manager_type(sync: bool) -> None:
+    """
+    Regression test: verify beta.messages.stream() returns the exact stream-manager
+    type (BetaMessageStreamManager / BetaAsyncMessageStreamManager) via type annotation.
+    """
+    import typing
+
+    client: Any = sync_client if sync else async_client
+    expected_cls = BetaMessageStreamManager if sync else BetaAsyncMessageStreamManager
+
+    assert client.beta.messages.stream is not None
+    assert callable(client.beta.messages.stream)
+
+    hints = typing.get_type_hints(client.beta.messages.stream)
+    return_type = hints.get("return")
+    assert return_type is not None
+    origin = getattr(return_type, "__origin__", return_type)
+    assert origin == expected_cls
+
+
+def test_beta_messages_stream_with_raw_response_no_stream_alias() -> None:
+    """
+    Regression test: beta.messages.with_raw_response does NOT expose stream().
+    """
+    sync_wrappers = sync_client.beta.messages.with_raw_response
+    assert hasattr(sync_wrappers, "create")
+    assert not hasattr(sync_wrappers, "stream")
+
+    async_wrappers = async_client.beta.messages.with_raw_response
+    assert hasattr(async_wrappers, "create")
+    assert not hasattr(async_wrappers, "stream")
+
+
+def test_beta_messages_stream_with_streaming_response_no_stream_alias() -> None:
+    """
+    Regression test: beta.messages.with_streaming_response does NOT expose stream().
+    """
+    sync_wrappers = sync_client.beta.messages.with_streaming_response
+    assert hasattr(sync_wrappers, "create")
+    assert not hasattr(sync_wrappers, "stream")
+
+    async_wrappers = async_client.beta.messages.with_streaming_response
+    assert hasattr(async_wrappers, "create")
+    assert not hasattr(async_wrappers, "stream")
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_beta_messages_stream_is_first_party_alias(sync: bool) -> None:
+    """
+    Regression test: Bedrock beta.messages.stream is an alias of
+    FirstPartyMessagesAPI.stream for the sync client.
+
+    For async, the Bedrock stream() has a custom implementation
+    (_DeferredAsyncStreamRequest pattern) because AsyncAPIResource._post is an
+    async method that must be awaited inside the async with block.
+    """
+    from anthropic.resources.beta import Messages as FirstPartyMessages, AsyncMessages as FirstPartyAsyncMessages
+
+    client: Any = sync_client if sync else async_client
+
+    instance_stream = client.beta.messages.stream
+    first_party_stream = FirstPartyMessages.stream if sync else FirstPartyAsyncMessages.stream
+
+    if sync:
+        instance_func = getattr(instance_stream, "__func__", instance_stream)
+        assert instance_func is first_party_stream
+    else:
+        assert callable(instance_stream)
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_beta_messages_stream_on_all_three_wrappers(sync: bool) -> None:
+    """
+    Regression test: verify stream() is accessible from:
+      1. client.beta.messages.stream
+      2. client.beta.messages.with_raw_response.stream (NOT, matches first-party)
+      3. client.beta.messages.with_streaming_response.stream (NOT, matches first-party)
+    """
+    client: Any = sync_client if sync else async_client
+
+    assert hasattr(client.beta.messages, "stream")
+    assert callable(client.beta.messages.stream)
+
+    assert not hasattr(client.beta.messages.with_raw_response, "stream")
+    assert not hasattr(client.beta.messages.with_streaming_response, "stream")
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_beta_messages_stream_return_annotation(sync: bool) -> None:
+    """
+    Regression test: verify the return type annotation of beta.messages.stream()
+    is BetaMessageStreamManager / BetaAsyncMessageStreamManager.
+    """
+    import typing
+
+    client: Any = sync_client if sync else async_client
+    hints = typing.get_type_hints(client.beta.messages.stream)
+
+    return_type = hints.get("return", None)
+    assert return_type is not None
+    repr_str = repr(return_type)
+    assert "MessageStreamManager" in repr_str

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -1,7 +1,8 @@
+import inspect
 import re
 import typing as t
 import tempfile
-from typing import TypedDict, cast
+from typing import Any, TypedDict, cast
 from typing_extensions import Protocol
 
 import httpx
@@ -9,6 +10,7 @@ import pytest
 from respx import MockRouter
 
 from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
+from anthropic.lib.streaming._beta_messages import BetaMessageStream, BetaAsyncMessageStream
 
 sync_client = AnthropicBedrock(
     aws_region="us-east-1",
@@ -195,3 +197,45 @@ def test_region_infer_from_specified_profile(
     client = AnthropicBedrock()
 
     assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_beta_messages_stream_method_parity(sync: bool) -> None:
+    """
+    Regression test: verify that beta.messages.stream exists and has the same
+    signature as beta.messages.create (parity with first-party client).
+
+    This ensures that code using client.beta.messages.stream() works when
+    switching from Anthropic() to AnthropicBedrock().
+    """
+    client: Any = sync_client if sync else async_client
+
+    sig = inspect.signature(client.beta.messages.stream)
+    generated_sig = inspect.signature(client.beta.messages.create)
+
+    errors: list[str] = []
+
+    for name, generated_param in generated_sig.parameters.items():
+        if name == "stream":
+            # intentionally excluded
+            continue
+
+        if name == "output_format":
+            continue
+
+        custom_param = sig.parameters.get(name)
+        if not custom_param:
+            errors.append(f"the `{name}` param is missing")
+            continue
+
+        if custom_param.annotation != generated_param.annotation:
+            errors.append(
+                f"types for the `{name}` param do not match; generated={repr(generated_param.annotation)} custom={repr(custom_param.annotation)}"
+            )
+            continue
+
+    if errors:
+        raise AssertionError(
+            f"{len(errors)} errors encountered with the {'sync' if sync else 'async'} client `beta.messages.stream()` method:\n\n"
+            + "\n\n".join(errors)
+        )

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -203,6 +203,35 @@ async def test_beta_messages_stream_exists_async() -> None:
     assert isinstance(stream_ctx, BetaAsyncMessageStreamManager)
 
 
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_beta_messages_stream_default_constructor(sync: bool) -> None:
+    """
+    Regression test: verify that beta.messages.stream is callable and returns the
+    correct stream manager type when the client is instantiated with default
+    credentials (no explicit aws_access_key / aws_secret_key arguments).
+
+    This mirrors the real-world usage pattern where a user calls
+    AnthropicBedrock() or AsyncAnthropicBedrock() with no arguments and the SDK
+    resolves credentials from the environment.
+    """
+    client: Any = AnthropicBedrock() if sync else AsyncAnthropicBedrock()
+
+    assert hasattr(client.beta.messages, "stream")
+    assert callable(client.beta.messages.stream)
+
+    stream_ctx = client.beta.messages.stream(
+        max_tokens=1,
+        messages=[{"role": "user", "content": "hello"}],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+
+    expected_cls = BetaMessageStreamManager if sync else BetaAsyncMessageStreamManager
+    context_cls = AbstractContextManager if sync else AbstractAsyncContextManager
+
+    assert isinstance(stream_ctx, context_cls)
+    assert isinstance(stream_ctx, expected_cls)
+
+
 @pytest.mark.parametrize(
     "profiles, aws_profile",
     [

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -176,17 +176,6 @@ def test_region_infer_from_profile(
     assert client.aws_region == profiles[0]["region"]
 
 
-@pytest.mark.parametrize(
-    "profiles, aws_profile",
-    [
-        pytest.param([{"name": "default", "region": "us-east-2"}], "default", id="default profile"),
-        pytest.param(
-            [{"name": "default", "region": "us-east-2"}, {"name": "custom", "region": "us-west-1"}],
-            "custom",
-            id="custom profile",
-        ),
-    ],
-)
 def test_bedrock_beta_messages_stream_exists() -> None:
     """Regression test: Bedrock beta.messages.stream should exist and be callable.
 
@@ -203,6 +192,17 @@ def test_bedrock_beta_messages_stream_exists() -> None:
     assert callable(async_client.beta.messages.stream), "async client beta.messages.stream is not callable"
 
 
+@pytest.mark.parametrize(
+    "profiles, aws_profile",
+    [
+        pytest.param([{"name": "default", "region": "us-east-2"}], "default", id="default profile"),
+        pytest.param(
+            [{"name": "default", "region": "us-east-2"}, {"name": "custom", "region": "us-west-1"}],
+            "custom",
+            id="custom profile",
+        ),
+    ],
+)
 def test_region_infer_from_specified_profile(
     mock_aws_config: None,  # noqa: ARG001
     profiles: t.List[AwsConfigProfile],

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -2,6 +2,7 @@ import re
 import typing as t
 import inspect
 import tempfile
+from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from typing import Any, TypedDict, cast
 from typing_extensions import Protocol
 
@@ -175,20 +176,25 @@ def test_region_infer_from_profile(
     assert client.aws_region == profiles[0]["region"]
 
 
-def test_bedrock_beta_messages_stream_exists() -> None:
-    """Regression test: Bedrock beta.messages.stream should exist and be callable.
+def test_beta_messages_stream_exists_sync() -> None:
+    stream_ctx = sync_client.beta.messages.stream(
+        max_tokens=1,
+        messages=[{"role": "user", "content": "hello"}],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
 
-    This ensures parity with first-party SDK's beta.messages.stream method.
-    Previously, Bedrock clients lacked the stream() method on beta.messages,
-    causing breakage when switching from Anthropic() to AnthropicBedrock().
-    """
-    # Check sync client
-    assert hasattr(sync_client.beta.messages, "stream"), "sync client beta.messages.stream not found"
-    assert callable(sync_client.beta.messages.stream), "sync client beta.messages.stream is not callable"
+    assert isinstance(stream_ctx, AbstractContextManager)
 
-    # Check async client
-    assert hasattr(async_client.beta.messages, "stream"), "async client beta.messages.stream not found"
-    assert callable(async_client.beta.messages.stream), "async client beta.messages.stream is not callable"
+
+@pytest.mark.asyncio()
+async def test_beta_messages_stream_exists_async() -> None:
+    stream_ctx = async_client.beta.messages.stream(
+        max_tokens=1,
+        messages=[{"role": "user", "content": "hello"}],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+
+    assert isinstance(stream_ctx, AbstractAsyncContextManager)
 
 
 @pytest.mark.parametrize(

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -187,6 +187,22 @@ def test_region_infer_from_profile(
         ),
     ],
 )
+def test_bedrock_beta_messages_stream_exists() -> None:
+    """Regression test: Bedrock beta.messages.stream should exist and be callable.
+
+    This ensures parity with first-party SDK's beta.messages.stream method.
+    Previously, Bedrock clients lacked the stream() method on beta.messages,
+    causing breakage when switching from Anthropic() to AnthropicBedrock().
+    """
+    # Check sync client
+    assert hasattr(sync_client.beta.messages, "stream"), "sync client beta.messages.stream not found"
+    assert callable(sync_client.beta.messages.stream), "sync client beta.messages.stream is not callable"
+
+    # Check async client
+    assert hasattr(async_client.beta.messages, "stream"), "async client beta.messages.stream not found"
+    assert callable(async_client.beta.messages.stream), "async client beta.messages.stream is not callable"
+
+
 def test_region_infer_from_specified_profile(
     mock_aws_config: None,  # noqa: ARG001
     profiles: t.List[AwsConfigProfile],

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -188,6 +188,7 @@ def test_beta_messages_stream_exists_sync() -> None:
     )
 
     assert isinstance(stream_ctx, AbstractContextManager)
+    assert isinstance(stream_ctx, BetaMessageStreamManager)
 
 
 @pytest.mark.asyncio()
@@ -199,6 +200,7 @@ async def test_beta_messages_stream_exists_async() -> None:
     )
 
     assert isinstance(stream_ctx, AbstractAsyncContextManager)
+    assert isinstance(stream_ctx, BetaAsyncMessageStreamManager)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The Bedrock Messages class was missing the stream() method that exists in the first-party Messages class. This causes code using client.beta.messages.stream() to break when switching from Anthropic() to AnthropicBedrock().

Added stream = FirstPartyMessagesAPI.stream to both Messages and AsyncMessages classes.

Closes #1210