### PR TITLE
Fix unhelpful error message for malformed JSON in streaming tool use

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,12 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":

--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -175,25 +175,31 @@ class BetaAsyncAbstractMemoryTool(BetaAsyncBuiltinFunctionTool):
     Example usage:
 
     ```py
-    class MyMemoryTool(BetaAbstractMemoryTool):
-        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+    import asyncio
+    from anthropic import AsyncAnthropic
+
+    class MyMemoryTool(BetaAsyncAbstractMemoryTool):
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             ...
             return "view result"
 
-        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
             ...
             return "created successfully"
 
         # ... implement other abstract methods
 
 
-    client = Anthropic()
-    memory_tool = MyMemoryTool()
-    message = client.beta.messages.run_tools(
-        model="claude-sonnet-4-5",
-        messages=[{"role": "user", "content": "Remember that I like coffee"}],
-        tools=[memory_tool],
-    ).until_done()
+    async def main():
+        client = AsyncAnthropic()
+        memory_tool = MyMemoryTool()
+        message = await client.beta.messages.run_tools(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Remember that I like coffee"}],
+            tools=[memory_tool],
+        ).until_done()
+
+    asyncio.run(main())
     ```
     """
 


### PR DESCRIPTION
## Summary

- Wraps the bare `from_json()` call in `_messages.py` with the same `try-except ValueError` that already exists in `_beta_messages.py`, so users get a clear, actionable error message when the model emits malformed tool parameter JSON during streaming

## Problem

When using `client.messages.stream()` with tools, if the model emits malformed JSON in an `input_json_delta` event, users see a raw parser error like `ValueError: expected ident at line 1 column 11` with no context about what went wrong or what to do.

The beta path (`_beta_messages.py`) already handles this with a helpful message. The non-beta path (`_messages.py`) was missing the same handling.

## Fix

6-line change: wrap the `from_json` call at line 480 of `_messages.py` with the same try-except pattern from `_beta_messages.py`. Zero behavior change for valid JSON.

Fixes #1265