### PR TITLE
fix: replace allowed_tools with claude_args in Claude Code Action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,8 +42,9 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Allow Claude to run git commands and push changes
-          allowed_tools: "Bash(git commit:*),Bash(git push:*),Bash(git merge:*),Bash(git checkout:*),Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git fetch:*),Bash(gh pr:*),Bash(gh issue:*)"
-
+          claude_args: |
+            --allowedTools Bash(git commit:*),Bash(git push:*),Bash(git merge:*),Bash(git checkout:*),Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git fetch:*),Bash(gh pr:*),Bash(gh issue:*)
+    
           # Allow github-actions[bot] to trigger Claude Code Action
           allowed_bots: "stainless-app"
 


### PR DESCRIPTION

**What was wrong:**
- `allowed_tools` is not a valid input in `claude-code-action@v1` — it was removed
- This caused a warning and the action couldn't resolve the tools permission correctly

**What was changed:**
- Replaced `allowed_tools: "..."` with `claude_args: | --allowedTools ...` which is the correct v1 syntax
- No functional change — same tools are allowed, just using the right input key
