### PR TITLE
fix: correct async docstring example in BetaAsyncAbstractMemoryTool

### DIFF
--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -166,30 +166,30 @@ class BetaAbstractMemoryTool(BetaBuiltinFunctionTool):
 
 
 class BetaAsyncAbstractMemoryTool(BetaAsyncBuiltinFunctionTool):
-    """Abstract base class for memory tool implementations.
+    """Abstract base class for async memory tool implementations.
 
-    This class provides the interface for implementing a custom memory backend for Claude.
+    This class provides the interface for implementing a custom async memory backend for Claude.
 
     Subclass this to create your own memory storage solution (e.g., database, cloud storage, encrypted files, etc.).
 
     Example usage:
 
     ```py
-    class MyMemoryTool(BetaAbstractMemoryTool):
-        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+    class MyMemoryTool(BetaAsyncAbstractMemoryTool):
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             ...
             return "view result"
 
-        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
             ...
             return "created successfully"
 
         # ... implement other abstract methods
 
 
-    client = Anthropic()
+    client = AsyncAnthropic()
     memory_tool = MyMemoryTool()
-    message = client.beta.messages.run_tools(
+    message = await client.beta.messages.run_tools(
         model="claude-sonnet-4-5",
         messages=[{"role": "user", "content": "Remember that I like coffee"}],
         tools=[memory_tool],


### PR DESCRIPTION
## Summary

Fixes the copy-pasted sync docstring example in `BetaAsyncAbstractMemoryTool` that would cause `TypeError` if followed verbatim:

- **Base class:** `BetaAbstractMemoryTool` → `BetaAsyncAbstractMemoryTool`
- **Methods:** `def view/create` → `async def view/create`
- **Client:** `Anthropic()` → `AsyncAnthropic()`
- **Call:** `client.beta.messages.run_tools(...)` → `await client.beta.messages.run_tools(...)`

Fixes #1290

## Test plan

- [x] Docstring-only change, no functional impact
- [x] Example now correctly demonstrates async usage pattern