### PR TITLE
fix(files): remove erroneous tuple check from is_file_content type guard (#1318)

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -25,9 +25,7 @@ def is_base64_file_input(obj: object) -> TypeGuard[Base64FileInput]:
 
 
 def is_file_content(obj: object) -> TypeGuard[FileContent]:
-    return (
-        isinstance(obj, bytes) or isinstance(obj, tuple) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
-    )
+    return isinstance(obj, bytes) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
 
 
 def assert_is_file_content(obj: object, *, key: str | None = None) -> None:


### PR DESCRIPTION
## Summary

Fixes #1318.

`client.beta.files.upload(file=("foo.txt", Path("foo.txt"), "text/plain"))` fails because the `is_file_content` type guard incorrectly matches tuples, preventing the tuple-specific branch in `_transform_file` from handling `PathLike` resolution.

## Problem

`is_file_content()` included `isinstance(obj, tuple)` despite `FileContent` being defined as `Union[IO[bytes], bytes, PathLike]` (no tuple). This caused `_transform_file` to enter the `FileContent` branch for tuple inputs, skipping the `is_tuple_t` branch where `read_file_content` properly resolves `PathLike` elements.

## Fix

Remove the erroneous `isinstance(obj, tuple)` check from `is_file_content`, aligning the runtime type guard with the static `FileContent` type definition. Tuples now correctly reach the `is_tuple_t` branch and have their `PathLike` elements opened before being passed to httpx.

## Change

```diff
 def is_file_content(obj: object) -> TypeGuard[FileContent]:
-    return (
-        isinstance(obj, bytes) or isinstance(obj, tuple) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
-    )
+    return isinstance(obj, bytes) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
```