### PR TITLE
fix: handle content_block_delta streaming deserialization fallback

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -27,7 +27,7 @@ from ._beta_types import (
     ParsedBetaContentBlockStopEvent,
 )
 from ..._streaming import Stream, AsyncStream
-from ...types.beta import BetaRawMessageStreamEvent
+from ...types.beta import BetaRawMessageStreamEvent, BetaRawContentBlockDeltaEvent
 from ..._utils._utils import is_given
 from .._parse._response import ResponseFormatT, parse_text
 from ...types.beta.parsed_beta_message import ParsedBetaMessage, ParsedBetaContentBlock
@@ -460,6 +460,13 @@ def accumulate_event(
                 value=event,
             ),
         )
+        if not isinstance(cast(Any, event), BaseModel) and isinstance(cast(Any, event), dict):
+            if event.get("type") == "content_block_delta":
+                event = cast(
+                    BetaRawMessageStreamEvent,
+                    construct_type_unchecked(type_=BetaRawContentBlockDeltaEvent, value=event),
+                )
+
         if not isinstance(cast(Any, event), BaseModel):
             raise TypeError(
                 f"Unexpected event runtime type, after deserialising twice - {event} - {builtins.type(event)}"

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -20,7 +20,7 @@ from ._types import (
     ParsedMessageStreamEvent,
     ParsedContentBlockStopEvent,
 )
-from ...types import RawMessageStreamEvent
+from ...types import RawMessageStreamEvent, RawContentBlockDeltaEvent
 from ..._types import NOT_GIVEN, NotGiven
 from ..._utils import consume_sync_iterator, consume_async_iterator
 from ..._models import build, construct_type, construct_type_unchecked
@@ -444,6 +444,13 @@ def accumulate_event(
                 value=event,
             ),
         )
+        if not isinstance(cast(Any, event), BaseModel) and isinstance(cast(Any, event), dict):
+            if event.get("type") == "content_block_delta":
+                event = cast(
+                    RawMessageStreamEvent,
+                    construct_type_unchecked(type_=RawContentBlockDeltaEvent, value=event),
+                )
+
         if not isinstance(cast(Any, event), BaseModel):
             raise TypeError(f"Unexpected event runtime type, after deserialising twice - {event} - {type(event)}")
 

--- a/tests/lib/streaming/test_messages.py
+++ b/tests/lib/streaming/test_messages.py
@@ -10,10 +10,11 @@ from respx import MockRouter
 from anthropic import Stream, Anthropic, AsyncStream, AsyncAnthropic
 from anthropic._utils import assert_signatures_in_sync
 from anthropic._compat import PYDANTIC_V1
+from anthropic.types.usage import Usage
 from anthropic.lib.streaming import ParsedMessageStreamEvent
 from anthropic.types.message import Message
 from anthropic.resources.messages import DEPRECATED_MODELS
-from anthropic.lib.streaming._messages import TRACKS_TOOL_INPUT
+from anthropic.lib.streaming._messages import TRACKS_TOOL_INPUT, accumulate_event
 
 from .helpers import get_response, to_async_iter
 
@@ -106,6 +107,33 @@ def assert_tool_use_response(events: list[ParsedMessageStreamEvent[None]], messa
 
 
 class TestSyncMessages:
+    def test_accumulate_dict_content_block_delta_event(self) -> None:
+        message = Message(
+            id="msg_123",
+            type="message",
+            role="assistant",
+            content=[{"type": "text", "text": ""}],
+            model="claude-3-opus-latest",
+            stop_reason=None,
+            stop_sequence=None,
+            usage=Usage(input_tokens=10, output_tokens=10),
+        )
+
+        updated = cast(
+            Message,
+            accumulate_event(
+                event={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "hello"},
+                },
+                current_snapshot=message,
+            ),
+        )
+
+        assert updated.content[0].type == "text"
+        assert updated.content[0].text == "hello"
+
     @pytest.mark.respx(base_url=base_url)
     def test_basic_response(self, respx_mock: MockRouter) -> None:
         respx_mock.post("/v1/messages").mock(

--- a/tests/lib/streaming/test_partial_json.py
+++ b/tests/lib/streaming/test_partial_json.py
@@ -11,6 +11,31 @@ from anthropic.types.beta.parsed_beta_message import ParsedBetaMessage
 
 
 class TestPartialJson:
+    def test_accumulate_dict_content_block_delta_event(self) -> None:
+        message = ParsedBetaMessage(
+            id="msg_123",
+            type="message",
+            role="assistant",
+            content=[{"type": "text", "text": ""}],
+            model="claude-sonnet-4-5",
+            stop_reason=None,
+            stop_sequence=None,
+            usage=BetaUsage(input_tokens=10, output_tokens=10),
+        )
+
+        updated = accumulate_event(
+            event={
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "hello"},
+            },
+            current_snapshot=message,
+            request_headers=httpx.Headers(),
+        )
+
+        assert updated.content[0].type == "text"
+        assert updated.content[0].text == "hello"
+
     def test_trailing_strings_mode_header(self) -> None:
         """Test behavior differences with and without the beta header for JSON parsing."""
         message = ParsedBetaMessage(


### PR DESCRIPTION
Fixes #941

## Summary
- add a targeted fallback when a streamed `content_block_delta` event remains a raw dict after the generic union deserialization path
- apply the same fallback in the beta streaming accumulator
- add regression tests covering dict-shaped `content_block_delta` events in both standard and beta streaming paths

## Testing
- uv run ruff check src/anthropic/lib/streaming/_messages.py src/anthropic/lib/streaming/_beta_messages.py tests/lib/streaming/test_messages.py tests/lib/streaming/test_partial_json.py
- uv run pytest tests/lib/streaming/test_messages.py tests/lib/streaming/test_partial_json.py -q -n 0