### PR TITLE
Fix streamed tool search result blocks in parsed message snapshots

### DIFF
--- a/src/anthropic/types/beta/parsed_beta_message.py
+++ b/src/anthropic/types/beta/parsed_beta_message.py
@@ -14,7 +14,10 @@ from .beta_mcp_tool_result_block import BetaMCPToolResultBlock
 from .beta_server_tool_use_block import BetaServerToolUseBlock
 from .beta_container_upload_block import BetaContainerUploadBlock
 from .beta_redacted_thinking_block import BetaRedactedThinkingBlock
+from .beta_advisor_tool_result_block import BetaAdvisorToolResultBlock
+from .beta_web_fetch_tool_result_block import BetaWebFetchToolResultBlock
 from .beta_web_search_tool_result_block import BetaWebSearchToolResultBlock
+from .beta_tool_search_tool_result_block import BetaToolSearchToolResultBlock
 from .beta_code_execution_tool_result_block import BetaCodeExecutionToolResultBlock
 from .beta_bash_code_execution_tool_result_block import BetaBashCodeExecutionToolResultBlock
 from .beta_text_editor_code_execution_tool_result_block import BetaTextEditorCodeExecutionToolResultBlock
@@ -44,9 +47,12 @@ ParsedBetaContentBlock: TypeAlias = Annotated[
         BetaToolUseBlock,
         BetaServerToolUseBlock,
         BetaWebSearchToolResultBlock,
+        BetaWebFetchToolResultBlock,
+        BetaAdvisorToolResultBlock,
         BetaCodeExecutionToolResultBlock,
         BetaBashCodeExecutionToolResultBlock,
         BetaTextEditorCodeExecutionToolResultBlock,
+        BetaToolSearchToolResultBlock,
         BetaMCPToolUseBlock,
         BetaMCPToolResultBlock,
         BetaContainerUploadBlock,

--- a/src/anthropic/types/parsed_message.py
+++ b/src/anthropic/types/parsed_message.py
@@ -9,8 +9,14 @@ from .text_block import TextBlock
 from .thinking_block import ThinkingBlock
 from .tool_use_block import ToolUseBlock
 from .server_tool_use_block import ServerToolUseBlock
+from .container_upload_block import ContainerUploadBlock
 from .redacted_thinking_block import RedactedThinkingBlock
+from .web_fetch_tool_result_block import WebFetchToolResultBlock
 from .web_search_tool_result_block import WebSearchToolResultBlock
+from .tool_search_tool_result_block import ToolSearchToolResultBlock
+from .code_execution_tool_result_block import CodeExecutionToolResultBlock
+from .bash_code_execution_tool_result_block import BashCodeExecutionToolResultBlock
+from .text_editor_code_execution_tool_result_block import TextEditorCodeExecutionToolResultBlock
 
 ResponseFormatT = TypeVar("ResponseFormatT", default=None)
 
@@ -37,6 +43,12 @@ ParsedContentBlock: TypeAlias = Annotated[
         ToolUseBlock,
         ServerToolUseBlock,
         WebSearchToolResultBlock,
+        WebFetchToolResultBlock,
+        CodeExecutionToolResultBlock,
+        BashCodeExecutionToolResultBlock,
+        TextEditorCodeExecutionToolResultBlock,
+        ToolSearchToolResultBlock,
+        ContainerUploadBlock,
     ],
     PropertyInfo(discriminator="type"),
 ]

--- a/tests/lib/streaming/test_messages.py
+++ b/tests/lib/streaming/test_messages.py
@@ -314,3 +314,69 @@ def test_tracks_tool_input_type_alias_is_up_to_date() -> None:
             f"ContentBlock type {block_type.__name__} has an input property, "
             f"but is not included in TRACKS_TOOL_INPUT. You probably need to update the TRACKS_TOOL_INPUT type alias."
         )
+
+
+@pytest.mark.skipif(PYDANTIC_V1, reason="only applicable in pydantic v2")
+def test_parsed_content_block_type_aliases_are_up_to_date() -> None:
+    from typing import get_args
+
+    from anthropic.types.content_block import ContentBlock
+    from anthropic.types.text_block import TextBlock
+    from anthropic.types.parsed_message import ParsedContentBlock, ParsedTextBlock
+    from anthropic.types.beta.beta_content_block import BetaContentBlock
+    from anthropic.types.beta.beta_text_block import BetaTextBlock
+    from anthropic.types.beta.parsed_beta_message import ParsedBetaContentBlock, ParsedBetaTextBlock
+
+    def get_union_members(type_alias: Any) -> set[Any]:
+        return set(get_args(get_args(type_alias)[0]))
+
+    content_block_types = get_union_members(ContentBlock)
+    parsed_content_block_types = get_union_members(ParsedContentBlock)
+    assert parsed_content_block_types == (content_block_types - {TextBlock}) | {ParsedTextBlock}
+
+    beta_content_block_types = get_union_members(BetaContentBlock)
+    parsed_beta_content_block_types = get_union_members(ParsedBetaContentBlock)
+    assert parsed_beta_content_block_types == (beta_content_block_types - {BetaTextBlock}) | {ParsedBetaTextBlock}
+
+
+def test_accumulate_event_parses_tool_search_result_blocks() -> None:
+    from anthropic.lib.streaming._messages import accumulate_event
+    from anthropic.types.tool_search_tool_result_block import ToolSearchToolResultBlock
+    from anthropic.types.tool_search_tool_search_result_block import ToolSearchToolSearchResultBlock
+
+    snapshot = accumulate_event(
+        event={
+            "type": "message_start",
+            "message": {
+                "id": "msg_test",
+                "content": [],
+                "model": "claude-sonnet-4-20250514",
+                "role": "assistant",
+                "stop_reason": None,
+                "stop_sequence": None,
+                "type": "message",
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        },
+        current_snapshot=None,
+    )
+
+    snapshot = accumulate_event(
+        event={
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_search_tool_result",
+                "tool_use_id": "toolu_123",
+                "content": {
+                    "type": "tool_search_tool_search_result",
+                    "tool_references": [],
+                },
+            },
+        },
+        current_snapshot=snapshot,
+    )
+
+    block = snapshot.content[0]
+    assert isinstance(block, ToolSearchToolResultBlock)
+    assert isinstance(block.content, ToolSearchToolSearchResultBlock)


### PR DESCRIPTION
## Summary

Fix a streaming type-contract bug where `tool_search_tool_result` content blocks could fall out of the parsed message snapshot shape.

This updates the handwritten parsed content block unions to stay aligned with the generated `ContentBlock` unions, so newer block types like `ToolSearchToolResultBlock` are preserved correctly during streaming.

## Changes

- add missing non-text content block types to `ParsedContentBlock`
- add missing beta content block types to `ParsedBetaContentBlock`
- add a regression test for streamed `tool_search_tool_result` blocks
- add a guard test to keep parsed content block unions aligned with generated content block unions

## Verification

- `PYTHONPATH=src python -m pytest -q tests/lib/streaming/test_messages.py`

## Notes

This addresses the class of issue reported in `#1394`, where streamed `ToolSearchToolResultBlock` content could show up as an untyped/raw structure instead of the declared SDK model type.