### PR TITLE
fix: remove duplicate word in compaction_control deprecation warning

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -149,7 +149,7 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
         if compaction_control is not None and compaction_control.get("enabled"):
             warnings.warn(
                 "The 'compaction_control' parameter is deprecated and will be removed in a future version. "
-                "Use server-side compaction instead by passing `edits=[{'type': 'compact_20260112'}]` in your "
+                "Use server-side compaction instead by passing `edits=[{'type': 'compact_20260112'}]` in "
                 "the params passed to `tool_runner()`. See https://platform.claude.com/docs/en/build-with-claude/compaction",
                 DeprecationWarning,
                 stacklevel=3,
@@ -428,7 +428,7 @@ class BaseAsyncToolRunner(
         if compaction_control is not None and compaction_control.get("enabled"):
             warnings.warn(
                 "The 'compaction_control' parameter is deprecated and will be removed in a future version. "
-                "Use server-side compaction instead by passing `edits=[{'type': 'compact_20260112'}]` in your "
+                "Use server-side compaction instead by passing `edits=[{'type': 'compact_20260112'}]` in "
                 "the params passed to `tool_runner()`. See https://platform.claude.com/docs/en/build-with-claude/compaction",
                 DeprecationWarning,
                 stacklevel=3,


### PR DESCRIPTION
## What

Fixes a typo in the `compaction_control` deprecation warning in the tool runner. The message read "in your the params passed to `tool_runner()`" instead of "in the params passed to `tool_runner()`".

Fixed in both `BaseSyncToolRunner` and `BaseAsyncToolRunner`.

## Verification
- Build: pass
- Tests: pass (93 passed, 1 skipped, 1 xfailed)
- Lint: pass (ruff)
- Type check: pass (pyright, 0 errors)