### PR TITLE
fix(streaming): emit beta input_json for server tools

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -365,7 +365,11 @@ def build_events(
                     )
                 )
         elif event.delta.type == "input_json_delta":
-            if content_block.type == "tool_use" or content_block.type == "mcp_tool_use":
+            if (
+                content_block.type == "tool_use"
+                or content_block.type == "mcp_tool_use"
+                or content_block.type == "server_tool_use"
+            ):
                 events_to_fire.append(
                     build(
                         BetaInputJsonEvent,

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -501,6 +501,7 @@ def accumulate_event(
         if content_block.type == "text" and is_given(output_format):
             content_block.parsed_output = parse_text(content_block.text, output_format)
     elif event.type == "message_delta":
+        current_snapshot.container = event.delta.container
         current_snapshot.stop_reason = event.delta.stop_reason
         current_snapshot.stop_sequence = event.delta.stop_sequence
         current_snapshot.usage.output_tokens = event.usage.output_tokens

--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -175,25 +175,32 @@ class BetaAsyncAbstractMemoryTool(BetaAsyncBuiltinFunctionTool):
     Example usage:
 
     ```py
-    class MyMemoryTool(BetaAbstractMemoryTool):
-        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+    import asyncio
+
+
+    class MyMemoryTool(BetaAsyncAbstractMemoryTool):
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             ...
             return "view result"
 
-        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
             ...
             return "created successfully"
 
         # ... implement other abstract methods
 
 
-    client = Anthropic()
-    memory_tool = MyMemoryTool()
-    message = client.beta.messages.run_tools(
-        model="claude-sonnet-4-5",
-        messages=[{"role": "user", "content": "Remember that I like coffee"}],
-        tools=[memory_tool],
-    ).until_done()
+    async def main() -> None:
+        client = AsyncAnthropic()
+        memory_tool = MyMemoryTool()
+        message = await client.beta.messages.run_tools(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Remember that I like coffee"}],
+            tools=[memory_tool],
+        ).until_done()
+
+
+    asyncio.run(main())
     ```
     """
 

--- a/src/anthropic/types/beta/beta_tool_search_tool_result_block.py
+++ b/src/anthropic/types/beta/beta_tool_search_tool_result_block.py
@@ -1,15 +1,19 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Annotated, Literal, TypeAlias
 
+from ..._utils import PropertyInfo
 from ..._models import BaseModel
 from .beta_tool_search_tool_result_error import BetaToolSearchToolResultError
 from .beta_tool_search_tool_search_result_block import BetaToolSearchToolSearchResultBlock
 
 __all__ = ["BetaToolSearchToolResultBlock", "Content"]
 
-Content: TypeAlias = Union[BetaToolSearchToolResultError, BetaToolSearchToolSearchResultBlock]
+Content: TypeAlias = Annotated[
+    Union[BetaToolSearchToolResultError, BetaToolSearchToolSearchResultBlock],
+    PropertyInfo(discriminator="type"),
+]
 
 
 class BetaToolSearchToolResultBlock(BaseModel):

--- a/src/anthropic/types/tool_search_tool_result_block.py
+++ b/src/anthropic/types/tool_search_tool_result_block.py
@@ -1,15 +1,19 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Annotated, Literal, TypeAlias
 
+from .._utils import PropertyInfo
 from .._models import BaseModel
 from .tool_search_tool_result_error import ToolSearchToolResultError
 from .tool_search_tool_search_result_block import ToolSearchToolSearchResultBlock
 
 __all__ = ["ToolSearchToolResultBlock", "Content"]
 
-Content: TypeAlias = Union[ToolSearchToolResultError, ToolSearchToolSearchResultBlock]
+Content: TypeAlias = Annotated[
+    Union[ToolSearchToolResultError, ToolSearchToolSearchResultBlock],
+    PropertyInfo(discriminator="type"),
+]
 
 
 class ToolSearchToolResultBlock(BaseModel):

--- a/tests/lib/streaming/test_message_container.py
+++ b/tests/lib/streaming/test_message_container.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from datetime import timezone
+
+from anthropic.lib.streaming._messages import accumulate_event
+from anthropic.types import Message
+from anthropic.types import RawMessageDeltaEvent
+from anthropic.types import TextBlock
+from anthropic.types import Usage
+
+
+def test_message_delta_propagates_container() -> None:
+    message = Message(
+        id="msg_123",
+        type="message",
+        role="assistant",
+        container=None,
+        content=[TextBlock(type="text", text="hello", citations=None)],
+        model="claude-sonnet-4-20250514",
+        stop_reason=None,
+        stop_sequence=None,
+        usage=Usage(input_tokens=1, output_tokens=0),
+    )
+
+    updated = accumulate_event(
+        event=RawMessageDeltaEvent(
+            type="message_delta",
+            delta={
+                "container": {
+                    "id": "container_123",
+                    "expires_at": datetime(2026, 4, 21, tzinfo=timezone.utc),
+                },
+                "stop_reason": "end_turn",
+            },
+            usage={"output_tokens": 4},
+        ),
+        current_snapshot=message,
+    )
+
+    assert updated.container is not None
+    assert updated.container.id == "container_123"
+    assert updated.stop_reason == "end_turn"
+    assert updated.usage.output_tokens == 4

--- a/tests/lib/streaming/test_partial_json.py
+++ b/tests/lib/streaming/test_partial_json.py
@@ -3,14 +3,56 @@ from typing import List, cast
 
 import httpx
 
-from anthropic.types.beta import BetaDirectCaller, BetaToolUseBlock, BetaInputJSONDelta, BetaRawContentBlockDeltaEvent
+from anthropic.types.beta import (
+    BetaDirectCaller,
+    BetaToolUseBlock,
+    BetaInputJSONDelta,
+    BetaRawContentBlockDeltaEvent,
+    BetaServerToolUseBlock,
+)
 from anthropic.types.tool_use_block import ToolUseBlock
 from anthropic.types.beta.beta_usage import BetaUsage
-from anthropic.lib.streaming._beta_messages import accumulate_event
+from anthropic.lib.streaming._beta_messages import accumulate_event, build_events
 from anthropic.types.beta.parsed_beta_message import ParsedBetaMessage
 
 
 class TestPartialJson:
+    def test_server_tool_use_emits_input_json_event(self) -> None:
+        message = ParsedBetaMessage(
+            id="msg_123",
+            type="message",
+            role="assistant",
+            content=[
+                BetaServerToolUseBlock(
+                    type="server_tool_use",
+                    id="srvtool_123",
+                    name="web_search",
+                    input={"query": "Anth"},
+                )
+            ],
+            model="claude-sonnet-4-5",
+            stop_reason=None,
+            stop_sequence=None,
+            usage=BetaUsage(input_tokens=10, output_tokens=10),
+        )
+
+        event = BetaRawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=BetaInputJSONDelta(type="input_json_delta", partial_json='{"query":"Anth"}'),
+        )
+
+        message = accumulate_event(
+            event=event,
+            current_snapshot=message,
+            request_headers=httpx.Headers(),
+        )
+        parsed_events = build_events(event=event, message_snapshot=message)
+
+        assert [parsed_event.type for parsed_event in parsed_events] == ["content_block_delta", "input_json"]
+        assert parsed_events[1].partial_json == '{"query":"Anth"}'
+        assert parsed_events[1].snapshot == {"query": "Anth"}
+
     def test_trailing_strings_mode_header(self) -> None:
         """Test behavior differences with and without the beta header for JSON parsing."""
         message = ParsedBetaMessage(

--- a/tests/test_tool_search_result_block.py
+++ b/tests/test_tool_search_result_block.py
@@ -1,0 +1,36 @@
+from anthropic.types.tool_search_tool_result_block import ToolSearchToolResultBlock
+from anthropic.types.beta.beta_tool_search_tool_result_block import BetaToolSearchToolResultBlock
+
+
+def test_tool_search_tool_result_block_content_is_typed() -> None:
+    block = ToolSearchToolResultBlock.model_validate(
+        {
+            "type": "tool_search_tool_result",
+            "tool_use_id": "toolu_123",
+            "content": {
+                "type": "tool_search_tool_result_error",
+                "error_code": "unavailable",
+                "error_message": "search backend unavailable",
+            },
+        }
+    )
+
+    assert block.content.type == "tool_search_tool_result_error"
+    assert type(block.content).__name__ == "ToolSearchToolResultError"
+
+
+def test_beta_tool_search_tool_result_block_content_is_typed() -> None:
+    block = BetaToolSearchToolResultBlock.model_validate(
+        {
+            "type": "tool_search_tool_result",
+            "tool_use_id": "toolu_123",
+            "content": {
+                "type": "tool_search_tool_result_error",
+                "error_code": "unavailable",
+                "error_message": "search backend unavailable",
+            },
+        }
+    )
+
+    assert block.content.type == "tool_search_tool_result_error"
+    assert type(block.content).__name__ == "BetaToolSearchToolResultError"


### PR DESCRIPTION
## Summary
- emit `BetaInputJsonEvent` for `server_tool_use` blocks in beta streaming helpers
- add a focused regression test covering the parsed event path for server-side tools

## Testing
- `PYTHONPATH=src PYTHONPYCACHEPREFIX=/tmp/anthropic-sdk-python-pyc python3 -m py_compile src/anthropic/lib/streaming/_beta_messages.py tests/lib/streaming/test_partial_json.py`
- `PYTHONPATH=src python3` direct smoke check for `build_events()` on a `server_tool_use` block
- `PYTHONPATH=src python3 -m pytest tests/lib/streaming/test_partial_json.py -k server_tool_use_emits_input_json_event` *(fails locally: missing `inline_snapshot` in tests/conftest.py)*