### PR TITLE
fix: update BetaAsyncAbstractMemoryTool docstring for async usage

### DIFF
--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -157,34 +157,43 @@ class BetaAbstractMemoryTool(BetaBuiltinFunctionTool):
 
 
 class BetaAsyncAbstractMemoryTool(BetaAsyncBuiltinFunctionTool):
-    """Abstract base class for memory tool implementations.
+    """Abstract base class for async memory tool implementations.
 
-    This class provides the interface for implementing a custom memory backend for Claude.
+    This class provides the interface for implementing a custom async memory backend for Claude.
 
     Subclass this to create your own memory storage solution (e.g., database, cloud storage, encrypted files, etc.).
 
     Example usage:
 
     ```py
-    class MyMemoryTool(BetaAbstractMemoryTool):
-        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+    import asyncio
+
+    from anthropic import AsyncAnthropic
+
+
+    class MyMemoryTool(BetaAsyncAbstractMemoryTool):
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             ...
             return "view result"
 
-        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
             ...
             return "created successfully"
 
         # ... implement other abstract methods
 
 
-    client = Anthropic()
-    memory_tool = MyMemoryTool()
-    message = client.beta.messages.run_tools(
-        model="claude-sonnet-4-5",
-        messages=[{"role": "user", "content": "Remember that I like coffee"}],
-        tools=[memory_tool],
-    ).until_done()
+    async def main() -> None:
+        client = AsyncAnthropic()
+        memory_tool = MyMemoryTool()
+        message = await client.beta.messages.run_tools(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Remember that I like coffee"}],
+            tools=[memory_tool],
+        ).until_done()
+
+
+    asyncio.run(main())
     ```
     """
 


### PR DESCRIPTION
## Summary

The `BetaAsyncAbstractMemoryTool` docstring example was copy-pasted from the sync `BetaAbstractMemoryTool` without being updated for async usage. Following the example verbatim raises `TypeError` at instantiation time.

### Changes
- Use `BetaAsyncAbstractMemoryTool` as base class (not `BetaAbstractMemoryTool`)
- Add `async` keyword to method definitions
- Replace `Anthropic()` with `AsyncAnthropic()`
- Wrap usage in `async def main()` / `asyncio.run(main())`

Fixes #1290