### PR TITLE
fix: remove encrypted_content in all compaction types (breaks round-tripping of compaction blocks)

### DIFF
--- a/src/anthropic/types/beta/beta_compaction_block.py
+++ b/src/anthropic/types/beta/beta_compaction_block.py
@@ -19,7 +19,4 @@ class BetaCompactionBlock(BaseModel):
     content: Optional[str] = None
     """Summary of compacted content, or null if compaction failed"""
 
-    encrypted_content: Optional[str] = None
-    """Opaque metadata from prior compaction, to be round-tripped verbatim"""
-
     type: Literal["compaction"]

--- a/src/anthropic/types/beta/beta_compaction_block_param.py
+++ b/src/anthropic/types/beta/beta_compaction_block_param.py
@@ -27,6 +27,3 @@ class BetaCompactionBlockParam(TypedDict, total=False):
 
     cache_control: Optional[BetaCacheControlEphemeralParam]
     """Create a cache control breakpoint at this content block."""
-
-    encrypted_content: Optional[str]
-    """Opaque metadata from prior compaction, to be round-tripped verbatim"""

--- a/src/anthropic/types/beta/beta_compaction_content_block_delta.py
+++ b/src/anthropic/types/beta/beta_compaction_content_block_delta.py
@@ -11,7 +11,4 @@ __all__ = ["BetaCompactionContentBlockDelta"]
 class BetaCompactionContentBlockDelta(BaseModel):
     content: Optional[str] = None
 
-    encrypted_content: Optional[str] = None
-    """Opaque metadata from prior compaction, to be round-tripped verbatim"""
-
     type: Literal["compaction_delta"]


### PR DESCRIPTION
according to the API docs, there is no such attribute:

https://platform.claude.com/docs/en/api/python/beta#beta_compaction_block https://platform.claude.com/docs/en/api/python/beta#beta_compaction_block_param https://platform.claude.com/docs/en/api/python/beta#beta_compaction_content_block_delta