### PR TITLE
fix: support PathLike values in file tuples

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -25,9 +25,7 @@ def is_base64_file_input(obj: object) -> TypeGuard[Base64FileInput]:
 
 
 def is_file_content(obj: object) -> TypeGuard[FileContent]:
-    return (
-        isinstance(obj, bytes) or isinstance(obj, tuple) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
-    )
+    return isinstance(obj, bytes) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
 
 
 def assert_is_file_content(obj: object, *, key: str | None = None) -> None:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -21,6 +21,12 @@ def test_tuple_input() -> None:
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
 
 
+def test_tuple_pathlike_input_with_content_type() -> None:
+    result = to_httpx_files({"file": ("README.md", readme_path, "text/markdown")})
+    print(result)
+    assert result == IsDict({"file": IsTuple("README.md", IsBytes(), "text/markdown")})
+
+
 @pytest.mark.asyncio
 async def test_async_pathlib_includes_file_name() -> None:
     result = await async_to_httpx_files({"file": readme_path})
@@ -40,6 +46,13 @@ async def test_async_tuple_input() -> None:
     result = await async_to_httpx_files([("file", readme_path)])
     print(result)
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
+
+
+@pytest.mark.asyncio
+async def test_async_tuple_pathlike_input_with_content_type() -> None:
+    result = await async_to_httpx_files({"file": ("README.md", readme_path, "text/markdown")})
+    print(result)
+    assert result == IsDict({"file": IsTuple("README.md", IsBytes(), "text/markdown")})
 
 
 def test_string_not_allowed() -> None:


### PR DESCRIPTION
Summary:
- stop treating tuples as raw FileContent in _files.py so tuple uploads reach the tuple transformation path
- support PathLike values inside multipart file tuples as documented by the type hints
- add sync and async regression tests for tuple PathLike inputs with an explicit content type

Testing:
- PYTHONPATH=src python3 - <<'PY'
from pathlib import Path
from anthropic._files import to_httpx_files
readme = Path('README.md').resolve()
result = to_httpx_files({'file': ('README.md', readme, 'text/markdown')})
assert result['file'][0] == 'README.md'
assert result['file'][1] == readme.read_bytes()
assert result['file'][2] == 'text/markdown'
print('sync ok')
PY
- PYTHONPATH=src python3 - <<'PY'
import asyncio
from pathlib import Path
from anthropic._files import async_to_httpx_files
readme = Path('README.md').resolve()
async def main():
    result = await async_to_httpx_files({'file': ('README.md', readme, 'text/markdown')})
    assert result['file'][0] == 'README.md'
    assert result['file'][1] == readme.read_bytes()
    assert result['file'][2] == 'text/markdown'
    print('async ok')
asyncio.run(main())
PY

Fixes #1318