### PR TITLE
fix: check is_tuple_t before is_file_content in _transform_file

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -61,15 +61,15 @@ def to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles | None:
 
 
 def _transform_file(file: FileTypes) -> HttpxFileTypes:
+    if is_tuple_t(file):
+        return (file[0], read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = pathlib.Path(file)
             return (path.name, path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 
@@ -103,15 +103,15 @@ async def async_to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles 
 
 
 async def _async_transform_file(file: FileTypes) -> HttpxFileTypes:
+    if is_tuple_t(file):
+        return (file[0], await async_read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = anyio.Path(file)
             return (path.name, await path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], await async_read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 


### PR DESCRIPTION
## Problem

`_transform_file` and `_async_transform_file` silently ignore `PathLike` objects in file upload tuples like `("foo.txt", Path("foo.txt"), "text/plain")`.

Root cause: `is_file_content()` returns `True` for **any** tuple (it does `isinstance(obj, tuple)`), so the `is_tuple_t` branch is unreachable when a tuple is passed in. The tuple is returned as-is without reading the `PathLike` contents, which breaks `httpx` serialization.

## Fix

Swap the check order — test `is_tuple_t` first. Tuples then go through `read_file_content(file[1])` (sync) / `async_read_file_content(file[1])` (async), both of which already handle `PathLike` correctly.

Same fix applied to `_async_transform_file`.

Fixes #1318