### PR TITLE
fix: correct BetaAsyncAbstractMemoryTool docstring example

### DIFF
--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -53,25 +53,26 @@ class BetaAbstractMemoryTool(BetaBuiltinFunctionTool):
     Example usage:
 
     ```py
-    class MyMemoryTool(BetaAbstractMemoryTool):
-        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+    class MyMemoryTool(BetaAsyncAbstractMemoryTool):
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             ...
             return "view result"
 
-        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
             ...
             return "created successfully"
 
         # ... implement other abstract methods
 
 
-    client = Anthropic()
-    memory_tool = MyMemoryTool()
-    message = client.beta.messages.run_tools(
-        model="claude-sonnet-4-5",
-        messages=[{"role": "user", "content": "Remember that I like coffee"}],
-        tools=[memory_tool],
-    ).until_done()
+    async def main():
+        client = AsyncAnthropic()
+        memory_tool = MyMemoryTool()
+        message = await client.beta.messages.run_tools(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Remember that I like coffee"}],
+            tools=[memory_tool],
+        ).until_done()
     ```
     """
 
@@ -166,25 +167,26 @@ class BetaAsyncAbstractMemoryTool(BetaAsyncBuiltinFunctionTool):
     Example usage:
 
     ```py
-    class MyMemoryTool(BetaAbstractMemoryTool):
-        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+    class MyMemoryTool(BetaAsyncAbstractMemoryTool):
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             ...
             return "view result"
 
-        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
             ...
             return "created successfully"
 
         # ... implement other abstract methods
 
 
-    client = Anthropic()
-    memory_tool = MyMemoryTool()
-    message = client.beta.messages.run_tools(
-        model="claude-sonnet-4-5",
-        messages=[{"role": "user", "content": "Remember that I like coffee"}],
-        tools=[memory_tool],
-    ).until_done()
+    async def main():
+        client = AsyncAnthropic()
+        memory_tool = MyMemoryTool()
+        message = await client.beta.messages.run_tools(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Remember that I like coffee"}],
+            tools=[memory_tool],
+        ).until_done()
     ```
     """
 


### PR DESCRIPTION
The docstring for `BetaAsyncAbstractMemoryTool` was copy-pasted from the sync version and never updated. Three issues fixed:

- Base class in example changed from `BetaAbstractMemoryTool` to `BetaAsyncAbstractMemoryTool`
- Methods updated to `async def`
- Client updated to `AsyncAnthropic` with `await`

Fixes #1290