### PR TITLE
docs(examples): add mTLS and custom TLS configuration example

### DIFF
--- a/examples/mtls.py
+++ b/examples/mtls.py
@@ -1,0 +1,88 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "anthropic",
+# ]
+#
+# [tool.uv.sources]
+# anthropic = { path = "../", editable = true }
+# ///
+"""Configure the SDK for mTLS client certificates or corporate proxy CA bundles.
+
+Enterprise environments often require mutual TLS (mTLS) for per-user attribution
+through API gateways, or custom CA bundles for corporate TLS inspection proxies
+(Zscaler, Netskope, etc.). This example shows how to configure both using the
+SDK's existing http_client parameter.
+"""
+
+import ssl
+import asyncio
+
+from anthropic import Anthropic, AsyncAnthropic, DefaultHttpxClient, DefaultAsyncHttpxClient
+
+# ---------------------------------------------------------------------------
+# 1. mTLS client certificate authentication (synchronous)
+# ---------------------------------------------------------------------------
+# Build an SSL context with both the CA bundle and the client certificate,
+# then pass it as verify= to DefaultHttpxClient. This preserves the SDK's
+# default connection limits, timeouts, TCP keepalive, and proxy detection.
+
+ctx = ssl.create_default_context()
+ctx.load_verify_locations("/path/to/ca-bundle.crt")
+ctx.load_cert_chain("/path/to/client.crt", "/path/to/client.key")
+
+sync_client = Anthropic(
+    http_client=DefaultHttpxClient(verify=ctx),
+)
+
+message = sync_client.messages.create(
+    model="claude-sonnet-4-5-20250929",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello from behind an mTLS proxy!"}],
+)
+print(message.content)
+
+
+# ---------------------------------------------------------------------------
+# 2. mTLS client certificate authentication (asynchronous)
+# ---------------------------------------------------------------------------
+
+
+async def async_mtls_example() -> None:
+    ctx = ssl.create_default_context()
+    ctx.load_verify_locations("/path/to/ca-bundle.crt")
+    ctx.load_cert_chain("/path/to/client.crt", "/path/to/client.key")
+
+    async_client = AsyncAnthropic(
+        http_client=DefaultAsyncHttpxClient(verify=ctx),
+    )
+
+    message = await async_client.messages.create(
+        model="claude-sonnet-4-5-20250929",
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "Hello from async mTLS!"}],
+    )
+    print(message.content)
+
+
+asyncio.run(async_mtls_example())
+
+
+# ---------------------------------------------------------------------------
+# 3. Corporate proxy with custom CA bundle (no client certificate)
+# ---------------------------------------------------------------------------
+# If your corporate proxy performs TLS inspection (e.g., Zscaler, Netskope),
+# you only need to trust the proxy's CA — no client certificate is required.
+
+proxy_client = Anthropic(
+    http_client=DefaultHttpxClient(
+        verify="/path/to/corporate-ca-bundle.crt",
+    ),
+)
+
+message = proxy_client.messages.create(
+    model="claude-sonnet-4-5-20250929",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello through the corporate proxy!"}],
+)
+print(message.content)


### PR DESCRIPTION
Closes #1279

### What

Adds `examples/mtls.py` demonstrating how to use the SDK with mTLS client certificate authentication and custom CA bundles.

### Why

mTLS is becoming an industry standard for API access in regulated environments. [OpenAI recently launched an mTLS beta program](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program) for their API, and enterprise users are increasingly expecting the same capability from Anthropic deployments.

Common use cases include:
- **mTLS client certificates** for per-user attribution in shared API gateway deployments
- **Custom CA bundles** for corporate TLS inspection proxies (Zscaler, Netskope, etc.)

This is a recurring question across the ecosystem:
- langchain-ai/langchain#35843 — mTLS support for Anthropic in LangChain (open, active)
- #923 — proxy env variables not applied (fixed in v0.54.0, shows enterprise proxy usage is a real pain point)

The underlying SDK already supports this via the `http_client` parameter, but there is no example or documentation showing the pattern.

### How

Uses the existing `http_client` parameter with `DefaultHttpxClient` / `DefaultAsyncHttpxClient`. **No SDK code changes required** — this is purely documentation of existing capability.

The example builds an `ssl.SSLContext` with the CA bundle and client certificate, then passes it as `verify=` to `DefaultHttpxClient`. This preserves all SDK defaults (connection limits, timeouts, TCP keepalive, proxy detection) while enabling mTLS:

```python
import ssl
from anthropic import Anthropic, DefaultHttpxClient

ctx = ssl.create_default_context()
ctx.load_verify_locations("/path/to/ca-bundle.crt")
ctx.load_cert_chain("/path/to/client.crt", "/path/to/client.key")

client = Anthropic(
    http_client=DefaultHttpxClient(verify=ctx),
)
```

Covers three scenarios:
1. mTLS with sync client (`Anthropic` + `DefaultHttpxClient`)
2. mTLS with async client (`AsyncAnthropic` + `DefaultAsyncHttpxClient`)
3. Corporate proxy custom CA bundle (no client cert)

### Testing

Verified locally against an nginx mTLS reverse proxy with self-signed certificates. The TLS handshake completes successfully and the SDK correctly processes the upstream response.