### PR TITLE
fix: correct typo "th" to "the" in StreamAlreadyConsumed error message

### DIFF
--- a/src/anthropic/_response.py
+++ b/src/anthropic/_response.py
@@ -611,7 +611,7 @@ class StreamAlreadyConsumed(AnthropicError):
     been streamed.
 
     This can happen if you use a method like `.iter_lines()` and then attempt
-    to read th entire response body afterwards, e.g.
+    to read the entire response body afterwards, e.g.
 
     ```py
     response = await client.post(...)


### PR DESCRIPTION
## Summary
- Fixes a typo in the `StreamAlreadyConsumed` error message: "read th entire" → "read the entire"

## Changes
- `src/anthropic/_response.py`: Line 614 typo correction

## Context
- Documentation-only fix, no behavioral changes
- Single character addition