### PR TITLE
fix(vertex): async client missing us/eu multi-region base_url branches

### DIFF
--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -268,6 +268,10 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
             if base_url is None:
                 if region == "global":
                     base_url = "https://aiplatform.googleapis.com/v1"
+                elif region == "us":
+                    base_url = "https://aiplatform.us.rep.googleapis.com/v1"
+                elif region == "eu":
+                    base_url = "https://aiplatform.eu.rep.googleapis.com/v1"
                 else:
                     base_url = f"https://{region}-aiplatform.googleapis.com/v1"
 


### PR DESCRIPTION
## Summary

`AnthropicVertex.__init__` (sync) maps `region="us"` to `https://aiplatform.us.rep.googleapis.com/v1` and `region="eu"` to the `.eu.rep.googleapis.com` hostname (added in 0.89.0). Those branches were never added to `AsyncAnthropicVertex.__init__`, so passing `region="us"` / `"eu"` to the async client falls through to the generic fallback and builds `{region}-aiplatform.googleapis.com`, which is not a valid endpoint and returns 404 from the GCP URL router.

This PR mirrors the two `elif` branches from the sync class into the async class. 4 lines added, no other changes.

## Repro (SDK 0.96.0, before fix)

```python
import anthropic, asyncio

async def main():
    c = anthropic.AsyncAnthropicVertex(project_id="YOUR_PROJECT", region="us")
    print(c.base_url)
    # https://us-aiplatform.googleapis.com/v1/   <-- wrong hostname
    await c.messages.create(
        model="claude-opus-4-7",
        max_tokens=16,
        messages=[{"role": "user", "content": "hi"}],
    )
    # anthropic.NotFoundError: Error code: 404 (HTML page from GCP URL router)

asyncio.run(main())
```

## After fix

`c.base_url` becomes `https://aiplatform.us.rep.googleapis.com/v1/` — matches the sync client and the working US multi-region endpoint, and the request succeeds.

## Test plan

- [ ] Unit: add a test that `AsyncAnthropicVertex(region="us").base_url` ends with `aiplatform.us.rep.googleapis.com/v1/` (mirror whatever the sync test does)
- [x] Manual: verified `messages.create` now returns 200 against `region="us"` with `claude-opus-4-7`