### PR TITLE
fix(streaming): fire BetaInputJsonEvent for server_tool_use blocks

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -365,7 +365,14 @@ def build_events(
                     )
                 )
         elif event.delta.type == "input_json_delta":
-            if content_block.type == "tool_use" or content_block.type == "mcp_tool_use":
+            # Server-side tools (server_tool_use) stream input_json_delta the
+            # same way client-side tool_use blocks do, and the accumulator's
+            # TRACKS_TOOL_INPUT tuple (see below) already includes
+            # BetaServerToolUseBlock — so the SDK accumulates `content_block.input`
+            # correctly. We just weren't firing the parsed event for them, which
+            # forced consumers to bypass BetaInputJsonEvent and match on the raw
+            # delta. Fire it for server_tool_use too. (closes #1421)
+            if content_block.type in ("tool_use", "mcp_tool_use", "server_tool_use"):
                 events_to_fire.append(
                     build(
                         BetaInputJsonEvent,


### PR DESCRIPTION
Closes #1421.

## Bug

\`lib/streaming/_beta_messages.py\` fires \`BetaInputJsonEvent\` for \`tool_use\` and \`mcp_tool_use\` content blocks but **not** for \`server_tool_use\`, even though the API streams \`input_json_delta\` events for server-side tools the same way.

This was inconsistent with the accumulator's own \`TRACKS_TOOL_INPUT\` tuple in the same file, which **does** include \`BetaServerToolUseBlock\` — so the SDK accumulates the streamed input into \`content_block.input\` correctly, but never fires the parsed event to consumers. Forces consumers to bypass \`BetaInputJsonEvent\` and match on the raw \`BetaRawContentBlockDeltaEvent\` with a \`BetaInputJSONDelta\` delta.

## Fix

Add \`"server_tool_use"\` to the content-block type check on line 368:

\`\`\`diff
     elif event.delta.type == "input_json_delta":
-        if content_block.type == "tool_use" or content_block.type == "mcp_tool_use":
+        if content_block.type in ("tool_use", "mcp_tool_use", "server_tool_use"):
             events_to_fire.append(
                 build(
                     BetaInputJsonEvent,
                     type="input_json",
                     partial_json=event.delta.partial_json,
                     snapshot=content_block.input,
                 )
             )
\`\`\`

(Plus a comment explaining the consistency with \`TRACKS_TOOL_INPUT\`.)

\`+8 / -1\`. Affects only the parsed event surface — the accumulator's state already tracks server_tool_use correctly. Now \`tool_search_tool_regex\` / \`web_search\` / future server-side tools' input streams will surface as \`BetaInputJsonEvent\` to consumers using the stream helpers.

---

Contributed by [kcolbchain](https://kcolbchain.com).