### PR TITLE
Discriminate tool search result union

### DIFF
--- a/src/anthropic/types/beta/beta_tool_search_tool_result_block.py
+++ b/src/anthropic/types/beta/beta_tool_search_tool_result_block.py
@@ -1,15 +1,18 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Literal, Annotated, TypeAlias
 
+from ..._utils import PropertyInfo
 from ..._models import BaseModel
 from .beta_tool_search_tool_result_error import BetaToolSearchToolResultError
 from .beta_tool_search_tool_search_result_block import BetaToolSearchToolSearchResultBlock
 
 __all__ = ["BetaToolSearchToolResultBlock", "Content"]
 
-Content: TypeAlias = Union[BetaToolSearchToolResultError, BetaToolSearchToolSearchResultBlock]
+Content: TypeAlias = Annotated[
+    Union[BetaToolSearchToolResultError, BetaToolSearchToolSearchResultBlock], PropertyInfo(discriminator="type")
+]
 
 
 class BetaToolSearchToolResultBlock(BaseModel):

--- a/src/anthropic/types/tool_search_tool_result_block.py
+++ b/src/anthropic/types/tool_search_tool_result_block.py
@@ -1,15 +1,18 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Literal, Annotated, TypeAlias
 
+from .._utils import PropertyInfo
 from .._models import BaseModel
 from .tool_search_tool_result_error import ToolSearchToolResultError
 from .tool_search_tool_search_result_block import ToolSearchToolSearchResultBlock
 
 __all__ = ["ToolSearchToolResultBlock", "Content"]
 
-Content: TypeAlias = Union[ToolSearchToolResultError, ToolSearchToolSearchResultBlock]
+Content: TypeAlias = Annotated[
+    Union[ToolSearchToolResultError, ToolSearchToolSearchResultBlock], PropertyInfo(discriminator="type")
+]
 
 
 class ToolSearchToolResultBlock(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -891,6 +891,38 @@ def test_discriminated_union_case() -> None:
     assert isinstance(m, ModelB)
 
 
+def test_tool_search_tool_result_construct_discriminates_loose_content() -> None:
+    from anthropic.types.tool_search_tool_result_block import ToolSearchToolResultBlock
+    from anthropic.types.tool_search_tool_search_result_block import ToolSearchToolSearchResultBlock
+
+    block = ToolSearchToolResultBlock.construct(
+        content={
+            "type": "tool_search_tool_search_result",
+            "tool_references": [{"type": "tool_reference"}],
+        },
+        tool_use_id="srvtoolu_test",
+        type="tool_search_tool_result",
+    )
+
+    assert isinstance(block.content, ToolSearchToolSearchResultBlock)
+
+
+def test_beta_tool_search_tool_result_construct_discriminates_loose_content() -> None:
+    from anthropic.types.beta.beta_tool_search_tool_result_block import BetaToolSearchToolResultBlock
+    from anthropic.types.beta.beta_tool_search_tool_search_result_block import BetaToolSearchToolSearchResultBlock
+
+    block = BetaToolSearchToolResultBlock.construct(
+        content={
+            "type": "tool_search_tool_search_result",
+            "tool_references": [{"type": "tool_reference"}],
+        },
+        tool_use_id="srvtoolu_test",
+        type="tool_search_tool_result",
+    )
+
+    assert isinstance(block.content, BetaToolSearchToolSearchResultBlock)
+
+
 def test_nested_discriminated_union() -> None:
     class InnerType1(BaseModel):
         type: Literal["type_1"]


### PR DESCRIPTION
Fixes #1394

`ToolSearchToolResultBlock.content` is generated as a plain union, but the two variants are discriminated by `type`. Without that discriminator metadata, `BaseModel.construct()` can fall back to the first union member and construct a search result payload as `ToolSearchToolResultError`.

This adds the expected discriminator metadata for stable and beta, plus regression coverage.

I realize these files are Stainless-generated, so this PR may not be directly mergeable as-is. I’m submitting it to make the bug and expected generated output concrete.