### PR TITLE
fix(types): sync ParsedBetaContentBlock union with BetaContentBlock

### DIFF
--- a/src/anthropic/types/beta/parsed_beta_message.py
+++ b/src/anthropic/types/beta/parsed_beta_message.py
@@ -14,7 +14,10 @@ from .beta_mcp_tool_result_block import BetaMCPToolResultBlock
 from .beta_server_tool_use_block import BetaServerToolUseBlock
 from .beta_container_upload_block import BetaContainerUploadBlock
 from .beta_redacted_thinking_block import BetaRedactedThinkingBlock
+from .beta_advisor_tool_result_block import BetaAdvisorToolResultBlock
+from .beta_web_fetch_tool_result_block import BetaWebFetchToolResultBlock
 from .beta_web_search_tool_result_block import BetaWebSearchToolResultBlock
+from .beta_tool_search_tool_result_block import BetaToolSearchToolResultBlock
 from .beta_code_execution_tool_result_block import BetaCodeExecutionToolResultBlock
 from .beta_bash_code_execution_tool_result_block import BetaBashCodeExecutionToolResultBlock
 from .beta_text_editor_code_execution_tool_result_block import BetaTextEditorCodeExecutionToolResultBlock
@@ -44,9 +47,12 @@ ParsedBetaContentBlock: TypeAlias = Annotated[
         BetaToolUseBlock,
         BetaServerToolUseBlock,
         BetaWebSearchToolResultBlock,
+        BetaWebFetchToolResultBlock,
+        BetaAdvisorToolResultBlock,
         BetaCodeExecutionToolResultBlock,
         BetaBashCodeExecutionToolResultBlock,
         BetaTextEditorCodeExecutionToolResultBlock,
+        BetaToolSearchToolResultBlock,
         BetaMCPToolUseBlock,
         BetaMCPToolResultBlock,
         BetaContainerUploadBlock,


### PR DESCRIPTION
Closes #1422.

## Bug

\`ParsedBetaContentBlock\` (the union used by \`ParsedBetaMessage.content\` in the beta streaming accumulator) was missing three block types that the sibling \`BetaContentBlock\` does include:

- \`BetaWebFetchToolResultBlock\`
- \`BetaAdvisorToolResultBlock\` (also missing — added while syncing)
- \`BetaToolSearchToolResultBlock\`

When \`accumulate_event\` in \`lib/streaming/_beta_messages.py\` calls \`construct_type(type_=ParsedBetaContentBlock, value=event.content_block.to_dict())\` for a \`content_block_start\` carrying any of those three result blocks, pydantic's discriminated-union resolution fails to match and the block is silently dropped from \`stream.get_final_message().content\`.

## Fix

Add the missing imports and union members so \`ParsedBetaContentBlock\` mirrors \`BetaContentBlock\` exactly. Keeping the two unions in lockstep is the property we actually want — there's no reason any block type that streams should be absent from the parsed snapshot.

\`\`\`diff
 ParsedBetaContentBlock: TypeAlias = Annotated[
     Union[
         ParsedBetaTextBlock[ResponseFormatT],
         BetaThinkingBlock,
         BetaRedactedThinkingBlock,
         BetaToolUseBlock,
         BetaServerToolUseBlock,
         BetaWebSearchToolResultBlock,
+        BetaWebFetchToolResultBlock,
+        BetaAdvisorToolResultBlock,
         BetaCodeExecutionToolResultBlock,
         BetaBashCodeExecutionToolResultBlock,
         BetaTextEditorCodeExecutionToolResultBlock,
+        BetaToolSearchToolResultBlock,
         BetaMCPToolUseBlock,
         BetaMCPToolResultBlock,
         BetaContainerUploadBlock,
         BetaCompactionBlock,
     ],
     PropertyInfo(discriminator="type"),
 ]
\`\`\`

\`+6 / -0\`. Type-only change; no runtime behavior change apart from the previously-dropped blocks now being present in \`stream.get_final_message().content\`.

The issue body explicitly named tool-search and web-fetch; advisor was added because it has the same root cause and the same fix. Happy to drop it if you'd rather keep this PR strictly to the issue's letter.

---

Contributed by [kcolbchain](https://kcolbchain.com).