### PR TITLE
chore(examples): bump tools_runner.py to claude-sonnet-4-5-20250929

### DIFF
--- a/examples/tools_runner.py
+++ b/examples/tools_runner.py
@@ -44,7 +44,7 @@ def get_weather(location: str, units: Literal["c", "f"]) -> str:
 def main() -> None:
     runner = client.beta.messages.tool_runner(
         max_tokens=1024,
-        model="claude-3-5-sonnet-latest",
+        model="claude-sonnet-4-5-20250929",
         # alternatively, you can use `tools=[anthropic.beta_tool(get_weather)]`
         tools=[get_weather],
         messages=[{"role": "user", "content": "What is the weather in SF?"}],


### PR DESCRIPTION
## What

Bump the model in `examples/tools_runner.py` from `claude-3-5-sonnet-latest` to `claude-sonnet-4-5-20250929`.

## Why

`examples/tools_runner.py` is the only example file still pointing at `claude-3-5-sonnet-latest`. Every sibling example uses `claude-sonnet-4-5-20250929`:

```
$ grep -h 'model=' examples/*.py | sort -u
        model="anthropic.claude-sonnet-4-5-20250929-v1:0",
        model="claude-haiku-4-5",
        model="claude-sonnet-4-5",
        model="claude-sonnet-4-5-20250929",
        model="claude-sonnet-4-6",
        model="claude-3-5-sonnet-latest",   <- the outlier
```

Aligning this example so copy-paste users land on a current model.

## Notes

- Per CONTRIBUTING.md, `examples/` is not modified by the generator, so this edit is safe to land manually.
- The example logic is unchanged — only the model identifier moves to the current default seen elsewhere in `examples/`.

## How to test

```bash
$ ANTHROPIC_API_KEY=... uv run python examples/tools_runner.py
```

Output should match the previous behavior — the runner queries the weather tool and prints messages.