### PR TITLE
fix: discriminate tool search result content

### DIFF
--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -175,25 +175,32 @@ class BetaAsyncAbstractMemoryTool(BetaAsyncBuiltinFunctionTool):
     Example usage:
 
     ```py
-    class MyMemoryTool(BetaAbstractMemoryTool):
-        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+    import asyncio
+
+
+    class MyMemoryTool(BetaAsyncAbstractMemoryTool):
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             ...
             return "view result"
 
-        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
             ...
             return "created successfully"
 
         # ... implement other abstract methods
 
 
-    client = Anthropic()
-    memory_tool = MyMemoryTool()
-    message = client.beta.messages.run_tools(
-        model="claude-sonnet-4-5",
-        messages=[{"role": "user", "content": "Remember that I like coffee"}],
-        tools=[memory_tool],
-    ).until_done()
+    async def main() -> None:
+        client = AsyncAnthropic()
+        memory_tool = MyMemoryTool()
+        message = await client.beta.messages.run_tools(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Remember that I like coffee"}],
+            tools=[memory_tool],
+        ).until_done()
+
+
+    asyncio.run(main())
     ```
     """
 

--- a/src/anthropic/types/beta/beta_tool_search_tool_result_block.py
+++ b/src/anthropic/types/beta/beta_tool_search_tool_result_block.py
@@ -1,15 +1,19 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Annotated, Literal, TypeAlias
 
+from ..._utils import PropertyInfo
 from ..._models import BaseModel
 from .beta_tool_search_tool_result_error import BetaToolSearchToolResultError
 from .beta_tool_search_tool_search_result_block import BetaToolSearchToolSearchResultBlock
 
 __all__ = ["BetaToolSearchToolResultBlock", "Content"]
 
-Content: TypeAlias = Union[BetaToolSearchToolResultError, BetaToolSearchToolSearchResultBlock]
+Content: TypeAlias = Annotated[
+    Union[BetaToolSearchToolResultError, BetaToolSearchToolSearchResultBlock],
+    PropertyInfo(discriminator="type"),
+]
 
 
 class BetaToolSearchToolResultBlock(BaseModel):

--- a/src/anthropic/types/tool_search_tool_result_block.py
+++ b/src/anthropic/types/tool_search_tool_result_block.py
@@ -1,15 +1,19 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Annotated, Literal, TypeAlias
 
+from .._utils import PropertyInfo
 from .._models import BaseModel
 from .tool_search_tool_result_error import ToolSearchToolResultError
 from .tool_search_tool_search_result_block import ToolSearchToolSearchResultBlock
 
 __all__ = ["ToolSearchToolResultBlock", "Content"]
 
-Content: TypeAlias = Union[ToolSearchToolResultError, ToolSearchToolSearchResultBlock]
+Content: TypeAlias = Annotated[
+    Union[ToolSearchToolResultError, ToolSearchToolSearchResultBlock],
+    PropertyInfo(discriminator="type"),
+]
 
 
 class ToolSearchToolResultBlock(BaseModel):

--- a/tests/test_tool_search_result_block.py
+++ b/tests/test_tool_search_result_block.py
@@ -1,0 +1,36 @@
+from anthropic.types.tool_search_tool_result_block import ToolSearchToolResultBlock
+from anthropic.types.beta.beta_tool_search_tool_result_block import BetaToolSearchToolResultBlock
+
+
+def test_tool_search_tool_result_block_content_is_typed() -> None:
+    block = ToolSearchToolResultBlock.model_validate(
+        {
+            "type": "tool_search_tool_result",
+            "tool_use_id": "toolu_123",
+            "content": {
+                "type": "tool_search_tool_result_error",
+                "error_code": "unavailable",
+                "error_message": "search backend unavailable",
+            },
+        }
+    )
+
+    assert block.content.type == "tool_search_tool_result_error"
+    assert type(block.content).__name__ == "ToolSearchToolResultError"
+
+
+def test_beta_tool_search_tool_result_block_content_is_typed() -> None:
+    block = BetaToolSearchToolResultBlock.model_validate(
+        {
+            "type": "tool_search_tool_result",
+            "tool_use_id": "toolu_123",
+            "content": {
+                "type": "tool_search_tool_result_error",
+                "error_code": "unavailable",
+                "error_message": "search backend unavailable",
+            },
+        }
+    )
+
+    assert block.content.type == "tool_search_tool_result_error"
+    assert type(block.content).__name__ == "BetaToolSearchToolResultError"


### PR DESCRIPTION
Summary:
- mark ToolSearchToolResultBlock.content as a discriminated union by type
- apply the same fix to the beta variant
- add regression tests to ensure nested tool search result content is parsed into typed models instead of raw dicts

Testing:
- attempted pytest for the new test file, but this local environment is missing the inline_snapshot test dependency from the repo test setup

Closes #1394