### PR TITLE
fix: improve error message for malformed tool use JSON in streaming

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,12 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":


### PR DESCRIPTION
## Summary
- Add try-except error handling around `from_json()` in `_messages.py` to match the existing pattern in `_beta_messages.py`
- When the model emits malformed JSON for tool use input during streaming, the error now includes the raw JSON content and guidance instead of a bare deserialization traceback

## Problem
The non-beta streaming path (`client.messages.stream()`) crashes with an unhelpful error when the model produces invalid JSON for tool input. The beta path already handles this gracefully with a descriptive message. See #1265.

## Test plan
- [ ] Verify normal streaming tool use still works
- [ ] Verify malformed JSON produces the improved error message
- [ ] Verify behavior matches beta path

Fixes #1265