### PR TITLE
fix(streaming): fire BetaInputJsonEvent for server_tool_use blocks

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -365,7 +365,7 @@ def build_events(
                     )
                 )
         elif event.delta.type == "input_json_delta":
-            if content_block.type == "tool_use" or content_block.type == "mcp_tool_use":
+            if isinstance(content_block, TRACKS_TOOL_INPUT):
                 events_to_fire.append(
                     build(
                         BetaInputJsonEvent,

--- a/tests/lib/streaming/test_beta_messages.py
+++ b/tests/lib/streaming/test_beta_messages.py
@@ -12,10 +12,20 @@ from respx import MockRouter
 from anthropic import Anthropic, AsyncAnthropic
 from anthropic._utils import assert_overloads_in_sync, assert_signatures_in_sync
 from anthropic._compat import PYDANTIC_V1
+from anthropic.types.beta.beta_usage import BetaUsage
 from anthropic.types.beta.beta_message import BetaMessage
 from anthropic.lib.streaming._beta_types import ParsedBetaMessageStreamEvent
 from anthropic.resources.messages.messages import DEPRECATED_MODELS
-from anthropic.lib.streaming._beta_messages import TRACKS_TOOL_INPUT, BetaMessageStream, BetaAsyncMessageStream
+from anthropic.lib.streaming._beta_messages import (
+    TRACKS_TOOL_INPUT,
+    BetaMessageStream,
+    BetaAsyncMessageStream,
+    build_events,
+)
+from anthropic.types.beta.parsed_beta_message import ParsedBetaMessage
+from anthropic.types.beta.beta_input_json_delta import BetaInputJSONDelta
+from anthropic.types.beta.beta_server_tool_use_block import BetaServerToolUseBlock
+from anthropic.types.beta.beta_raw_content_block_delta_event import BetaRawContentBlockDeltaEvent
 
 from .helpers import get_response, to_async_iter
 
@@ -438,3 +448,25 @@ def test_tracks_tool_input_type_alias_is_up_to_date() -> None:
             f"ContentBlock type {block_type.__name__} has an input property, "
             f"but is not included in TRACKS_TOOL_INPUT. You probably need to update the TRACKS_TOOL_INPUT type alias."
         )
+
+
+def test_input_json_event_fires_for_server_tool_use() -> None:
+    snapshot = ParsedBetaMessage(
+        id="msg_01",
+        content=[
+            BetaServerToolUseBlock(id="srvtoolu_01", input={}, name="web_search", type="server_tool_use"),
+        ],
+        model="claude-sonnet-4-5",
+        role="assistant",
+        type="message",
+        usage=BetaUsage(input_tokens=1, output_tokens=1),
+    )
+    event = BetaRawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=0,
+        delta=BetaInputJSONDelta(type="input_json_delta", partial_json='{"query":'),
+    )
+
+    events = build_events(event=event, message_snapshot=snapshot)
+
+    assert [e.type for e in events] == ["content_block_delta", "input_json"]


### PR DESCRIPTION
`build_events()` decides whether to fire an `input_json` event by testing the content block's type string against two hardcoded values:

```python
if content_block.type == "tool_use" or content_block.type == "mcp_tool_use":
```

`server_tool_use` is missing, so streaming a server tool call never fires `input_json`, even though the same module accumulates that block's input JSON into the message snapshot.

The module already defines `TRACKS_TOOL_INPUT` as the canonical set of content blocks that carry tool input:

```python
TRACKS_TOOL_INPUT = (
    BetaToolUseBlock,
    BetaServerToolUseBlock,
    BetaMCPToolUseBlock,
)
```

`accumulate_event()` checks membership in it, and `test_tracks_tool_input_type_alias_is_up_to_date` enforces that it stays complete as new block types land. So the two paths disagreed: one tracked server tool input, the other fired no event for it.

This switches the check in `build_events()` to the same constant, which fixes the bug and keeps the two paths from drifting apart again.

The regression test fails on current code with only `content_block_delta` fired, and passes after the change.

On scope: `_messages.py` has the same inconsistency in the non-beta layer, where the check is only `tool_use` while its `TRACKS_TOOL_INPUT` covers `ToolUseBlock` and `ServerToolUseBlock`. #1380 covers that layer, so this PR leaves it alone.

Checks run: `ruff check` and `ruff format` clean, `mypy` and `pyright` 1.1.399 clean on both touched files. Full `tests/lib` suite gives 324 passed against a 323-passed baseline on an unmodified tree, with the same 24 failures in `test_aws.py`, `test_bedrock.py` and `memory_tools/test_filesystem.py` that already fail here without my changes on Windows.
