### PR TITLE
fix: add missing f-string prefix in async_to_httpx_files error message

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -99,7 +99,7 @@ async def async_to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles 
     elif is_sequence_t(files):
         files = [(key, await _async_transform_file(file)) for key, file in files]
     else:
-        raise TypeError("Unexpected file type input {type(files)}, expected mapping or sequence")
+        raise TypeError(f"Unexpected file type input {type(files)}, expected mapping or sequence")
 
     return files
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -52,6 +52,17 @@ def test_string_not_allowed() -> None:
         )
 
 
+def test_invalid_files_type_error_message() -> None:
+    with pytest.raises(TypeError, match="<class 'int'>"):
+        to_httpx_files(42)  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_async_invalid_files_type_error_message() -> None:
+    with pytest.raises(TypeError, match="<class 'int'>"):
+        await async_to_httpx_files(42)  # type: ignore
+
+
 def assert_different_identities(obj1: object, obj2: object) -> None:
     assert obj1 == obj2
     assert obj1 is not obj2


### PR DESCRIPTION
## What

The `TypeError` raised in `async_to_httpx_files()` was missing the `f` prefix on its format string, causing the error message to literally print `{type(files)}` instead of the actual type. The sync counterpart `to_httpx_files()` already had the correct f-string (line 60).

**Before (line 102):**
```python
raise TypeError("Unexpected file type input {type(files)}, expected mapping or sequence")
# Output: "Unexpected file type input {type(files)}, expected mapping or sequence"
```

**After:**
```python
raise TypeError(f"Unexpected file type input {type(files)}, expected mapping or sequence")
# Output: "Unexpected file type input <class 'int'>, expected mapping or sequence"
```

## Verification

- Build: pass
- Tests: pass (16 passed)
- Lint: pass
- Type check: pass