### PR TITLE
fix(bedrock,vertex): add missing 413 and 529 status error handling

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -114,6 +114,9 @@ class BaseBedrockClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         if response.status_code == 409:
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
+        if response.status_code == 413:
+            return _exceptions.RequestTooLargeError(err_msg, response=response, body=body)
+
         if response.status_code == 422:
             return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
 
@@ -122,6 +125,9 @@ class BaseBedrockClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
 
         if response.status_code == 503:
             return _exceptions.ServiceUnavailableError(err_msg, response=response, body=body)
+
+        if response.status_code == 529:
+            return _exceptions.OverloadedError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)

--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -70,6 +70,9 @@ class BaseVertexClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         if response.status_code == 409:
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
+        if response.status_code == 413:
+            return _exceptions.RequestTooLargeError(err_msg, response=response, body=body)
+
         if response.status_code == 422:
             return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
 
@@ -81,6 +84,9 @@ class BaseVertexClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
 
         if response.status_code == 504:
             return _exceptions.DeadlineExceededError(err_msg, response=response, body=body)
+
+        if response.status_code == 529:
+            return _exceptions.OverloadedError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -9,6 +9,19 @@ import pytest
 from respx import MockRouter
 
 from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
+from anthropic._exceptions import (
+    BadRequestError,
+    AuthenticationError,
+    PermissionDeniedError,
+    NotFoundError,
+    ConflictError,
+    RequestTooLargeError,
+    UnprocessableEntityError,
+    RateLimitError,
+    ServiceUnavailableError,
+    OverloadedError,
+    InternalServerError,
+)
 
 sync_client = AnthropicBedrock(
     aws_region="us-east-1",
@@ -195,3 +208,25 @@ def test_region_infer_from_specified_profile(
     client = AnthropicBedrock()
 
     assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]
+
+
+@pytest.mark.parametrize(
+    "status_code, expected_error",
+    [
+        (400, BadRequestError),
+        (401, AuthenticationError),
+        (403, PermissionDeniedError),
+        (404, NotFoundError),
+        (409, ConflictError),
+        (413, RequestTooLargeError),
+        (422, UnprocessableEntityError),
+        (429, RateLimitError),
+        (500, InternalServerError),
+        (503, ServiceUnavailableError),
+        (529, OverloadedError),
+    ],
+)
+def test_make_status_error(status_code: int, expected_error: type) -> None:
+    response = httpx.Response(status_code, request=httpx.Request("GET", "/"))
+    err = sync_client._make_status_error("msg", body=None, response=response)
+    assert type(err) is expected_error

--- a/tests/lib/test_vertex.py
+++ b/tests/lib/test_vertex.py
@@ -9,6 +9,20 @@ import pytest
 from respx import MockRouter
 
 from anthropic import AnthropicVertex, AsyncAnthropicVertex
+from anthropic._exceptions import (
+    BadRequestError,
+    AuthenticationError,
+    PermissionDeniedError,
+    NotFoundError,
+    ConflictError,
+    RequestTooLargeError,
+    UnprocessableEntityError,
+    RateLimitError,
+    ServiceUnavailableError,
+    DeadlineExceededError,
+    OverloadedError,
+    InternalServerError,
+)
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -276,3 +290,29 @@ class TestAsyncAnthropicVertex:
             base_url="https://test.googleapis.com/v1",
         )
         assert str(client.base_url).rstrip("/") == "https://test.googleapis.com/v1"
+
+
+vertex_client = AnthropicVertex(region="region", project_id="project", access_token="my-access-token")
+
+
+@pytest.mark.parametrize(
+    "status_code, expected_error",
+    [
+        (400, BadRequestError),
+        (401, AuthenticationError),
+        (403, PermissionDeniedError),
+        (404, NotFoundError),
+        (409, ConflictError),
+        (413, RequestTooLargeError),
+        (422, UnprocessableEntityError),
+        (429, RateLimitError),
+        (500, InternalServerError),
+        (503, ServiceUnavailableError),
+        (504, DeadlineExceededError),
+        (529, OverloadedError),
+    ],
+)
+def test_make_status_error(status_code: int, expected_error: type) -> None:
+    response = httpx.Response(status_code, request=httpx.Request("GET", "/"))
+    err = vertex_client._make_status_error("msg", body=None, response=response)
+    assert type(err) is expected_error


### PR DESCRIPTION
The `BaseBedrockClient` and `BaseVertexClient` `_make_status_error` methods are missing handlers for HTTP 413 (`RequestTooLargeError`) and 529 (`OverloadedError`). These were added to the main `Anthropic`/`AsyncAnthropic` clients in #1244, but the Bedrock and Vertex variants were not updated.

**Before this change:**
- `AnthropicBedrock` receiving a 413 response returns a generic `APIStatusError` instead of `RequestTooLargeError`
- `AnthropicBedrock` receiving a 529 response returns `InternalServerError` instead of `OverloadedError`
- Same for `AnthropicVertex` (and their async counterparts)

**After this change:**
All three client families (`Anthropic`, `AnthropicBedrock`, `AnthropicVertex`) return the same typed exception for every status code.

### Changes

- `src/anthropic/lib/bedrock/_client.py` — add 413 and 529 handlers to `BaseBedrockClient._make_status_error`
- `src/anthropic/lib/vertex/_client.py` — add 413 and 529 handlers to `BaseVertexClient._make_status_error`
- `tests/lib/test_bedrock.py` — add parametrized `test_make_status_error` covering all 11 status codes
- `tests/lib/test_vertex.py` — add parametrized `test_make_status_error` covering all 12 status codes (including Vertex-specific 504)

### Test plan

- [x] All 23 new parametrized tests pass
- [x] Existing `test_make_status_error_sync_async_parity` in `test_client.py` continues to pass
- [x] No changes to generated code — both files are in `lib/` (hand-maintained)