### PR TITLE
docs(messages): document batch custom_id length limit

### DIFF
--- a/src/anthropic/resources/beta/messages/batches.py
+++ b/src/anthropic/resources/beta/messages/batches.py
@@ -366,7 +366,9 @@ class Batches(SyncAPIResource):
 
         Each line in the file is a JSON object containing the result of a single request
         in the Message Batch. Results are not guaranteed to be in the same order as
-        requests. Use the `custom_id` field to match results to requests.
+        requests. Use the `custom_id` field to match results to requests. Each
+        `custom_id` must be unique within the batch and be at most 64 characters
+        long.
 
         Learn more about the Message Batches API in our
         [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)
@@ -755,7 +757,9 @@ class AsyncBatches(AsyncAPIResource):
 
         Each line in the file is a JSON object containing the result of a single request
         in the Message Batch. Results are not guaranteed to be in the same order as
-        requests. Use the `custom_id` field to match results to requests.
+        requests. Use the `custom_id` field to match results to requests. Each
+        `custom_id` must be unique within the batch and be at most 64 characters
+        long.
 
         Learn more about the Message Batches API in our
         [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)

--- a/src/anthropic/resources/messages/batches.py
+++ b/src/anthropic/resources/messages/batches.py
@@ -291,7 +291,9 @@ class Batches(SyncAPIResource):
 
         Each line in the file is a JSON object containing the result of a single request
         in the Message Batch. Results are not guaranteed to be in the same order as
-        requests. Use the `custom_id` field to match results to requests.
+        requests. Use the `custom_id` field to match results to requests. Each
+        `custom_id` must be unique within the batch and be at most 64 characters
+        long.
 
         Learn more about the Message Batches API in our
         [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)
@@ -594,7 +596,9 @@ class AsyncBatches(AsyncAPIResource):
 
         Each line in the file is a JSON object containing the result of a single request
         in the Message Batch. Results are not guaranteed to be in the same order as
-        requests. Use the `custom_id` field to match results to requests.
+        requests. Use the `custom_id` field to match results to requests. Each
+        `custom_id` must be unique within the batch and be at most 64 characters
+        long.
 
         Learn more about the Message Batches API in our
         [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)

--- a/src/anthropic/types/beta/messages/batch_create_params.py
+++ b/src/anthropic/types/beta/messages/batch_create_params.py
@@ -31,7 +31,8 @@ class Request(TypedDict, total=False):
     Useful for matching results to requests, as results may be given out of request
     order.
 
-    Must be unique for each request within the Message Batch.
+    Must be unique for each request within the Message Batch and be at most 64
+    characters long.
     """
 
     params: Required[MessageCreateParamsNonStreaming]

--- a/src/anthropic/types/messages/batch_create_params.py
+++ b/src/anthropic/types/messages/batch_create_params.py
@@ -25,7 +25,8 @@ class Request(TypedDict, total=False):
     Useful for matching results to requests, as results may be given out of request
     order.
 
-    Must be unique for each request within the Message Batch.
+    Must be unique for each request within the Message Batch and be at most 64
+    characters long.
     """
 
     params: Required[MessageCreateParamsNonStreaming]


### PR DESCRIPTION
## Summary
- document that message batch `custom_id` values must be unique and at most 64 characters long
- update both stable and beta message batch resource docs
- update the typed parameter docs for both stable and beta batch request shapes

## Why
The current SDK docs mention uniqueness but do not mention the 64-character limit, which leads to a 400 at runtime without an obvious hint in the Python SDK docs.

Fixes #984.