### PR TITLE
fix: add file_id to CitationPageLocationParam for roundtrip support

### DIFF
--- a/src/anthropic/types/beta/beta_citation_page_location_param.py
+++ b/src/anthropic/types/beta/beta_citation_page_location_param.py
@@ -17,6 +17,8 @@ class BetaCitationPageLocationParam(TypedDict, total=False):
 
     end_page_number: Required[int]
 
+    file_id: Optional[str]
+
     start_page_number: Required[int]
 
     type: Required[Literal["page_location"]]

--- a/src/anthropic/types/citation_page_location_param.py
+++ b/src/anthropic/types/citation_page_location_param.py
@@ -17,6 +17,8 @@ class CitationPageLocationParam(TypedDict, total=False):
 
     end_page_number: Required[int]
 
+    file_id: Optional[str]
+
     start_page_number: Required[int]
 
     type: Required[Literal["page_location"]]


### PR DESCRIPTION
Fixes #1450

## What
Adds `file_id: Optional[str]` to both `CitationPageLocationParam` and `BetaCitationPageLocationParam` so that assistant messages containing `page_location` citations can be roundtripped back as request params without manual stripping.

The response types (`CitationPageLocation` / `BetaCitationPageLocation`) include `file_id: Optional[str] = None`, but the corresponding param types omit it. This causes `model_dump(mode="json")` output to include `file_id: None`, which the API rejects since the field is unknown to the param type's transform pipeline.

## Verification
- Build: pass
- Lint (ruff): pass
- Type check (pyright): pass — 0 errors, 0 warnings
- Type check (mypy): pass — 805 source files, no issues