### PR TITLE
fix(utils): recursively copy tuples in deepcopy_minimal to prevent in-place mutation

### DIFF
--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -181,6 +181,7 @@ def deepcopy_minimal(item: _T) -> _T:
 
     - mappings, e.g. `dict`
     - list
+    - tuple (recursively copies elements so mutable items inside are not shared)
 
     This is done for performance reasons.
     """
@@ -188,6 +189,8 @@ def deepcopy_minimal(item: _T) -> _T:
         return cast(_T, {k: deepcopy_minimal(v) for k, v in item.items()})
     if is_list(item):
         return cast(_T, [deepcopy_minimal(entry) for entry in item])
+    if isinstance(item, tuple):
+        return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
     return item
 
 


### PR DESCRIPTION
## Description

Fixes in-place mutation of user-provided data when using `files.beta.upload`, as reported in #1202.

### Problem

`deepcopy_minimal` only recursively copies `dict` and `list`. When a `FileTypes` tuple like `(filename, content, mime_type, headers_dict)` is passed, the tuple is returned as-is. The `headers_dict` (4th element) shares the same reference, so internal SDK mutations propagate back to the caller.

### Solution

Add `tuple` handling to `deepcopy_minimal`:

```python
if isinstance(item, tuple):
    return cast(_T, tuple(deepcopy_minimal(entry) for entry in item))
```

This ensures mutable objects inside tuples (like the headers dict) are properly copied.

### Changes

| File | Change |
|------|--------|
| `src/anthropic/_utils/_utils.py` | Add tuple support to `deepcopy_minimal` |

Fixes #1202