### PR TITLE
fix(streaming): handle dict objects that lack to_dict() in stream accumulator

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -467,8 +467,9 @@ def accumulate_event(
 
     if current_snapshot is None:
         if event.type == "message_start":
+            message_data = event.message.to_dict() if hasattr(event.message, "to_dict") else dict(event.message)
             return cast(
-                ParsedBetaMessage[ResponseFormatT], ParsedBetaMessage.construct(**cast(Any, event.message.to_dict()))
+                ParsedBetaMessage[ResponseFormatT], ParsedBetaMessage.construct(**cast(Any, message_data))
             )
 
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')
@@ -478,7 +479,10 @@ def accumulate_event(
         current_snapshot.content.append(
             cast(
                 Any,  # Pydantic does not support generic unions at runtime
-                construct_type(type_=ParsedBetaContentBlock, value=event.content_block.to_dict()),
+                construct_type(
+                    type_=ParsedBetaContentBlock,
+                    value=event.content_block.to_dict() if hasattr(event.content_block, "to_dict") else dict(event.content_block),
+                ),
             ),
         )
     elif event.type == "content_block_delta":

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -449,7 +449,8 @@ def accumulate_event(
 
     if current_snapshot is None:
         if event.type == "message_start":
-            return cast(ParsedMessage[ResponseFormatT], ParsedMessage.construct(**cast(Any, event.message.to_dict())))
+            message_data = event.message.to_dict() if hasattr(event.message, "to_dict") else dict(event.message)
+            return cast(ParsedMessage[ResponseFormatT], ParsedMessage.construct(**cast(Any, message_data)))
 
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')
 


### PR DESCRIPTION
## Description

Fixes intermittent `AttributeError: 'dict' object has no attribute 'to_dict'` during beta streaming, as reported in #1088.

### Problem

When using `client.beta.messages.stream()` with certain betas (e.g. `effort-2025-11-24`, `code-execution-2025-08-25`), the stream accumulator intermittently receives raw `dict` objects instead of Pydantic models for `message_start` and `content_block_start` events.

Calling `.to_dict()` on a plain dict raises `AttributeError`.

### Solution

Add `hasattr` checks before calling `.to_dict()`, falling back to `dict()` conversion:

```python
message_data = event.message.to_dict() if hasattr(event.message, "to_dict") else dict(event.message)
```

Applied to both `_messages.py` (non-beta) and `_beta_messages.py` (beta) for consistency.

### Changes

| File | Change |
|------|--------|
| `src/anthropic/lib/streaming/_beta_messages.py` | Guard `to_dict()` calls on message + content_block |
| `src/anthropic/lib/streaming/_messages.py` | Guard `to_dict()` call on message |

Fixes #1088