### PR TITLE
fix(streaming): replace IndexError with descriptive RuntimeError for out-of-bounds content_block_delta

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -482,6 +482,12 @@ def accumulate_event(
             ),
         )
     elif event.type == "content_block_delta":
+        if event.index >= len(current_snapshot.content):
+            raise RuntimeError(
+                f"Received content_block_delta for index {event.index}, "
+                f"but snapshot only has {len(current_snapshot.content)} content block(s). "
+                f"This may indicate a missing content_block_start event."
+            )
         content = current_snapshot.content[event.index]
         if event.delta.type == "text_delta":
             if content.type == "text":

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -462,6 +462,12 @@ def accumulate_event(
             ),
         )
     elif event.type == "content_block_delta":
+        if event.index >= len(current_snapshot.content):
+            raise RuntimeError(
+                f"Received content_block_delta for index {event.index}, "
+                f"but snapshot only has {len(current_snapshot.content)} content block(s). "
+                f"This may indicate a missing content_block_start event."
+            )
         content = current_snapshot.content[event.index]
         if event.delta.type == "text_delta":
             if content.type == "text":


### PR DESCRIPTION
## Description

Improves error diagnostics for intermittent `IndexError` during streaming, as reported in #1192.

### Problem

In `accumulate_event()`, `current_snapshot.content[event.index]` can raise an opaque `IndexError` when the index exceeds the content list length (e.g. due to a missing `content_block_start` event or a race condition).

The raw `IndexError` provides no context about what happened.

### Solution

Add bounds checking before the index access with a descriptive error:

```python
if event.index >= len(current_snapshot.content):
    raise RuntimeError(
        f"Received content_block_delta for index {event.index}, "
        f"but snapshot only has {len(current_snapshot.content)} content block(s). "
        f"This may indicate a missing content_block_start event."
    )
```

Applied to both `_messages.py` and `_beta_messages.py`.

Fixes #1192