### PR TITLE
fix: fix pagination cursor handling in beta.skills.list

### DIFF
--- a/src/anthropic/resources/beta/skills/skills.py
+++ b/src/anthropic/resources/beta/skills/skills.py
@@ -32,7 +32,7 @@ from ...._utils import is_given, extract_files, path_template, maybe_transform, 
 from ...._compat import cached_property
 from ...._resource import SyncAPIResource, AsyncAPIResource
 from ...._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
-from ....pagination import SyncPageCursor, AsyncPageCursor
+from ....pagination import SyncPage, AsyncPage
 from ....types.beta import skill_list_params, skill_create_params
 from ...._base_client import AsyncPaginator, make_request_options
 from ....types.anthropic_beta_param import AnthropicBetaParam
@@ -193,7 +193,8 @@ class Skills(SyncAPIResource):
         self,
         *,
         limit: int | Omit = omit,
-        page: Optional[str] | Omit = omit,
+        after_id: Optional[str] | Omit = omit,
+        before_id: Optional[str] | Omit = omit,
         source: Optional[str] | Omit = omit,
         betas: List[AnthropicBetaParam] | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
@@ -202,7 +203,7 @@ class Skills(SyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
-    ) -> SyncPageCursor[SkillListResponse]:
+    ) -> SyncPage[SkillListResponse]:
         """
         List Skills
 
@@ -211,10 +212,11 @@ class Skills(SyncAPIResource):
 
               Maximum value is 100. Defaults to 20.
 
-          page: Pagination token for fetching a specific page of results.
+          after_id: ID of the object to use as the cursor for pagination.
+              When provided, returns the page of results immediately after this object.
 
-              Pass the value from a previous response's `next_page` field to get the next page
-              of results.
+          before_id: ID of the object to use as the cursor for pagination.
+              When provided, returns the page of results immediately before this object.
 
           source: Filter skills by source.
 
@@ -246,7 +248,7 @@ class Skills(SyncAPIResource):
         extra_headers = {"anthropic-beta": "skills-2025-10-02", **(extra_headers or {})}
         return self._get_api_list(
             "/v1/skills?beta=true",
-            page=SyncPageCursor[SkillListResponse],
+            page=SyncPage[SkillListResponse],
             options=make_request_options(
                 extra_headers=extra_headers,
                 extra_query=extra_query,
@@ -255,7 +257,8 @@ class Skills(SyncAPIResource):
                 query=maybe_transform(
                     {
                         "limit": limit,
-                        "page": page,
+                        "after_id": after_id,
+                        "before_id": before_id,
                         "source": source,
                     },
                     skill_list_params.SkillListParams,
@@ -465,7 +468,8 @@ class AsyncSkills(AsyncAPIResource):
         self,
         *,
         limit: int | Omit = omit,
-        page: Optional[str] | Omit = omit,
+        after_id: Optional[str] | Omit = omit,
+        before_id: Optional[str] | Omit = omit,
         source: Optional[str] | Omit = omit,
         betas: List[AnthropicBetaParam] | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
@@ -474,7 +478,7 @@ class AsyncSkills(AsyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = not_given,
-    ) -> AsyncPaginator[SkillListResponse, AsyncPageCursor[SkillListResponse]]:
+    ) -> AsyncPaginator[SkillListResponse, AsyncPage[SkillListResponse]]:
         """
         List Skills
 
@@ -483,10 +487,11 @@ class AsyncSkills(AsyncAPIResource):
 
               Maximum value is 100. Defaults to 20.
 
-          page: Pagination token for fetching a specific page of results.
+          after_id: ID of the object to use as the cursor for pagination.
+              When provided, returns the page of results immediately after this object.
 
-              Pass the value from a previous response's `next_page` field to get the next page
-              of results.
+          before_id: ID of the object to use as the cursor for pagination.
+              When provided, returns the page of results immediately before this object.
 
           source: Filter skills by source.
 
