### PR TITLE
fix: add try/except for tool JSON parsing in non-beta streaming path

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,12 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":


### PR DESCRIPTION
## Summary

The beta streaming path (`_beta_messages.py`) already wraps `from_json()` in a `try/except` that provides a helpful error message including the raw JSON bytes. The non-beta path (`_messages.py`) was missing this protection, causing a bare `ValueError` with no context when the model emits malformed partial JSON during tool use streaming.

This PR ports the same error handling from the beta path to the non-beta path.

### Before
```
ValueError: invalid JSON
```

### After
```
ValueError: Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: invalid JSON. JSON: {"name": "get_weather", "input": {"loc
```

### Changes
- `src/anthropic/lib/streaming/_messages.py` (line 480): wrap `from_json()` call in `try/except ValueError`, matching the existing pattern in `_beta_messages.py` (line 500)

Fixes #1265