### PR TITLE
fix(streaming): add helpful error for malformed tool JSON in non-beta path

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,12 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":


### PR DESCRIPTION
Fixes #1265.

## What changed

`src/anthropic/lib/streaming/_messages.py` had a bare `from_json()` call with no error handling on the `input_json_delta` path. When the model emits malformed JSON during a streaming tool call, users got a raw `jiter` `ValueError` with no context:

```
ValueError: expected ident at line 1 column 11
```

The beta path (`_beta_messages.py`) already wraps the identical call with a `try-except` that produces an actionable message. This PR adds the same guard to the non-beta path so both paths behave consistently.

## After this fix

```
ValueError: Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: expected ident at line 1 column 11. JSON: {"city": INVALID_VALUE}
```

## Diff

6-line change, no behavior change for valid JSON. The error message text is identical to the existing beta path.