### PR TITLE
fix(files): resolve PathLike inside FileTypes tuples

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -25,16 +25,14 @@ def is_base64_file_input(obj: object) -> TypeGuard[Base64FileInput]:
 
 
 def is_file_content(obj: object) -> TypeGuard[FileContent]:
-    return (
-        isinstance(obj, bytes) or isinstance(obj, tuple) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
-    )
+    return isinstance(obj, bytes) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
 
 
 def assert_is_file_content(obj: object, *, key: str | None = None) -> None:
     if not is_file_content(obj):
         prefix = f"Expected entry at `{key}`" if key is not None else f"Expected file input `{obj!r}`"
         raise RuntimeError(
-            f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://github.com/anthropics/anthropic-sdk-python/tree/main#file-uploads"
+            f"{prefix} to be bytes, an io.IOBase instance, or a PathLike but received {type(obj)} instead. See https://github.com/anthropics/anthropic-sdk-python/tree/main#file-uploads"
         ) from None
 
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -42,6 +42,17 @@ async def test_async_tuple_input() -> None:
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
 
 
+def test_pathlike_in_tuple() -> None:
+    result = to_httpx_files({"file": ("custom_name.txt", readme_path, "text/plain")})
+    assert result == IsDict({"file": IsTuple("custom_name.txt", IsBytes(), "text/plain")})
+
+
+@pytest.mark.asyncio
+async def test_async_pathlike_in_tuple() -> None:
+    result = await async_to_httpx_files({"file": ("custom_name.txt", readme_path, "text/plain")})
+    assert result == IsDict({"file": IsTuple("custom_name.txt", IsBytes(), "text/plain")})
+
+
 def test_string_not_allowed() -> None:
     with pytest.raises(TypeError, match="Expected file types input to be a FileContent type or to be a tuple"):
         to_httpx_files(


### PR DESCRIPTION
## What

Fixes #1318.

`is_file_content()` in `_files.py` included `isinstance(obj, tuple)` in its check, but `FileContent = Union[IO[bytes], bytes, PathLike[str]]` — tuples are **not** file content, they are `FileTypes` variants (the `(name, content, content_type[, headers])` forms).

This meant the `is_tuple_t(file)` branch in `_transform_file` and `_async_transform_file` was unreachable for any tuple input. Instead of calling `read_file_content(file[1])` on the inner element, both functions returned the tuple unchanged. When that inner element was a `PathLike`, httpx received it as-is and failed.

## Why it worked before (sort of)

Passing `("name", b"bytes")` as a `FileTypes` value still produced a usable result because httpx accepts raw tuples with bytes. But `("name", Path("foo"), "text/plain")` failed because httpx does not read `PathLike` objects — and the type annotation in `_types.py` explicitly promises `PathLike` is a valid `FileContent`.

## Fix

Remove `isinstance(obj, tuple)` from `is_file_content`. Tuples now fall through to the `is_tuple_t` branch and get processed correctly — `read_file_content` / `async_read_file_content` resolves the `PathLike` to bytes before passing to httpx.

Also corrects the `assert_is_file_content` error message, which listed "or a tuple" as a valid `FileContent` form.

## Tests

Added `test_pathlike_in_tuple` and `test_async_pathlike_in_tuple` which exercise the previously broken path. All existing tests pass.

```python
# was silently broken
to_httpx_files({"file": ("report.pdf", Path("report.pdf"), "application/pdf")})
# now works correctly
```