### PR TITLE
fix(tools): prevent tool_runner from exiting when server_tool_use blocks are present

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -306,6 +306,13 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
 
         tool_use_blocks = [block for block in content if block.type == "tool_use"]
         if not tool_use_blocks:
+            # When server-side tools (e.g. web_search, web_fetch) are present,
+            # the API responds with server_tool_use blocks and stop_reason="pause_turn".
+            # The runner should continue the loop so the server can return results.
+            has_server_tools = any(block.type == "server_tool_use" for block in content)
+            if has_server_tools:
+                log.debug("Server tool use detected, continuing runner loop.")
+                return {"role": "user", "content": []}
             return None
 
         results: list[BetaToolResultBlockParam] = []
@@ -598,6 +605,10 @@ class BaseAsyncToolRunner(
 
         tool_use_blocks = [block for block in content if block.type == "tool_use"]
         if not tool_use_blocks:
+            has_server_tools = any(block.type == "server_tool_use" for block in content)
+            if has_server_tools:
+                log.debug("Server tool use detected, continuing runner loop (async).")
+                return {"role": "user", "content": []}
             return None
 
         results: list[BetaToolResultBlockParam] = []


### PR DESCRIPTION
## Description

Fixes premature exit of `tool_runner` when server-side tools are used alongside client tools, as reported in #1170.

### Problem

When using `client.beta.messages.tool_runner()` with server-side tools like `web_search` or `web_fetch`, the API responds with `server_tool_use` blocks and `stop_reason="pause_turn"`. However, `_generate_tool_call_response()` only filters for `block.type == "tool_use"`:

```python
tool_use_blocks = [block for block in content if block.type == "tool_use"]
if not tool_use_blocks:
    return None  # exits the runner
```

`server_tool_use` blocks have a different type, so the list is empty, `None` is returned, and the runner exits before the server can return results.

### Solution

When no client `tool_use` blocks are found, check for `server_tool_use` blocks. If present, return an empty user message to continue the loop:

```python
has_server_tools = any(block.type == "server_tool_use" for block in content)
if has_server_tools:
    return {"role": "user", "content": []}
```

Applied to both sync and async paths.

### Changes

| File | Change |
|------|--------|
| `src/anthropic/lib/tools/_beta_runner.py` | Handle server_tool_use in sync + async |

Fixes #1170