### PR TITLE
fix: add helpful error message for malformed tool JSON in non-beta streaming path

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,12 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":


### PR DESCRIPTION
## Summary

- Wraps the bare `from_json()` call in the non-beta streaming accumulator (`_messages.py`) with a `try-except ValueError` that produces a clear, actionable error message — matching the existing behavior in the beta path (`_beta_messages.py`)

## Problem

When using `client.messages.stream()` with tools, if the model emits malformed JSON during an `input_json_delta` event, the user gets a raw internal parser error with no context:

```
ValueError: expected ident at line 1 column 11
```

The beta path (`_beta_messages.py`) already wraps the same call and produces a helpful message:

```
ValueError: Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: expected ident at line 1 column 11. JSON: {"city": INVALID_VALUE}
```

The non-beta path was simply missing the same `try-except`.

## Changes

- `src/anthropic/lib/streaming/_messages.py`: Added `try-except ValueError` around the `from_json(json_buf, partial_mode=True)` call in `accumulate_event()`, re-raising with a descriptive message that includes the original error and the raw JSON that failed to parse

## Test plan

- [x] All 21 existing streaming tests pass (`tests/test_streaming.py`)
- [x] All 25 streaming lib tests pass (`tests/lib/streaming/`)
- [x] Zero behavior change for valid JSON — the try-except only activates on malformed input
- [x] Verified the error message format matches the beta path exactly

Fixes #1265