### PR TITLE
fix: retain tool search and web fetch beta blocks in parsed streams

### DIFF
--- a/src/anthropic/types/beta/parsed_beta_message.py
+++ b/src/anthropic/types/beta/parsed_beta_message.py
@@ -14,6 +14,8 @@ from .beta_mcp_tool_result_block import BetaMCPToolResultBlock
 from .beta_server_tool_use_block import BetaServerToolUseBlock
 from .beta_container_upload_block import BetaContainerUploadBlock
 from .beta_redacted_thinking_block import BetaRedactedThinkingBlock
+from .beta_tool_search_tool_result_block import BetaToolSearchToolResultBlock
+from .beta_web_fetch_tool_result_block import BetaWebFetchToolResultBlock
 from .beta_web_search_tool_result_block import BetaWebSearchToolResultBlock
 from .beta_code_execution_tool_result_block import BetaCodeExecutionToolResultBlock
 from .beta_bash_code_execution_tool_result_block import BetaBashCodeExecutionToolResultBlock
@@ -43,6 +45,8 @@ ParsedBetaContentBlock: TypeAlias = Annotated[
         BetaRedactedThinkingBlock,
         BetaToolUseBlock,
         BetaServerToolUseBlock,
+        BetaToolSearchToolResultBlock,
+        BetaWebFetchToolResultBlock,
         BetaWebSearchToolResultBlock,
         BetaCodeExecutionToolResultBlock,
         BetaBashCodeExecutionToolResultBlock,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,9 @@ from pydantic import Field
 from anthropic._utils import PropertyInfo
 from anthropic._compat import PYDANTIC_V1, parse_obj, model_dump, model_json
 from anthropic._models import DISCRIMINATOR_CACHE, BaseModel, construct_type
+from anthropic.types.beta.parsed_beta_message import ParsedBetaContentBlock
+from anthropic.types.beta.beta_tool_search_tool_result_block import BetaToolSearchToolResultBlock
+from anthropic.types.beta.beta_web_fetch_tool_result_block import BetaWebFetchToolResultBlock
 
 
 class BasicModel(BaseModel):
@@ -685,6 +688,40 @@ def test_discriminated_unions_invalid_data() -> None:
         assert m.data == "100"
     else:
         assert m.data == 100  # type: ignore[comparison-overlap]
+
+
+def test_parsed_beta_content_block_accepts_tool_search_result_blocks() -> None:
+    block = construct_type(
+        value={
+            "type": "tool_search_tool_result",
+            "tool_use_id": "toolu_123",
+            "content": {
+                "type": "tool_search_results",
+                "tool_search_results": [],
+            },
+        },
+        type_=cast(Any, ParsedBetaContentBlock),
+    )
+
+    assert isinstance(block, BetaToolSearchToolResultBlock)
+
+
+def test_parsed_beta_content_block_accepts_web_fetch_result_blocks() -> None:
+    block = construct_type(
+        value={
+            "type": "web_fetch_tool_result",
+            "tool_use_id": "toolu_123",
+            "content": {
+                "type": "web_fetch",
+                "url": "https://example.com",
+                "title": "Example",
+                "content": "hello",
+            },
+        },
+        type_=cast(Any, ParsedBetaContentBlock),
+    )
+
+    assert isinstance(block, BetaWebFetchToolResultBlock)
 
 
 def test_discriminated_unions_unknown_variant() -> None:


### PR DESCRIPTION
Fixes #1422

## Summary
- add the missing beta tool-search and web-fetch result block variants to `ParsedBetaContentBlock`
- cover both variants with focused construction tests so the parsed streaming union accepts them

## Testing
- python3 -m venv .venv
- . .venv/bin/activate
- pip install -q inline_snapshot http_snapshot pytest pytest-xdist pytest_asyncio respx httpx pydantic
- pytest tests/test_models.py -k parsed_beta_content_block_accepts