### PR TITLE
fix: raise ValueError when model is None in Bedrock client

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -51,6 +51,8 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
             raise RuntimeError("Expected dictionary json_data for post /completions endpoint")
 
         model = options.json_data.pop("model", None)
+        if model is None:
+            raise ValueError("model is required for Bedrock API calls")
         model = urllib.parse.quote(str(model), safe=":")
         stream = options.json_data.pop("stream", False)
         if stream:


### PR DESCRIPTION
## Summary

When `model` is not provided in the request options for a Bedrock API call, `options.json_data.pop("model", None)` returns `None`. The code then calls `urllib.parse.quote(str(None), safe=":")` which produces the string `"None"`, resulting in a URL like `/model/None/invoke` — a silent bug that only surfaces as a confusing 404 from AWS.

This PR adds an explicit `ValueError` when `model` is `None`, giving users a clear error message instead.

## Changes

- `src/anthropic/lib/bedrock/_client.py`: Added `if model is None: raise ValueError(...)` guard before URL construction

## Test plan

- [ ] Verify that calling `client.messages.create(...)` without a `model` parameter now raises `ValueError: model is required for Bedrock API calls`
- [ ] Verify that providing a valid model still constructs the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)