### PR TITLE
docs: document message batch custom_id length limit

### DIFF
--- a/src/anthropic/types/beta/messages/batch_create_params.py
+++ b/src/anthropic/types/beta/messages/batch_create_params.py
@@ -30,7 +30,8 @@ class Request(TypedDict, total=False):
     Useful for matching results to requests, as results may be given out of request
     order.
 
-    Must be unique for each request within the Message Batch.
+    Must be unique for each request within the Message Batch and be at most 64
+    characters long.
     """
 
     params: Required[MessageCreateParamsNonStreaming]

--- a/src/anthropic/types/messages/batch_create_params.py
+++ b/src/anthropic/types/messages/batch_create_params.py
@@ -25,7 +25,8 @@ class Request(TypedDict, total=False):
     Useful for matching results to requests, as results may be given out of request
     order.
 
-    Must be unique for each request within the Message Batch.
+    Must be unique for each request within the Message Batch and be at most 64
+    characters long.
     """
 
     params: Required[MessageCreateParamsNonStreaming]


### PR DESCRIPTION
Fixes #984

## Summary
- document the 64-character limit for `custom_id` on message batch requests in the stable and beta typed parameter docs
- keep the change focused to the generated request parameter docstrings

## Testing
- `. .venv/bin/activate && python -m ruff check src/anthropic/types/messages/batch_create_params.py src/anthropic/types/beta/messages/batch_create_params.py`
- `. .venv/bin/activate && python -m py_compile src/anthropic/types/messages/batch_create_params.py src/anthropic/types/beta/messages/batch_create_params.py`
- attempted: `. .venv/bin/activate && python -m pytest tests/api_resources/messages/test_batches.py tests/api_resources/beta/messages/test_batches.py -q` (blocked because this repo's batch tests require the mock server on `127.0.0.1:4010`)