### PR TITLE
docs: clarify pause_turn server tool resumption

### DIFF
--- a/src/anthropic/types/beta/beta_message.py
+++ b/src/anthropic/types/beta/beta_message.py
@@ -95,7 +95,9 @@ class BetaMessage(BaseModel):
     - `"stop_sequence"`: one of your provided custom `stop_sequences` was generated
     - `"tool_use"`: the model invoked one or more tools
     - `"pause_turn"`: we paused a long-running turn. You may provide the response
-      back as-is in a subsequent request to let the model continue.
+      back in a subsequent request to let the model continue. For server tool
+      flows, make sure any pending tool-use blocks are resumed in the shape the
+      API expects, including any required tool-result blocks.
     - `"refusal"`: when streaming classifiers intervene to handle potential policy
       violations
 

--- a/src/anthropic/types/message.py
+++ b/src/anthropic/types/message.py
@@ -88,7 +88,9 @@ class Message(BaseModel):
     - `"stop_sequence"`: one of your provided custom `stop_sequences` was generated
     - `"tool_use"`: the model invoked one or more tools
     - `"pause_turn"`: we paused a long-running turn. You may provide the response
-      back as-is in a subsequent request to let the model continue.
+      back in a subsequent request to let the model continue. For server tool
+      flows, make sure any pending tool-use blocks are resumed in the shape the
+      API expects, including any required tool-result blocks.
     - `"refusal"`: when streaming classifiers intervene to handle potential policy
       violations
 


### PR DESCRIPTION
Fixes #1339

Clarifies the `pause_turn` stop-reason docs to note that server tool flows must be resumed in the shape the API expects, including any required tool-result blocks, instead of implying that replaying the assistant response is always sufficient.