### PR TITLE
fix: allow beta citation file_id in round-tripped params

### DIFF
--- a/src/anthropic/types/beta/beta_citation_page_location_param.py
+++ b/src/anthropic/types/beta/beta_citation_page_location_param.py
@@ -17,6 +17,8 @@ class BetaCitationPageLocationParam(TypedDict, total=False):
 
     end_page_number: Required[int]
 
+    file_id: Optional[str]
+
     start_page_number: Required[int]
 
     type: Required[Literal["page_location"]]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -17,6 +17,7 @@ from anthropic._utils import (
 )
 from anthropic._compat import PYDANTIC_V1
 from anthropic._models import BaseModel
+from anthropic.types.beta import BetaCitationPageLocationParam
 
 _T = TypeVar("_T")
 
@@ -142,6 +143,32 @@ async def test_includes_unknown_keys(use_async: bool) -> None:
     assert await transform({"bar": "bar", "baz_": {"FOO": 1}}, Foo6, use_async) == {
         "Bar": "bar",
         "baz_": {"FOO": 1},
+    }
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_known_optional_none_field_is_preserved(use_async: bool) -> None:
+    assert await transform(
+        {
+            "type": "page_location",
+            "cited_text": "hello",
+            "document_index": 0,
+            "document_title": "Doc",
+            "start_page_number": 1,
+            "end_page_number": 2,
+            "file_id": None,
+        },
+        BetaCitationPageLocationParam,
+        use_async,
+    ) == {
+        "type": "page_location",
+        "cited_text": "hello",
+        "document_index": 0,
+        "document_title": "Doc",
+        "start_page_number": 1,
+        "end_page_number": 2,
+        "file_id": None,
     }
 
 


### PR DESCRIPTION
Fixes #1450

## Summary
- add optional `file_id` to `BetaCitationPageLocationParam` so beta citation page locations can be round-tripped from response -> request
- add a transform test covering a known optional field with `None`

## Testing
- python -m ruff check src/anthropic/types/beta/beta_citation_page_location_param.py tests/test_transform.py
- pytest -q tests/test_transform.py -k known_optional_none_field_is_preserved
- pytest -q tests/test_transform.py