### PR TITLE
fix: remove spurious pass statement in signature_delta handler

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -403,7 +403,6 @@ def build_events(
                         signature=content_block.signature,
                     )
                 )
-            pass
         elif event.delta.type == "compaction_delta":
             if content_block.type == "compaction":
                 events_to_fire.append(

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -398,7 +398,6 @@ def build_events(
                         signature=content_block.signature,
                     )
                 )
-            pass
         else:
             # we only want exhaustive checking for linters, not at runtime
             if TYPE_CHECKING:  # type: ignore[unreachable]


### PR DESCRIPTION
## Summary

In `_messages.py` and `_beta_messages.py`, the `elif event.delta.type == "signature_delta":` branch in `build_events()` contains a spurious `pass` statement after the `if content_block.type == "thinking":` block. This `pass` is unreachable dead code that adds confusion about the control flow — it appears as though the `else` branch below is the fallthrough of the `pass`, when in reality it's the fallthrough of the entire `elif`.

## Changes

- `src/anthropic/lib/streaming/_messages.py`: Removed `pass` from `signature_delta` handler
- `src/anthropic/lib/streaming/_beta_messages.py`: Removed `pass` from `signature_delta` handler

## Test plan

- [ ] Verify that streaming with extended thinking still correctly fires `SignatureEvent` for `signature_delta` events
- [ ] Verify no change in behavior — this is purely dead code removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)