### PR TITLE
docs: remove outdated single-content-block note from get_final_text

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -100,9 +100,6 @@ class BetaMessageStream(Generic[ResponseFormatT]):
     def get_final_text(self) -> str:
         """Returns all `text` content blocks concatenated together.
 
-        > [!NOTE]
-        > Currently the API will only respond with a single content block.
-
         Will raise an error if no `text` content blocks were returned.
         """
         message = self.get_final_message()
@@ -248,9 +245,6 @@ class BetaAsyncMessageStream(Generic[ResponseFormatT]):
 
     async def get_final_text(self) -> str:
         """Returns all `text` content blocks concatenated together.
-
-        > [!NOTE]
-        > Currently the API will only respond with a single content block.
 
         Will raise an error if no `text` content blocks were returned.
         """

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -97,9 +97,6 @@ class MessageStream(Generic[ResponseFormatT]):
     def get_final_text(self) -> str:
         """Returns all `text` content blocks concatenated together.
 
-        > [!NOTE]
-        > Currently the API will only respond with a single content block.
-
         Will raise an error if no `text` content blocks were returned.
         """
         message = self.get_final_message()
@@ -244,9 +241,6 @@ class AsyncMessageStream(Generic[ResponseFormatT]):
 
     async def get_final_text(self) -> str:
         """Returns all `text` content blocks concatenated together.
-
-        > [!NOTE]
-        > Currently the API will only respond with a single content block.
 
         Will raise an error if no `text` content blocks were returned.
         """


### PR DESCRIPTION
## Summary

- Removes the outdated note `> Currently the API will only respond with a single content block.` from `get_final_text()` and `async get_final_text()` docstrings in both `_messages.py` and `_beta_messages.py`

## Why

This note was accurate when the SDK was first written, but it has been outdated since extended thinking was introduced. The API now routinely returns multiple content blocks — for example, a `thinking` block followed by a `text` block when extended thinking is enabled.

The implementation already handles multiple text blocks correctly (it concatenates them with `"".join(text_blocks)`); only the misleading documentation note needed removing.

## Test plan

- [x] Note removed from `MessageStream.get_final_text` (sync + async)
- [x] Note removed from `BetaMessageStream.get_final_text` (sync + async)
- No behaviour change; purely documentation cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)