### PR TITLE
fix: discriminate tool search result block content

### DIFF
--- a/src/anthropic/types/beta/beta_tool_search_tool_result_block.py
+++ b/src/anthropic/types/beta/beta_tool_search_tool_result_block.py
@@ -1,8 +1,9 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Literal, Annotated, TypeAlias
 
+from ..._utils import PropertyInfo
 from ..._models import BaseModel
 from .beta_tool_search_tool_result_error import BetaToolSearchToolResultError
 from .beta_tool_search_tool_search_result_block import BetaToolSearchToolSearchResultBlock
@@ -13,7 +14,7 @@ Content: TypeAlias = Union[BetaToolSearchToolResultError, BetaToolSearchToolSear
 
 
 class BetaToolSearchToolResultBlock(BaseModel):
-    content: Content
+    content: Annotated[Content, PropertyInfo(discriminator="type")]
 
     tool_use_id: str
 

--- a/src/anthropic/types/tool_search_tool_result_block.py
+++ b/src/anthropic/types/tool_search_tool_result_block.py
@@ -1,8 +1,9 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Union
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import Literal, Annotated, TypeAlias
 
+from .._utils import PropertyInfo
 from .._models import BaseModel
 from .tool_search_tool_result_error import ToolSearchToolResultError
 from .tool_search_tool_search_result_block import ToolSearchToolSearchResultBlock
@@ -13,7 +14,7 @@ Content: TypeAlias = Union[ToolSearchToolResultError, ToolSearchToolSearchResult
 
 
 class ToolSearchToolResultBlock(BaseModel):
-    content: Content
+    content: Annotated[Content, PropertyInfo(discriminator="type")]
 
     tool_use_id: str
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,8 @@ from pydantic import Field
 from anthropic._utils import PropertyInfo
 from anthropic._compat import PYDANTIC_V1, parse_obj, model_dump, model_json
 from anthropic._models import DISCRIMINATOR_CACHE, BaseModel, construct_type
+from anthropic.types import ToolSearchToolResultBlock
+from anthropic.types.beta import BetaToolSearchToolResultBlock
 
 
 class BasicModel(BaseModel):
@@ -961,3 +963,30 @@ def test_extra_properties() -> None:
     assert model.a.prop == 1
     assert isinstance(model.a, Item)
     assert model.other == "foo"
+
+
+
+def test_tool_search_tool_result_block_content_is_discriminated() -> None:
+    block = ToolSearchToolResultBlock.model_validate({
+        "type": "tool_search_tool_result",
+        "tool_use_id": "toolu_123",
+        "content": {
+            "type": "tool_search_tool_search_result",
+            "tool_references": [{"type": "tool_reference", "tool_name": "web_search", "url": "https://example.com", "title": "Example"}],
+        },
+    })
+
+    assert block.content.type == "tool_search_tool_search_result"
+
+
+def test_beta_tool_search_tool_result_block_content_is_discriminated() -> None:
+    block = BetaToolSearchToolResultBlock.model_validate({
+        "type": "tool_search_tool_result",
+        "tool_use_id": "toolu_123",
+        "content": {
+            "type": "tool_search_tool_search_result",
+            "tool_references": [{"type": "tool_reference", "tool_name": "web_search", "url": "https://example.com", "title": "Example"}],
+        },
+    })
+
+    assert block.content.type == "tool_search_tool_search_result"


### PR DESCRIPTION
Fixes #1394

## Summary
- add discriminators for `ToolSearchToolResultBlock.content` in stable and beta models
- ensure parsed tool-search content is typed instead of left as a raw dict
- add model validation tests for both variants

## Testing
- `python -m pytest tests/test_models.py -q -n0`