### PR TITLE
fix: propagate message_delta.container into aggregated Message for code_execution continuation

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -515,4 +515,8 @@ def accumulate_event(
         if event.usage.server_tool_use is not None:
             current_snapshot.usage.server_tool_use = event.usage.server_tool_use
 
+        # Propagate container from delta (needed for code_execution tool continuation)
+        if getattr(event.delta, "container", None) is not None:
+            current_snapshot.container = event.delta.container
+
     return current_snapshot


### PR DESCRIPTION
## Issue

Streaming-mode messages don't propagate the `container` field from message_delta events into the accumulated Message. This breaks multi-turn code_execution tool use, which requires the container_id on subsequent invocations.

## Solution

Propagate `container` from delta into current_snapshot when processing message_delta SSE events, matching the behavior of non-streaming messages.create().

## Testing

Verified existing streaming tests continue to pass (CI will validate).