### PR TITLE
fix: add helpful error message for malformed tool JSON in non-beta streaming

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,14 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. "
+                            f"Please retry your request or adjust your prompt. "
+                            f"Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":


### PR DESCRIPTION
## Summary

The beta streaming path (`_beta_messages.py`) wraps `from_json()` with a try-except that provides an actionable error message when the model emits malformed JSON during `input_json_delta` events. The non-beta path (`_messages.py`) was missing this wrapper.

**Before:** Users see a raw `ValueError` with no context:
```
ValueError: expected ident at line 1 column 11
```

**After:** Users see a clear message with the raw JSON for debugging:
```
ValueError: Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: expected ident at line 1 column 11. JSON: {"name": ...}
```

## Changes

- `src/anthropic/lib/streaming/_messages.py`: Added try-except around `from_json()` matching the beta path pattern

## Test plan

- [x] Verified non-beta path now raises `ValueError` with context message
- [x] Verified existing streaming tests still pass
- [x] Matches exact pattern from `_beta_messages.py` line 508-514

Fixes #1265