### PR TITLE
fix(bedrock): correctly infer region from AWS_DEFAULT_REGION and explicit aws_profile arg

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -67,17 +67,24 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     return options
 
 
-def _infer_region() -> str:
+def _infer_region(aws_profile: str | None = None) -> str:
     """
     Infer the AWS region from the environment variables or
     from the boto3 session if available.
+
+    Resolution order:
+    1. ``AWS_REGION`` environment variable (legacy, non-standard)
+    2. ``AWS_DEFAULT_REGION`` environment variable (boto3/botocore standard)
+    3. Region from the boto3 session (respects ``aws_profile``, ``AWS_PROFILE``,
+       and the region set in ``~/.aws/config``)
+    4. Fall back to ``us-east-1`` with a warning
     """
-    aws_region = os.environ.get("AWS_REGION")
+    aws_region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
     if aws_region is None:
         try:
             import boto3
 
-            session = boto3.Session()
+            session = boto3.Session(profile_name=aws_profile)
             if session.region_name:
                 aws_region = session.region_name
         except ImportError:
@@ -161,8 +168,8 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
         self.aws_profile = aws_profile
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
 
         self.aws_session_token = aws_session_token
 
@@ -303,8 +310,8 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
         self.aws_profile = aws_profile
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
 
         self.aws_session_token = aws_session_token
 

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -195,3 +195,44 @@ def test_region_infer_from_specified_profile(
     client = AnthropicBedrock()
 
     assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]
+
+
+def test_region_infer_from_aws_default_region_env(monkeypatch: t.Any) -> None:
+    """AWS_DEFAULT_REGION is the standard env var used by botocore/boto3."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-central-1")
+    client = AnthropicBedrock()
+    assert client.aws_region == "eu-central-1"
+
+
+def test_aws_region_env_takes_precedence_over_aws_default_region(monkeypatch: t.Any) -> None:
+    """AWS_REGION (legacy) takes precedence over AWS_DEFAULT_REGION when both are set."""
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-central-1")
+    client = AnthropicBedrock()
+    assert client.aws_region == "us-west-2"
+
+
+@pytest.mark.parametrize(
+    "profiles, aws_profile",
+    [
+        pytest.param(
+            [{"name": "default", "region": "us-east-2"}, {"name": "staging", "region": "ap-northeast-1"}],
+            "staging",
+            id="non-default profile passed explicitly",
+        ),
+    ],
+)
+def test_region_infer_from_explicit_aws_profile_arg(
+    mock_aws_config: None,  # noqa: ARG001
+    profiles: t.List[AwsConfigProfile],
+    aws_profile: str,
+    monkeypatch: t.Any,
+) -> None:
+    """When aws_profile is passed directly to the client, its region should be used."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    client = AnthropicBedrock(aws_profile=aws_profile)
+    expected_region = next(p for p in profiles if p["name"] == aws_profile)["region"]
+    assert client.aws_region == expected_region


### PR DESCRIPTION
## Summary

Fixes #892.

`_infer_region()` had two related gaps that could cause `AnthropicBedrock()` to build its base URL for the wrong region:

1. **`AWS_DEFAULT_REGION` not checked directly.** `AWS_DEFAULT_REGION` is the standard env var boto3/botocore uses for region configuration. The function only checked `AWS_REGION` before falling through to `boto3.Session()`. Users relying on `AWS_DEFAULT_REGION` would get the correct answer (boto3 picks it up), but the precedence and intent were not explicit.

2. **`aws_profile` not forwarded to boto3 during region inference.** `_infer_region()` was called with no arguments and created a plain `boto3.Session()`, ignoring any `aws_profile` passed to the client. This meant `AnthropicBedrock(aws_profile="us-west-2-profile")` would resolve the region from the default profile (or env), build `bedrock-runtime.<wrong-region>.amazonaws.com` as the base URL, and then sign requests using the named profile — resulting in a cross-region mismatch that breaks inference.

## Changes

- `_infer_region(aws_profile=None)` now checks `AWS_DEFAULT_REGION` after `AWS_REGION`.
- `_infer_region` accepts and forwards `aws_profile` to `boto3.Session(profile_name=...)`.
- Both `AnthropicBedrock.__init__` and `AsyncAnthropicBedrock.__init__` assign `self.aws_profile` before calling `_infer_region(aws_profile)` so the profile is available at inference time.

## Tests

Three new tests in `tests/lib/test_bedrock.py`:

- `test_region_infer_from_aws_default_region_env` — verifies `AWS_DEFAULT_REGION` is picked up.
- `test_aws_region_env_takes_precedence_over_aws_default_region` — verifies `AWS_REGION` wins when both are set.
- `test_region_infer_from_explicit_aws_profile_arg` — verifies that `aws_profile=` passed directly to the client is used when inferring region, even when `AWS_PROFILE` is not set in the environment.

All 9 tests pass.