### PR TITLE
fix: handle single-element tuple in file upload

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -69,7 +69,9 @@ def _transform_file(file: FileTypes) -> HttpxFileTypes:
         return file
 
     if is_tuple_t(file):
-        return (file[0], read_file_content(file[1]), *file[2:])
+        if len(file) > 1:
+            return (file[0], read_file_content(file[1]), *file[2:])
+        return (None, read_file_content(file[0]))
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 
@@ -111,7 +113,9 @@ async def _async_transform_file(file: FileTypes) -> HttpxFileTypes:
         return file
 
     if is_tuple_t(file):
-        return (file[0], await async_read_file_content(file[1]), *file[2:])
+        if len(file) > 1:
+            return (file[0], await async_read_file_content(file[1]), *file[2:])
+        return (None, await async_read_file_content(file[0]))
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 


### PR DESCRIPTION
## Summary
When passing a single-element tuple like `(pathlib.Path("/path/to/file"),)` as a file argument to `client.beta.files.upload`, the SDK crashes with `IndexError: tuple index out of range` because `_transform_file` unconditionally accesses `file[1]` without checking tuple length.

## Fix
In `_transform_file` and `_async_transform_file`, add a length check before treating a tuple as a `(filename, content)` pair. Single-element tuples are now correctly treated as `(None, content)`.

Fixes #1318