### PR TITLE
fix(files): check is_tuple_t before is_file_content to fix PathLike inside file tuples

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -61,15 +61,18 @@ def to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles | None:
 
 
 def _transform_file(file: FileTypes) -> HttpxFileTypes:
+    # Check tuple FIRST: is_file_content() also returns True for tuples, so placing
+    # the tuple branch second makes it unreachable — PathLike values inside a tuple
+    # would never be read.  See https://github.com/anthropics/anthropic-sdk-python/issues/1318
+    if is_tuple_t(file):
+        return (file[0], read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = pathlib.Path(file)
             return (path.name, path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 
@@ -103,15 +106,18 @@ async def async_to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles 
 
 
 async def _async_transform_file(file: FileTypes) -> HttpxFileTypes:
+    # Check tuple FIRST: is_file_content() also returns True for tuples, so placing
+    # the tuple branch second makes it unreachable — PathLike values inside a tuple
+    # would never be read.  See https://github.com/anthropics/anthropic-sdk-python/issues/1318
+    if is_tuple_t(file):
+        return (file[0], await async_read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = anyio.Path(file)
             return (path.name, await path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], await async_read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 


### PR DESCRIPTION
## Summary

Fixes #1318 — `client.beta.files.upload` crashes when a `PathLike` is passed as the second element of a file tuple (e.g. `("filename.txt", Path("foo.txt"), "text/plain")`).

**Root cause:** `is_file_content()` returns `True` for any `tuple`, so the `is_tuple_t` branch in both `_transform_file` and `_async_transform_file` was **unreachable**. A file tuple hit the `is_file_content` branch first and was returned unchanged — the `PathLike` inside was never read via `read_file_content`.

```python
# Before — is_file_content catches tuples, is_tuple_t is unreachable
def _transform_file(file: FileTypes) -> HttpxFileTypes:
    if is_file_content(file):   # True for tuples → returns tuple as-is
        ...
        return file              # PathLike inside tuple never read

    if is_tuple_t(file):        # UNREACHABLE for tuples
        return (file[0], read_file_content(file[1]), *file[2:])
```

**Fix:** Check `is_tuple_t` first in both the sync and async paths, so tuples with `PathLike` second elements are correctly read before being forwarded to httpx.

```python
# After — tuple branch runs first
def _transform_file(file: FileTypes) -> HttpxFileTypes:
    if is_tuple_t(file):
        return (file[0], read_file_content(file[1]), *file[2:])  # PathLike read ✓

    if is_file_content(file):
        if isinstance(file, os.PathLike):
            ...
        return file
```

Same fix applied to `_async_transform_file` with `async_read_file_content`.

## Test plan

- [ ] `("filename.txt", Path("foo.txt"), "text/plain")` — PathLike read, no crash
- [ ] `("filename.txt", Path("foo.txt"))` — 2-tuple variant works
- [ ] `Path("foo.txt")` bare PathLike — still works (goes through `is_file_content` branch)
- [ ] `("filename.txt", b"bytes", "text/plain")` — bytes tuple still works
- [ ] Run `pytest tests/test_files.py`