### PR TITLE
fix: read file contents when tuple file inputs use PathLike

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -63,15 +63,15 @@ def to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles | None:
 
 
 def _transform_file(file: FileTypes) -> HttpxFileTypes:
+    if is_tuple_t(file):
+        return (file[0], read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = pathlib.Path(file)
             return (path.name, path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 
@@ -105,15 +105,15 @@ async def async_to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles 
 
 
 async def _async_transform_file(file: FileTypes) -> HttpxFileTypes:
+    if is_tuple_t(file):
+        return (file[0], await async_read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = anyio.Path(file)
             return (path.name, await path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], await async_read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -22,6 +22,18 @@ def test_tuple_input() -> None:
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
 
 
+def test_tuple_with_pathlike_reads_contents() -> None:
+    result = to_httpx_files({"file": ("foo.txt", readme_path, "text/plain")})
+    print(result)
+    assert result == IsDict({"file": IsTuple("foo.txt", IsBytes(), "text/plain")})
+
+
+def test_tuple_with_pathlike_two_elements() -> None:
+    result = to_httpx_files({"file": ("foo.txt", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("foo.txt", IsBytes())})
+
+
 @pytest.mark.asyncio
 async def test_async_pathlib_includes_file_name() -> None:
     result = await async_to_httpx_files({"file": readme_path})
@@ -41,6 +53,20 @@ async def test_async_tuple_input() -> None:
     result = await async_to_httpx_files([("file", readme_path)])
     print(result)
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
+
+
+@pytest.mark.asyncio
+async def test_async_tuple_with_pathlike_reads_contents() -> None:
+    result = await async_to_httpx_files({"file": ("foo.txt", readme_path, "text/plain")})
+    print(result)
+    assert result == IsDict({"file": IsTuple("foo.txt", IsBytes(), "text/plain")})
+
+
+@pytest.mark.asyncio
+async def test_async_tuple_with_pathlike_two_elements() -> None:
+    result = await async_to_httpx_files({"file": ("foo.txt", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("foo.txt", IsBytes())})
 
 
 def test_string_not_allowed() -> None:


### PR DESCRIPTION
## Summary

Fixes #1318.

`_transform_file` and `_async_transform_file` in `src/anthropic/_files.py` checked `is_file_content` before `is_tuple_t`. Because `is_file_content` returns `True` for any `tuple` (it just does `isinstance(obj, tuple)`), a tuple file input like `("foo.txt", Path("foo.txt"), "text/plain")` fell through the file-content branch and was returned unchanged — the tuple branch that actually calls `read_file_content` on element `[1]` was unreachable for tuples.

As a result, `client.beta.files.upload(file=("foo.txt", Path("foo.txt"), "text/plain"))` failed downstream because the `PathLike` was passed through to `httpx` instead of being read into bytes, even though the type signature advertises `PathLike` support inside the tuple form.

## Fix

Swap the order in both `_transform_file` and `_async_transform_file` — check `is_tuple_t` first, then `is_file_content`. Tuples now go through `read_file_content` / `async_read_file_content`, which already handle `PathLike` correctly.

## Test plan

- [x] Added `test_tuple_with_pathlike_reads_contents` and `test_tuple_with_pathlike_two_elements` (sync)
- [x] Added matching `test_async_tuple_with_pathlike_reads_contents` and `test_async_tuple_with_pathlike_two_elements`
- [x] `uv run pytest tests/test_files.py -v` — 18 passed
- [x] `./scripts/lint` — ruff, pyright, and mypy all clean