### PR TITLE
fix: pass aws_profile to boto3.Session when inferring Bedrock region

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -67,7 +67,7 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     return options
 
 
-def _infer_region() -> str:
+def _infer_region(aws_profile: str | None = None) -> str:
     """
     Infer the AWS region from the environment variables or
     from the boto3 session if available.
@@ -77,7 +77,7 @@ def _infer_region() -> str:
         try:
             import boto3
 
-            session = boto3.Session()
+            session = boto3.Session(profile_name=aws_profile)
             if session.region_name:
                 aws_region = session.region_name
         except ImportError:
@@ -178,7 +178,7 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token
@@ -343,7 +343,7 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token


### PR DESCRIPTION
Fixes #892

## Summary

`_infer_region()` creates a bare `boto3.Session()` without the `profile_name` argument, so it never reads the region configured for the specified AWS profile in `~/.aws/config`. This causes `AnthropicBedrock(aws_profile=...)` to default to `us-east-1` instead of using the profile's configured region.

## Changes

Pass `aws_profile` through to `boto3.Session(profile_name=aws_profile)` in `_infer_region()`, and forward `aws_profile` from both `AnthropicBedrock.__init__` and `AsyncAnthropicBedrock.__init__`.

4 lines changed across 3 call sites in `src/anthropic/lib/bedrock/_client.py`.