### PR TITLE
fix: add helpful error message for malformed JSON in streaming tool use

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,12 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":


### PR DESCRIPTION
## Summary

Fixes #1265

The non-beta streaming path (`_messages.py`) was missing the `try-except` wrapper that the beta path (`_beta_messages.py`) already has.

## Problem

When using `client.messages.stream()` with tools, if the model emits malformed JSON during an `input_json_delta` event, users get a raw internal parser error:

```
ValueError: expected ident at line 1 column 11
```

This error provides no context about what went wrong or where it came from.

## Solution

Added the same try-except wrapper from the beta path:

```python
try:
    content.input = from_json(json_buf, partial_mode=True)
except ValueError as e:
    raise ValueError(
        f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8'}"
    ) from e
```

## Error Message Now Includes

- Clear explanation of what went wrong
- The original parsing error
- The malformed JSON that caused the issue
- Guidance to retry or adjust the prompt

## Testing

This change mirrors the existing beta implementation which has been working in production.