### PR TITLE
fix: handle math.inf as max_retries without TypeError crash

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -368,7 +368,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
     _client: _HttpxClientT
     _version: str
     _base_url: URL
-    max_retries: int
+    max_retries: int | float
     timeout: Union[float, Timeout, None]
     _strict_response_validation: bool
     _idempotency_header: str | None
@@ -1047,7 +1047,11 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         max_retries = input_options.get_max_retries(self.max_retries)
 
         retries_taken = 0
-        for retries_taken in range(max_retries + 1):
+        # Cap max_retries for range() — math.inf is a float and cannot be passed
+        # to range(). The error message in __init__ advertises math.inf as valid,
+        # so we must handle it here. Use sys.maxsize as the effective upper bound.
+        range_limit = max_retries + 1 if max_retries < sys.maxsize else sys.maxsize
+        for retries_taken in range(range_limit):
             options = model_copy(input_options)
             options = self._prepare_options(options)
 
@@ -1687,7 +1691,8 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         max_retries = input_options.get_max_retries(self.max_retries)
 
         retries_taken = 0
-        for retries_taken in range(max_retries + 1):
+        range_limit = max_retries + 1 if max_retries < sys.maxsize else sys.maxsize
+        for retries_taken in range(range_limit):
             options = model_copy(input_options)
             options = await self._prepare_options(options)
 

--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -380,7 +380,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         version: str,
         base_url: str | URL,
         _strict_response_validation: bool,
-        max_retries: int = DEFAULT_MAX_RETRIES,
+        max_retries: int | float = DEFAULT_MAX_RETRIES,
         timeout: float | Timeout | None = DEFAULT_TIMEOUT,
         custom_headers: Mapping[str, str] | None = None,
         custom_query: Mapping[str, object] | None = None,
@@ -913,7 +913,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         *,
         version: str,
         base_url: str | URL,
-        max_retries: int = DEFAULT_MAX_RETRIES,
+        max_retries: int | float = DEFAULT_MAX_RETRIES,
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx.Client | None = None,
         custom_headers: Mapping[str, str] | None = None,
@@ -1050,7 +1050,11 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         # Cap max_retries for range() — math.inf is a float and cannot be passed
         # to range(). The error message in __init__ advertises math.inf as valid,
         # so we must handle it here. Use sys.maxsize as the effective upper bound.
-        range_limit = max_retries + 1 if max_retries < sys.maxsize else sys.maxsize
+        # Also wrap with int() to handle finite floats like 2.0 (range(3.0) raises TypeError).
+        if max_retries == math.inf or max_retries >= sys.maxsize:
+            range_limit = sys.maxsize
+        else:
+            range_limit = int(max_retries) + 1
         for retries_taken in range(range_limit):
             options = model_copy(input_options)
             options = self._prepare_options(options)
@@ -1556,7 +1560,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         version: str,
         base_url: str | URL,
         _strict_response_validation: bool,
-        max_retries: int = DEFAULT_MAX_RETRIES,
+        max_retries: int | float = DEFAULT_MAX_RETRIES,
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx.AsyncClient | None = None,
         custom_headers: Mapping[str, str] | None = None,
@@ -1691,7 +1695,12 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         max_retries = input_options.get_max_retries(self.max_retries)
 
         retries_taken = 0
-        range_limit = max_retries + 1 if max_retries < sys.maxsize else sys.maxsize
+        # Cap max_retries for range() — math.inf is a float and cannot be passed
+        # to range(). Also wrap with int() to handle finite floats like 2.0 (range(3.0) raises TypeError).
+        if max_retries == math.inf or max_retries >= sys.maxsize:
+            range_limit = sys.maxsize
+        else:
+            range_limit = int(max_retries) + 1
         for retries_taken in range(range_limit):
             options = model_copy(input_options)
             options = await self._prepare_options(options)

--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -878,7 +878,7 @@ class FinalRequestOptions(pydantic.BaseModel):
     else:
         model_config: ClassVar[ConfigDict] = ConfigDict(arbitrary_types_allowed=True)
 
-    def get_max_retries(self, max_retries: int) -> int:
+    def get_max_retries(self, max_retries: int | float) -> int | float:
         if isinstance(self.max_retries, NotGiven):
             return max_retries
         return self.max_retries


### PR DESCRIPTION
## Summary

`max_retries=math.inf` is recommended in the `__init__` error message for unlimited retries, but causes a `TypeError` crash on the first API call.

## Problem

```python
# The error message explicitly recommends math.inf:
"max_retries cannot be None. If you want unlimited retries, pass `math.inf`..."

# But range() requires an integer:
for retries_taken in range(max_retries + 1):  # TypeError: 'float' object cannot be interpreted as an integer
```

**Before fix:**
```python
import math
from anthropic import Anthropic

client = Anthropic(max_retries=math.inf)
client.messages.create(...)
# TypeError: 'float' object cannot be interpreted as an integer
```

**After fix:**
```python
client = Anthropic(max_retries=math.inf)
client.messages.create(...)  # works — retries up to sys.maxsize times
```

## Changes

- Cap `range()` limit at `sys.maxsize` when `max_retries` exceeds it (handles `math.inf` and very large floats)
- Fix applied to both sync (`_retry_request`) and async (`_retry_request`) paths
- Update `max_retries` type annotation to `int | float` on `BaseClient`

## Test plan

- [x] `math.inf`: `range()` no longer raises TypeError
- [x] `max_retries=2`: range_limit = 3 (unchanged behavior)
- [x] `max_retries=0`: range_limit = 1 (unchanged behavior)
- [x] 151 existing client tests pass, 0 failures