### PR TITLE
fix: update long request docs link

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -735,7 +735,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         if expected_time > default_time or (max_nonstreaming_tokens and max_tokens > max_nonstreaming_tokens):
             raise ValueError(
                 "Streaming is required for operations that may take longer than 10 minutes. "
-                + "See https://github.com/anthropics/anthropic-sdk-python#long-requests for more details",
+                + "See https://docs.anthropic.com/en/api/errors#long-requests for more details",
             )
         return Timeout(
             default_time,


### PR DESCRIPTION
Fixes #1430

## Summary
- update the non-streaming timeout error to point at the current long-requests docs
- keep the existing guidance, but send users to the maintained documentation URL

## Testing
- `python -m pytest tests/test_response.py -q -n0`