### PR TITLE
fix(bedrock): use safe dict comprehension to remove connection header

### DIFF
--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -56,7 +56,7 @@ def get_auth_headers(
     # The connection header may be stripped by a proxy somewhere, so the receiver
     # of this message may not see this header, so we remove it from the set of headers
     # that are signed.
-    headers = {k: v for k, v in dict(headers).items() if k.lower() != "connection"}
+    headers = {k: v for k, v in headers.items() if k.lower() != "connection"}
 
     request = AWSRequest(method=method.upper(), url=url, headers=headers, data=data)
     credentials = session.get_credentials()

--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -56,8 +56,7 @@ def get_auth_headers(
     # The connection header may be stripped by a proxy somewhere, so the receiver
     # of this message may not see this header, so we remove it from the set of headers
     # that are signed.
-    headers = headers.copy()
-    del headers["connection"]
+    headers = {k: v for k, v in dict(headers).items() if k.lower() != "connection"}
 
     request = AWSRequest(method=method.upper(), url=url, headers=headers, data=data)
     credentials = session.get_credentials()

--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -56,9 +56,9 @@ def get_auth_headers(
     # The connection header may be stripped by a proxy somewhere, so the receiver
     # of this message may not see this header, so we remove it from the set of headers
     # that are signed.
-    headers = {k: v for k, v in headers.items() if k.lower() != "connection"}
+    new_headers = {k: v for k, v in headers.items() if k.lower() != "connection"}
 
-    request = AWSRequest(method=method.upper(), url=url, headers=headers, data=data)
+    request = AWSRequest(method=method.upper(), url=url, headers=new_headers, data=data)
     credentials = session.get_credentials()
     if not credentials:
         raise RuntimeError("could not resolve credentials from session")

--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -56,9 +56,9 @@ def get_auth_headers(
     # The connection header may be stripped by a proxy somewhere, so the receiver
     # of this message may not see this header, so we remove it from the set of headers
     # that are signed.
-    new_headers = {k: v for k, v in headers.items() if k.lower() != "connection"}
+    headers = {k: v for k, v in headers.items() if k.lower() != "connection"}
 
-    request = AWSRequest(method=method.upper(), url=url, headers=new_headers, data=data)
+    request = AWSRequest(method=method.upper(), url=url, headers=headers, data=data)
     credentials = session.get_credentials()
     if not credentials:
         raise RuntimeError("could not resolve credentials from session")


### PR DESCRIPTION
## Summary

Replace `del headers["connection"]` with a dict comprehension that safely filters out the header, preventing `KeyError` when the header is absent.

## Bug

`lib/bedrock/_auth.py:60`:

```python
headers = headers.copy()
del headers["connection"]  # KeyError if "connection" not in headers
```

The equivalent code in `lib/aws/_auth.py:60` already handles this safely:

```python
headers = {k: v for k, v in dict(headers).items() if k.lower() != "connection"}
```

The bedrock version crashes when `connection` header is missing, which happens with:
- HTTP/2 connections (no `connection` header by spec)
- Certain proxy configurations that strip it before the SDK sees it

## Fix

Align bedrock's implementation with the aws version — one line, same dict comprehension pattern.

## Test plan

- [x] When `connection` header exists: filtered out (same behavior as before)
- [x] When `connection` header is absent: no error (fixed)
- [x] Case-insensitive matching via `.lower()` (matches aws version)