### PR TITLE
fix: remove stray XML tag in memory example and fix beta docstring

### DIFF
--- a/examples/memory/basic.py
+++ b/examples/memory/basic.py
@@ -38,7 +38,7 @@ DEFAULT_MEMORY_SYSTEM_PROMPT = """- ***DO NOT just store the conversation histor
         - Store facts about the user and their preferences
         - Before responding, check memory to adjust technical depth and response style appropriately
         - Keep memories up-to-date - remove outdated info, add new details as you learn them
-        - Use an xml format like <xml><name>John Doe</name></user></xml>"""
+        - Use an xml format like <xml><name>John Doe</name></xml>"""
 
 
 class Spinner:

--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -148,7 +148,7 @@ class BetaMessageStream(Generic[ResponseFormatT]):
 
 
 class BetaMessageStreamManager(Generic[ResponseFormatT]):
-    """Wrapper over MessageStream that is returned by `.stream()`.
+    """Wrapper over BetaMessageStream that is returned by `.stream()`.
 
     ```py
     with client.beta.messages.stream(...) as stream:


### PR DESCRIPTION
## Summary

Two small fixes in non-generated code (`examples/` and `src/anthropic/lib/`):

- **`examples/memory/basic.py`**: The XML format example in the system prompt had a mismatched `</user>` closing tag with no corresponding opening tag. Changed `<xml><name>John Doe</name></user></xml>` → `<xml><name>John Doe</name></xml>`

- **`src/anthropic/lib/streaming/_beta_messages.py`**: `BetaMessageStreamManager` docstring incorrectly said "Wrapper over MessageStream" instead of "Wrapper over BetaMessageStream". The three sibling classes (`MessageStreamManager`, `AsyncMessageStreamManager`, `BetaAsyncMessageStreamManager`) all reference the correct class name — this was the only inconsistency.

## Test plan

- [x] Verified both files are in non-generated directories per CONTRIBUTING.md
- [x] Changes are documentation-only — no behavioral impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)