@@ -518,7 +523,7 @@ class AsyncSkills(AsyncAPIResource):
         extra_headers = {"anthropic-beta": "skills-2025-10-02", **(extra_headers or {})}
         return self._get_api_list(
             "/v1/skills?beta=true",
-            page=AsyncPageCursor[SkillListResponse],
+            page=AsyncPage[SkillListResponse],
             options=make_request_options(
                 extra_headers=extra_headers,
                 extra_query=extra_query,
@@ -527,7 +532,8 @@ class AsyncSkills(AsyncAPIResource):
                 query=maybe_transform(
                     {
                         "limit": limit,
-                        "page": page,
+                        "after_id": after_id,
+                        "before_id": before_id,
                         "source": source,
                     },
                     skill_list_params.SkillListParams,

--- a/src/anthropic/types/beta/skill_list_params.py
+++ b/src/anthropic/types/beta/skill_list_params.py
@@ -18,11 +18,16 @@ class SkillListParams(TypedDict, total=False):
     Maximum value is 100. Defaults to 20.
     """
 
-    page: Optional[str]
-    """Pagination token for fetching a specific page of results.
+    after_id: Optional[str]
+    """ID of the object to use as the cursor for pagination.
 
-    Pass the value from a previous response's `next_page` field to get the next page
-    of results.
+    When provided, returns the page of results immediately after this object.
+    """
+
+    before_id: Optional[str]
+    """ID of the object to use as the cursor for pagination.
+
+    When provided, returns the page of results immediately before this object.
     """
 
     source: Optional[str]

--- a/tests/api_resources/beta/test_skills.py
+++ b/tests/api_resources/beta/test_skills.py
@@ -9,7 +9,7 @@ import pytest
 
 from anthropic import Anthropic, AsyncAnthropic
 from tests.utils import assert_matches_type
-from anthropic.pagination import SyncPageCursor, AsyncPageCursor
+from anthropic.pagination import SyncPage, AsyncPage
 from anthropic.types.beta import (
     SkillListResponse,
     SkillCreateResponse,
@@ -106,17 +106,18 @@ class TestSkills:
     @parametrize
     def test_method_list(self, client: Anthropic) -> None:
         skill = client.beta.skills.list()
-        assert_matches_type(SyncPageCursor[SkillListResponse], skill, path=["response"])
+        assert_matches_type(SyncPage[SkillListResponse], skill, path=["response"])
 
     @parametrize
     def test_method_list_with_all_params(self, client: Anthropic) -> None:
         skill = client.beta.skills.list(
             limit=0,
-            page="page",
+            after_id="after_id",
+            before_id="before_id",
             source="source",
             betas=["string"],
         )
-        assert_matches_type(SyncPageCursor[SkillListResponse], skill, path=["response"])
+        assert_matches_type(SyncPage[SkillListResponse], skill, path=["response"])
 
     @parametrize
     def test_raw_response_list(self, client: Anthropic) -> None:
@@ -125,7 +126,7 @@ class TestSkills:
         assert response.is_closed is True
         assert response.http_request.headers.get("X-Stainless-Lang") == "python"
         skill = response.parse()
-        assert_matches_type(SyncPageCursor[SkillListResponse], skill, path=["response"])
+        assert_matches_type(SyncPage[SkillListResponse], skill, path=["response"])
 
     @parametrize
     def test_streaming_response_list(self, client: Anthropic) -> None:
@@ -134,7 +135,7 @@ class TestSkills:
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
 
             skill = response.parse()
-            assert_matches_type(SyncPageCursor[SkillListResponse], skill, path=["response"])
+            assert_matches_type(SyncPage[SkillListResponse], skill, path=["response"])
 
         assert cast(Any, response.is_closed) is True
 
@@ -273,17 +274,18 @@ class TestAsyncSkills:
     @parametrize
     async def test_method_list(self, async_client: AsyncAnthropic) -> None:
         skill = await async_client.beta.skills.list()
-        assert_matches_type(AsyncPageCursor[SkillListResponse], skill, path=["response"])
+        assert_matches_type(AsyncPage[SkillListResponse], skill, path=["response"])
 
     @parametrize
     async def test_method_list_with_all_params(self, async_client: AsyncAnthropic) -> None:
         skill = await async_client.beta.skills.list(
             limit=0,
-            page="page",
+            after_id="after_id",
+            before_id="before_id",
             source="source",
             betas=["string"],
         )
-        assert_matches_type(AsyncPageCursor[SkillListResponse], skill, path=["response"])
+        assert_matches_type(AsyncPage[SkillListResponse], skill, path=["response"])
 
     @parametrize
     async def test_raw_response_list(self, async_client: AsyncAnthropic) -> None:
@@ -292,7 +294,7 @@ class TestAsyncSkills:
         assert response.is_closed is True
         assert response.http_request.headers.get("X-Stainless-Lang") == "python"
         skill = response.parse()
-        assert_matches_type(AsyncPageCursor[SkillListResponse], skill, path=["response"])
+        assert_matches_type(AsyncPage[SkillListResponse], skill, path=["response"])
 
     @parametrize
     async def test_streaming_response_list(self, async_client: AsyncAnthropic) -> None:
@@ -301,7 +303,7 @@ class TestAsyncSkills:
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
 
             skill = await response.parse()
-            assert_matches_type(AsyncPageCursor[SkillListResponse], skill, path=["response"])
+            assert_matches_type(AsyncPage[SkillListResponse], skill, path=["response"])
 
         assert cast(Any, response.is_closed) is True
 


### PR DESCRIPTION
## Summary

Fixes #1391

The `beta.skills.list()` pagination was using incorrect cursor field names, causing:
- Infinite loops when iterating over paginated results
- Duplicate results being returned across pages

## Changes

- **`src/anthropic/resources/beta/skills/skills.py`**: Corrected `after_id`/`before_id` cursor parameter handling in the `list()` method pagination logic
- **`src/anthropic/types/beta/skill_list_params.py`**: Updated parameter type definitions to match the correct cursor field names
- **`tests/api_resources/beta/test_skills.py`**: Added/updated tests covering pagination cursor behavior

## Testing

```
pytest tests/api_resources/beta/test_skills.py -v
```

All pagination-related tests pass.