### PR TITLE
fix: update BetaAsyncAbstractMemoryTool docstring to use async example

### DIFF
--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -166,25 +166,33 @@ class BetaAsyncAbstractMemoryTool(BetaAsyncBuiltinFunctionTool):
     Example usage:
 
     ```py
-    class MyMemoryTool(BetaAbstractMemoryTool):
-        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+    import asyncio
+    from anthropic import AsyncAnthropic
+
+
+    class MyMemoryTool(BetaAsyncAbstractMemoryTool):
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             ...
             return "view result"
 
-        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
             ...
             return "created successfully"
 
         # ... implement other abstract methods
 
 
-    client = Anthropic()
-    memory_tool = MyMemoryTool()
-    message = client.beta.messages.run_tools(
-        model="claude-sonnet-4-5",
-        messages=[{"role": "user", "content": "Remember that I like coffee"}],
-        tools=[memory_tool],
-    ).until_done()
+    async def main():
+        client = AsyncAnthropic()
+        memory_tool = MyMemoryTool()
+        message = await client.beta.messages.run_tools(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Remember that I like coffee"}],
+            tools=[memory_tool],
+        ).until_done()
+
+
+    asyncio.run(main())
     ```
     """
 


### PR DESCRIPTION
## Summary

The `BetaAsyncAbstractMemoryTool` docstring example was copy-pasted from the synchronous `BetaAbstractMemoryTool` without being updated for async usage. Following the example verbatim raises `TypeError` at instantiation time.

### Changes

- Use `BetaAsyncAbstractMemoryTool` as the base class (was `BetaAbstractMemoryTool`)
- Add `async def` to method definitions (was `def`)
- Replace `Anthropic()` with `AsyncAnthropic()`
- Wrap usage in `async def main()` / `asyncio.run(main())`

### Before (broken)

```python
class MyMemoryTool(BetaAbstractMemoryTool):  # wrong base class
    def view(self, command: ...):             # missing async
        ...
client = Anthropic()                          # sync client
```

### After (fixed)

```python
class MyMemoryTool(BetaAsyncAbstractMemoryTool):
    async def view(self, command: ...):
        ...
client = AsyncAnthropic()
await client.beta.messages.run_tools(...)
```

Fixes #1290