### PR TITLE
fix(streaming): propagate stop_details from message_delta into accumulated Message

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -535,6 +535,7 @@ def accumulate_event(
             content_block.parsed_output = parse_text(content_block.text, output_format)
     elif event.type == "message_delta":
         current_snapshot.container = event.delta.container
+        current_snapshot.stop_details = event.delta.stop_details
         current_snapshot.stop_reason = event.delta.stop_reason
         current_snapshot.stop_sequence = event.delta.stop_sequence
         current_snapshot.usage.output_tokens = event.usage.output_tokens

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -501,6 +501,7 @@ def accumulate_event(
         if content_block.type == "text" and is_given(output_format):
             content_block.parsed_output = parse_text(content_block.text, output_format)
     elif event.type == "message_delta":
+        current_snapshot.stop_details = event.delta.stop_details
         current_snapshot.stop_reason = event.delta.stop_reason
         current_snapshot.stop_sequence = event.delta.stop_sequence
         current_snapshot.usage.output_tokens = event.usage.output_tokens

--- a/tests/lib/streaming/test_beta_messages.py
+++ b/tests/lib/streaming/test_beta_messages.py
@@ -438,3 +438,51 @@ def test_tracks_tool_input_type_alias_is_up_to_date() -> None:
             f"ContentBlock type {block_type.__name__} has an input property, "
             f"but is not included in TRACKS_TOOL_INPUT. You probably need to update the TRACKS_TOOL_INPUT type alias."
         )
+
+
+def test_beta_message_delta_propagates_stop_details_to_snapshot() -> None:
+    import httpx as _httpx
+
+    from anthropic.types.beta.beta_usage import BetaUsage
+    from anthropic.lib.streaming._beta_messages import accumulate_event
+    from anthropic.types.beta.beta_message_delta_usage import BetaMessageDeltaUsage
+    from anthropic.types.beta.beta_refusal_stop_details import BetaRefusalStopDetails
+    from anthropic.types.beta.beta_raw_message_delta_event import Delta, BetaRawMessageDeltaEvent
+
+    snapshot = BetaMessage(
+        id="msg_test",
+        type="message",
+        role="assistant",
+        model="claude-sonnet-4-6",
+        content=[],
+        stop_reason=None,
+        stop_sequence=None,
+        usage=BetaUsage(
+            input_tokens=10,
+            output_tokens=0,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
+            server_tool_use=None,
+            service_tier=None,
+        ),
+        stop_details=None,
+    )
+
+    stop_details = BetaRefusalStopDetails(type="refusal", category="bio", explanation="Content policy")
+    event = BetaRawMessageDeltaEvent(
+        type="message_delta",
+        delta=Delta(stop_reason="end_turn", stop_sequence=None, stop_details=stop_details),
+        usage=BetaMessageDeltaUsage(output_tokens=10),
+    )
+
+    updated = accumulate_event(
+        event=event,
+        current_snapshot=snapshot,
+        request_headers=_httpx.Headers({}),
+    )
+
+    assert updated.stop_details is not None
+    assert updated.stop_details.type == "refusal"
+    assert updated.stop_details.category == "bio"
+    assert updated.stop_details.explanation == "Content policy"
+    assert updated.stop_reason == "end_turn"

--- a/tests/lib/streaming/test_messages.py
+++ b/tests/lib/streaming/test_messages.py
@@ -314,3 +314,83 @@ def test_tracks_tool_input_type_alias_is_up_to_date() -> None:
             f"ContentBlock type {block_type.__name__} has an input property, "
             f"but is not included in TRACKS_TOOL_INPUT. You probably need to update the TRACKS_TOOL_INPUT type alias."
         )
+
+
+def test_message_delta_propagates_stop_details_to_snapshot() -> None:
+    from anthropic.types.usage import Usage
+    from anthropic.lib.streaming._messages import accumulate_event
+    from anthropic.types.message_delta_usage import MessageDeltaUsage
+    from anthropic.types.refusal_stop_details import RefusalStopDetails
+    from anthropic.types.raw_message_delta_event import Delta, RawMessageDeltaEvent
+
+    snapshot = Message(
+        id="msg_test",
+        type="message",
+        role="assistant",
+        model="claude-sonnet-4-6",
+        content=[],
+        stop_reason=None,
+        stop_sequence=None,
+        usage=Usage(
+            input_tokens=10,
+            output_tokens=0,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
+            server_tool_use=None,
+            service_tier=None,
+        ),
+        stop_details=None,
+    )
+
+    stop_details = RefusalStopDetails(type="refusal", category="cyber", explanation="Blocked by safety filter")
+    event = RawMessageDeltaEvent(
+        type="message_delta",
+        delta=Delta(stop_reason="end_turn", stop_sequence=None, stop_details=stop_details),
+        usage=MessageDeltaUsage(output_tokens=42),
+    )
+
+    updated = accumulate_event(event=event, current_snapshot=snapshot)
+
+    assert updated.stop_details is not None
+    assert updated.stop_details.type == "refusal"
+    assert updated.stop_details.category == "cyber"
+    assert updated.stop_details.explanation == "Blocked by safety filter"
+    assert updated.stop_reason == "end_turn"
+    assert updated.usage.output_tokens == 42
+
+
+def test_message_delta_without_stop_details_leaves_none() -> None:
+    from anthropic.types.usage import Usage
+    from anthropic.lib.streaming._messages import accumulate_event
+    from anthropic.types.message_delta_usage import MessageDeltaUsage
+    from anthropic.types.raw_message_delta_event import Delta, RawMessageDeltaEvent
+
+    snapshot = Message(
+        id="msg_test",
+        type="message",
+        role="assistant",
+        model="claude-sonnet-4-6",
+        content=[],
+        stop_reason=None,
+        stop_sequence=None,
+        usage=Usage(
+            input_tokens=10,
+            output_tokens=0,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
+            server_tool_use=None,
+            service_tier=None,
+        ),
+        stop_details=None,
+    )
+
+    event = RawMessageDeltaEvent(
+        type="message_delta",
+        delta=Delta(stop_reason="end_turn", stop_sequence=None),
+        usage=MessageDeltaUsage(output_tokens=42),
+    )
+
+    updated = accumulate_event(event=event, current_snapshot=snapshot)
+
+    assert updated.stop_details is None
+    assert updated.stop_reason == "end_turn"


### PR DESCRIPTION
## What

The streaming accumulator merges `stop_reason` and `stop_sequence` from `message_delta` events but does not propagate `stop_details` (`RefusalStopDetails`), even though both the `RawMessageDeltaEvent.Delta` and `Message` types define this field. This causes `stream.get_final_message().stop_details` to always be `None` when the API returns structured refusal information via streaming.

Fixed in both `_messages.py` (non-beta) and `_beta_messages.py` (beta) paths.

## Verification
- Build: pass
- Tests: pass (32 passed, including 3 new tests)
- Lint: pass (ruff)
- Type check: pass (pyright, 0 errors)