### PR TITLE
fix: route Bedrock SSE error events to the error handler

### DIFF
--- a/src/anthropic/lib/bedrock/_stream_decoder.py
+++ b/src/anthropic/lib/bedrock/_stream_decoder.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Iterator, AsyncIterator
 
-from ..._utils import lru_cache
+from ..._utils import is_dict, lru_cache
 from ..._streaming import ServerSentEvent
 
 if TYPE_CHECKING:
@@ -37,7 +38,7 @@ class AWSEventStreamDecoder:
             for event in event_stream_buffer:
                 message = self._parse_message_from_event(event)
                 if message:
-                    yield ServerSentEvent(data=message, event="completion")
+                    yield ServerSentEvent(data=message, event=self._get_sse_event_type(message))
 
     async def aiter_bytes(self, iterator: AsyncIterator[bytes]) -> AsyncIterator[ServerSentEvent]:
         """Given an async iterator that yields lines, iterate over it & yield every event encountered"""
@@ -49,7 +50,16 @@ class AWSEventStreamDecoder:
             for event in event_stream_buffer:
                 message = self._parse_message_from_event(event)
                 if message:
-                    yield ServerSentEvent(data=message, event="completion")
+                    yield ServerSentEvent(data=message, event=self._get_sse_event_type(message))
+
+    def _get_sse_event_type(self, message: str) -> str:
+        try:
+            data = json.loads(message)
+            if is_dict(data) and data.get("type") == "error":
+                return "error"
+        except (ValueError, KeyError):
+            pass
+        return "completion"
 
     def _parse_message_from_event(self, event: EventStreamMessage) -> str | None:
         response_dict = event.to_response_dict()

--- a/tests/lib/test_bedrock_stream_decoder.py
+++ b/tests/lib/test_bedrock_stream_decoder.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+
+from anthropic.lib.bedrock._stream_decoder import AWSEventStreamDecoder
+
+
+class TestGetSseEventType:
+    def test_error_event_returns_error(self) -> None:
+        decoder = _make_decoder()
+        message = json.dumps(
+            {
+                "type": "error",
+                "error": {"type": "rate_limit_error", "message": "Rate limited", "details": None},
+                "request_id": "req_123",
+            }
+        )
+        assert decoder._get_sse_event_type(message) == "error"
+
+    def test_message_start_event_returns_completion(self) -> None:
+        decoder = _make_decoder()
+        message = json.dumps(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_123",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": "claude-opus-4-7",
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 10, "output_tokens": 0},
+                },
+            }
+        )
+        assert decoder._get_sse_event_type(message) == "completion"
+
+    def test_content_block_delta_returns_completion(self) -> None:
+        decoder = _make_decoder()
+        message = json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hello"},
+            }
+        )
+        assert decoder._get_sse_event_type(message) == "completion"
+
+    def test_invalid_json_returns_completion(self) -> None:
+        decoder = _make_decoder()
+        assert decoder._get_sse_event_type("not json") == "completion"
+
+    def test_non_dict_json_returns_completion(self) -> None:
+        decoder = _make_decoder()
+        assert decoder._get_sse_event_type('"just a string"') == "completion"
+
+    def test_dict_without_type_returns_completion(self) -> None:
+        decoder = _make_decoder()
+        assert decoder._get_sse_event_type('{"foo": "bar"}') == "completion"
+
+
+def _make_decoder() -> AWSEventStreamDecoder:
+    return AWSEventStreamDecoder()


### PR DESCRIPTION
Fixes #1472

## What

The Bedrock `AWSEventStreamDecoder` previously hardcoded all SSE events as `event="completion"`, causing error payloads (e.g. `rate_limit_error`) from Bedrock to be deserialized as `RawMessageStartEvent` with `message=None` instead of being routed to the existing error handler. This resulted in `AttributeError: 'NoneType' object has no attribute 'model'` crashes during streaming.

This fix inspects the decoded event payload and emits `event="error"` for events with `"type": "error"`, allowing the existing error handling path in `Stream.__stream__()` to raise a proper `APIStatusError`.

## Verification

- Build: pass
- Tests: pass (29 passed — streaming + bedrock decoder tests)
- Lint: pass (ruff check)
- Type check: pass (pyright 0 errors)