### PR TITLE
fix(streaming): add helpful error message for malformed tool JSON in non-beta path

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,12 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":


### PR DESCRIPTION
## Description

Fixes unhelpful raw parser error when model emits malformed JSON during streaming tool use, as reported in #1265.

### Problem

The **beta** path (`_beta_messages.py`) already wraps `from_json()` with a helpful try-except:

```python
try:
    content.input = from_json(json_buf, partial_mode=...)
except ValueError as e:
    raise ValueError(
        f"Unable to parse tool parameter JSON from model. "
        f"Please retry your request or adjust your prompt. "
        f"Error: {e}. JSON: {json_buf.decode('utf-8')}"
    ) from e
```

The **non-beta** path (`_messages.py`) was missing this wrapper, causing raw errors like:

```
ValueError: expected ident at line 1 column 11
```

No context about what JSON was received or what to do.

### Solution

Add the same try-except wrapper to the non-beta `accumulate_event()` in `_messages.py`.

### Changes

| File | Change |
|------|--------|
| `src/anthropic/lib/streaming/_messages.py` | Wrap `from_json()` with helpful ValueError |

Fixes #1265