### PR TITLE
fix(bedrock): respect AWS profile region instead of hardcoding us-east-1 (#892)

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -67,17 +67,21 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     return options
 
 
-def _infer_region() -> str:
+def _infer_region(aws_profile: str | None = None) -> str:
     """
     Infer the AWS region from the environment variables or
     from the boto3 session if available.
+
+    When ``aws_profile`` is provided, the boto3 session is created against
+    that profile so the region defined in ``~/.aws/config`` for the profile
+    is honored (rather than the default profile's region).
     """
     aws_region = os.environ.get("AWS_REGION")
     if aws_region is None:
         try:
             import boto3
 
-            session = boto3.Session()
+            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
             if session.region_name:
                 aws_region = session.region_name
         except ImportError:
@@ -178,7 +182,7 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile=aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token
@@ -343,7 +347,7 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile=aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -275,3 +275,30 @@ def test_region_infer_from_specified_profile(
     client = AnthropicBedrock()
 
     assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]
+
+
+@pytest.mark.parametrize(
+    "profiles, aws_profile",
+    [
+        pytest.param(
+            [{"name": "default", "region": "us-east-2"}, {"name": "custom", "region": "us-west-1"}],
+            "custom",
+            id="custom profile via constructor",
+        ),
+    ],
+)
+def test_region_infer_from_constructor_profile(
+    mock_aws_config: None,  # noqa: ARG001
+    profiles: t.List[AwsConfigProfile],
+    aws_profile: str,
+) -> None:
+    """Region should be inferred from the profile passed to the constructor.
+
+    Regression test for #892: previously ``_infer_region`` always created
+    ``boto3.Session()`` without a profile name, so passing ``aws_profile=`` to
+    ``AnthropicBedrock`` would still pick up the default profile's region.
+    """
+    client = AnthropicBedrock(aws_profile=aws_profile)
+
+    assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]
+    assert client.aws_profile == aws_profile


### PR DESCRIPTION
## Summary

Fixes #892 — when `aws_profile=` is passed to `AnthropicBedrock` / `AsyncAnthropicBedrock`, the region from that profile in `~/.aws/config` is now honored.

PR #974 added `_infer_region()` to fall back to `boto3.Session().region_name`, but the session was created without `profile_name=...`, so the default profile's region was always used regardless of what `aws_profile=` was passed to the constructor. Cross-region setups still ended up on `us-east-1` (or whichever region the default profile defines), which is exactly the symptom the original issue describes for users running `AWS_PROFILE` setups with non-default regions.

## Changes

- `src/anthropic/lib/bedrock/_client.py`: `_infer_region` now accepts an optional `aws_profile` and passes it through to `boto3.Session(profile_name=aws_profile)`. Both `AnthropicBedrock.__init__` and `AsyncAnthropicBedrock.__init__` forward the constructor's `aws_profile` argument.
- `tests/lib/test_bedrock.py`: regression test `test_region_infer_from_constructor_profile` covers the constructor-profile path. The existing `mock_aws_config` fixture is reused (no new test infra).

Resolution order is unchanged: explicit `aws_region` wins, then `AWS_REGION`, then the boto3 session (now profile-aware), then `us-east-1` fallback.

## Test plan

- [ ] `./scripts/test tests/lib/test_bedrock.py`
- [ ] Without the fix, `test_region_infer_from_constructor_profile` returns `us-east-2` (default profile) instead of `us-west-1` (custom profile) and fails.