### PR TITLE
fix(bedrock): improve AWS region detection

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -72,8 +72,8 @@ def _infer_region() -> str:
     Infer the AWS region from the environment variables or
     from the boto3 session if available.
     """
-    aws_region = os.environ.get("AWS_REGION")
-    if aws_region is None:
+    aws_region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    if not aws_region:
         try:
             import boto3
 
@@ -83,7 +83,7 @@ def _infer_region() -> str:
         except ImportError:
             pass
 
-    if aws_region is None:
+    if not aws_region:
         log.warning("No AWS region specified, defaulting to us-east-1")
         aws_region = "us-east-1"  # fall back to legacy behavior
 

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -195,3 +195,36 @@ def test_region_infer_from_specified_profile(
     client = AnthropicBedrock()
 
     assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]
+
+
+def test_region_infer_from_aws_default_region(
+    monkeypatch: t.Any,
+) -> None:
+    """Test that AWS_DEFAULT_REGION environment variable is respected."""
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+    # Ensure AWS_REGION is not set
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    client = AnthropicBedrock()
+    assert client.aws_region == "eu-west-1"
+
+
+def test_region_aws_region_takes_precedence_over_aws_default_region(
+    monkeypatch: t.Any,
+) -> None:
+    """Test that AWS_REGION takes precedence over AWS_DEFAULT_REGION."""
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+    client = AnthropicBedrock()
+    assert client.aws_region == "us-west-2"
+
+
+def test_region_infer_from_profile_when_aws_region_is_empty_string(
+    mock_aws_config: None,  # noqa: ARG001
+    profiles: t.List[AwsConfigProfile],
+    monkeypatch: t.Any,
+) -> None:
+    """Test that empty AWS_REGION falls back to boto3/config file."""
+    monkeypatch.setenv("AWS_REGION", "")
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    client = AnthropicBedrock()
+    assert client.aws_region == profiles[0]["region"]


### PR DESCRIPTION
## Problem

The Bedrock client was failing to detect AWS region correctly in certain scenarios:

1. When `AWS_DEFAULT_REGION` was set (instead of `AWS_REGION`), it was ignored
2. When `AWS_REGION` was set to an empty string, the code didn't fall back to boto3/config file
3. Users with `AWS_PROFILE` pointing to a profile with a region in `~/.aws/config` would get `us-east-1` instead of their configured region

This caused cross-region inference to fail with HTTP 403 errors when credentials were generated for a different region than the one being used.

## Solution

Updated `_infer_region()` to:
- Check both `AWS_REGION` and `AWS_DEFAULT_REGION` environment variables
- Treat empty strings as unset (falsy), allowing fallback to boto3/config file
- Maintain backward compatibility with existing behavior (default to `us-east-1` if nothing else works)

## Changes

- Modified `src/anthropic/lib/bedrock/_client.py` - Updated `_infer_region()` function
- Added tests for `AWS_DEFAULT_REGION` support and empty string handling

Fixes #892