### PR TITLE
fix: repoint outdated long-requests doc link in streaming-required error

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -735,7 +735,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         if expected_time > default_time or (max_nonstreaming_tokens and max_tokens > max_nonstreaming_tokens):
             raise ValueError(
                 "Streaming is required for operations that may take longer than 10 minutes. "
-                + "See https://github.com/anthropics/anthropic-sdk-python#long-requests for more details",
+                + "See https://docs.anthropic.com/en/api/errors#long-requests for more details",
             )
         return Timeout(
             default_time,


### PR DESCRIPTION
Closes #1430.

The `Streaming is required for operations that may take longer than 10 minutes.` `ValueError` raised in `src/anthropic/_base_client.py` points users at:

> https://github.com/anthropics/anthropic-sdk-python#long-requests

That README heading was removed in 0e409217 — the link 404s.

The same project already references the canonical location for this guidance — `https://docs.anthropic.com/en/api/errors#long-requests` — from `src/anthropic/_exceptions.py:90` (the timeout error). This PR adopts the same URL in the streaming-required error so users hitting either path land on the same page.

Single-line change. No behavior change.

---

Contributed by [kcolbchain](https://kcolbchain.com).