### PR TITLE
Fix parsed beta stream unions for tool result blocks

### DIFF
--- a/src/anthropic/types/beta/parsed_beta_message.py
+++ b/src/anthropic/types/beta/parsed_beta_message.py
@@ -14,7 +14,10 @@ from .beta_mcp_tool_result_block import BetaMCPToolResultBlock
 from .beta_server_tool_use_block import BetaServerToolUseBlock
 from .beta_container_upload_block import BetaContainerUploadBlock
 from .beta_redacted_thinking_block import BetaRedactedThinkingBlock
+from .beta_advisor_tool_result_block import BetaAdvisorToolResultBlock
+from .beta_web_fetch_tool_result_block import BetaWebFetchToolResultBlock
 from .beta_web_search_tool_result_block import BetaWebSearchToolResultBlock
+from .beta_tool_search_tool_result_block import BetaToolSearchToolResultBlock
 from .beta_code_execution_tool_result_block import BetaCodeExecutionToolResultBlock
 from .beta_bash_code_execution_tool_result_block import BetaBashCodeExecutionToolResultBlock
 from .beta_text_editor_code_execution_tool_result_block import BetaTextEditorCodeExecutionToolResultBlock
@@ -44,9 +47,12 @@ ParsedBetaContentBlock: TypeAlias = Annotated[
         BetaToolUseBlock,
         BetaServerToolUseBlock,
         BetaWebSearchToolResultBlock,
+        BetaWebFetchToolResultBlock,
+        BetaAdvisorToolResultBlock,
         BetaCodeExecutionToolResultBlock,
         BetaBashCodeExecutionToolResultBlock,
         BetaTextEditorCodeExecutionToolResultBlock,
+        BetaToolSearchToolResultBlock,
         BetaMCPToolUseBlock,
         BetaMCPToolResultBlock,
         BetaContainerUploadBlock,

--- a/src/anthropic/types/beta/parsed_beta_message.py
+++ b/src/anthropic/types/beta/parsed_beta_message.py
@@ -38,7 +38,9 @@ class ParsedBetaTextBlock(BetaTextBlock, Generic[ResponseFormatT]):
     __api_exclude__ = {"parsed_output"}
 
 
-# Note that generic unions are not valid for pydantic at runtime
+# Keep this in sync with BetaContentBlock; ParsedBetaTextBlock is the only
+# intentional difference so parsed_output survives in streamed text blocks.
+# Note that generic unions are not valid for pydantic at runtime.
 ParsedBetaContentBlock: TypeAlias = Annotated[
     Union[
         ParsedBetaTextBlock[ResponseFormatT],

--- a/tests/lib/streaming/test_beta_messages.py
+++ b/tests/lib/streaming/test_beta_messages.py
@@ -165,7 +165,7 @@ EXPECTED_INCOMPLETE_EVENT_TYPES = [
     "message_delta",
 ]
 
-MISSING_PARSED_CONTENT_BLOCKS = [
+RESULT_CONTENT_BLOCKS = [
     pytest.param(
         {
             "type": "tool_search_tool_result",
@@ -174,7 +174,20 @@ MISSING_PARSED_CONTENT_BLOCKS = [
         },
         "tool_search_tool_result",
         "tool_search_tool_result_error",
-        id="tool-search",
+        id="tool-search-error",
+    ),
+    pytest.param(
+        {
+            "type": "tool_search_tool_result",
+            "tool_use_id": "toolu_search",
+            "content": {
+                "type": "tool_search_tool_search_result",
+                "tool_references": [{"type": "tool_reference", "tool_name": "web_search"}],
+            },
+        },
+        "tool_search_tool_result",
+        "tool_search_tool_search_result",
+        id="tool-search-success",
     ),
     pytest.param(
         {
@@ -185,7 +198,25 @@ MISSING_PARSED_CONTENT_BLOCKS = [
         },
         "web_fetch_tool_result",
         "web_fetch_tool_result_error",
-        id="web-fetch",
+        id="web-fetch-error",
+    ),
+    pytest.param(
+        {
+            "type": "web_fetch_tool_result",
+            "tool_use_id": "toolu_fetch",
+            "caller": {"type": "direct"},
+            "content": {
+                "type": "web_fetch_result",
+                "url": "https://example.com",
+                "content": {
+                    "type": "document",
+                    "source": {"type": "text", "media_type": "text/plain", "data": "example"},
+                },
+            },
+        },
+        "web_fetch_tool_result",
+        "web_fetch_result",
+        id="web-fetch-success",
     ),
     pytest.param(
         {
@@ -195,7 +226,17 @@ MISSING_PARSED_CONTENT_BLOCKS = [
         },
         "advisor_tool_result",
         "advisor_tool_result_error",
-        id="advisor",
+        id="advisor-error",
+    ),
+    pytest.param(
+        {
+            "type": "advisor_tool_result",
+            "tool_use_id": "toolu_advisor",
+            "content": {"type": "advisor_result", "text": "Looks good"},
+        },
+        "advisor_tool_result",
+        "advisor_result",
+        id="advisor-success",
     ),
 ]
 
@@ -242,7 +283,7 @@ def assert_incomplete_partial_input_response(events: list[ParsedBetaMessageStrea
 
 
 class TestSyncMessages:
-    @pytest.mark.parametrize(("content_block", "expected_type", "expected_content_type"), MISSING_PARSED_CONTENT_BLOCKS)
+    @pytest.mark.parametrize(("content_block", "expected_type", "expected_content_type"), RESULT_CONTENT_BLOCKS)
     def test_accumulate_event_keeps_non_text_result_blocks(
         self, content_block: Dict[str, Any], expected_type: str, expected_content_type: str
     ) -> None:

--- a/tests/lib/streaming/test_beta_messages.py
+++ b/tests/lib/streaming/test_beta_messages.py
@@ -15,7 +15,12 @@ from anthropic._compat import PYDANTIC_V1
 from anthropic.types.beta.beta_message import BetaMessage
 from anthropic.lib.streaming._beta_types import ParsedBetaMessageStreamEvent
 from anthropic.resources.messages.messages import DEPRECATED_MODELS
-from anthropic.lib.streaming._beta_messages import TRACKS_TOOL_INPUT, BetaMessageStream, BetaAsyncMessageStream
+from anthropic.lib.streaming._beta_messages import (
+    TRACKS_TOOL_INPUT,
+    BetaMessageStream,
+    BetaAsyncMessageStream,
+    accumulate_event,
+)
 
 from .helpers import get_response, to_async_iter
 
@@ -160,6 +165,56 @@ EXPECTED_INCOMPLETE_EVENT_TYPES = [
     "message_delta",
 ]
 
+MISSING_PARSED_CONTENT_BLOCKS = [
+    pytest.param(
+        {
+            "type": "tool_search_tool_result",
+            "tool_use_id": "toolu_search",
+            "content": {"type": "tool_search_tool_result_error", "error_code": "unavailable"},
+        },
+        "tool_search_tool_result",
+        "tool_search_tool_result_error",
+        id="tool-search",
+    ),
+    pytest.param(
+        {
+            "type": "web_fetch_tool_result",
+            "tool_use_id": "toolu_fetch",
+            "caller": {"type": "direct"},
+            "content": {"type": "web_fetch_tool_result_error", "error_code": "unavailable"},
+        },
+        "web_fetch_tool_result",
+        "web_fetch_tool_result_error",
+        id="web-fetch",
+    ),
+    pytest.param(
+        {
+            "type": "advisor_tool_result",
+            "tool_use_id": "toolu_advisor",
+            "content": {"type": "advisor_tool_result_error", "error_code": "unavailable"},
+        },
+        "advisor_tool_result",
+        "advisor_tool_result_error",
+        id="advisor",
+    ),
+]
+
+
+def _message_start_event() -> Dict[str, Any]:
+    return {
+        "type": "message_start",
+        "message": {
+            "id": "msg_test",
+            "model": "claude-sonnet-4-5",
+            "role": "assistant",
+            "type": "message",
+            "content": [],
+            "stop_reason": None,
+            "stop_sequence": None,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        },
+    }
+
 
 def assert_message_matches(message: BetaMessage, expected: Dict[str, Any]) -> None:
     actual_message_json = message.model_dump_json(
@@ -187,6 +242,25 @@ def assert_incomplete_partial_input_response(events: list[ParsedBetaMessageStrea
 
 
 class TestSyncMessages:
+    @pytest.mark.parametrize(("content_block", "expected_type", "expected_content_type"), MISSING_PARSED_CONTENT_BLOCKS)
+    def test_accumulate_event_keeps_non_text_result_blocks(
+        self, content_block: Dict[str, Any], expected_type: str, expected_content_type: str
+    ) -> None:
+        snapshot = accumulate_event(
+            event=_message_start_event(),
+            current_snapshot=None,
+            request_headers=httpx.Headers(),
+        )
+        snapshot = accumulate_event(
+            event={"type": "content_block_start", "index": 0, "content_block": content_block},
+            current_snapshot=snapshot,
+            request_headers=httpx.Headers(),
+        )
+
+        assert len(snapshot.content) == 1
+        assert snapshot.content[0].type == expected_type
+        assert snapshot.content[0].content.type == expected_content_type
+
     @pytest.mark.respx(base_url=base_url)
     def test_basic_response(self, respx_mock: MockRouter) -> None:
         respx_mock.post("/v1/messages").mock(


### PR DESCRIPTION
## Summary
- add missing beta tool result blocks to `ParsedBetaContentBlock` so streamed final messages retain them
- keep the parsed union aligned with `BetaContentBlock`
- add regression coverage for `tool_search_tool_result`, `web_fetch_tool_result`, and `advisor_tool_result`

## Testing
- `uv run pytest tests/lib/streaming/test_beta_messages.py -q`
- `uv run ruff check src/anthropic/types/beta/parsed_beta_message.py tests/lib/streaming/test_beta_messages.py`

Fixes #1422