### PR TITLE
docs: document custom_id length limit in batch requests

### DIFF
--- a/src/anthropic/types/beta/messages/batch_create_params.py
+++ b/src/anthropic/types/beta/messages/batch_create_params.py
@@ -31,6 +31,8 @@ class Request(TypedDict, total=False):
     order.
 
     Must be unique for each request within the Message Batch.
+
+    Must be at most 64 characters long.
     """
 
     params: Required[MessageCreateParamsNonStreaming]

--- a/src/anthropic/types/messages/batch_create_params.py
+++ b/src/anthropic/types/messages/batch_create_params.py
@@ -26,6 +26,8 @@ class Request(TypedDict, total=False):
     order.
 
     Must be unique for each request within the Message Batch.
+
+    Must be at most 64 characters long.
     """
 
     params: Required[MessageCreateParamsNonStreaming]


### PR DESCRIPTION
Fixes #984

Document the 64-character maximum length for `custom_id` in both message batch request typed dicts so the generated SDK docs match the API behavior.