### PR TITLE
fix(bedrock): raise APIStatusError instead of ValueError for non-200 stream events

### DIFF
--- a/src/anthropic/lib/bedrock/_stream_decoder.py
+++ b/src/anthropic/lib/bedrock/_stream_decoder.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Iterator, AsyncIterator
+
+import httpx
 
 from ..._utils import lru_cache
 from ..._streaming import ServerSentEvent
+from ..._exceptions import APIStatusError, InternalServerError, BadRequestError, RateLimitError
 
 if TYPE_CHECKING:
     from botocore.model import Shape
@@ -55,10 +59,35 @@ class AWSEventStreamDecoder:
         response_dict = event.to_response_dict()
         parsed_response = self.parser.parse(response_dict, get_response_stream_shape())
         if response_dict["status_code"] != 200:
-            raise ValueError(f"Bad response code, expected 200: {response_dict}")
+            self._raise_for_bedrock_stream_error(response_dict)
 
         chunk = parsed_response.get("chunk")
         if not chunk:
             return None
 
         return chunk.get("bytes").decode()  # type: ignore[no-any-return]
+
+    def _raise_for_bedrock_stream_error(self, response_dict: dict[str, object]) -> None:
+        status_code = int(response_dict["status_code"])  # type: ignore[arg-type]
+        body_bytes = response_dict.get("body", b"")
+        try:
+            body = json.loads(body_bytes)  # type: ignore[arg-type]
+        except Exception:
+            body = {}
+
+        message = body.get("message") or f"Bedrock event stream error (status {status_code})"
+
+        # Build a minimal synthetic response so APIStatusError is satisfied.
+        synthetic_response = httpx.Response(
+            status_code=status_code,
+            request=httpx.Request("POST", "https://bedrock-runtime.amazonaws.com"),
+        )
+
+        if status_code == 429:
+            raise RateLimitError(message, response=synthetic_response, body=body)
+        if status_code >= 500:
+            raise InternalServerError(message, response=synthetic_response, body=body)
+        if status_code == 400:
+            raise BadRequestError(message, response=synthetic_response, body=body)
+
+        raise APIStatusError(message, response=synthetic_response, body=body)


### PR DESCRIPTION
Fixes #1477

## Problem

`AWSEventStreamDecoder._parse_message_from_event` raises a raw `ValueError` when Bedrock returns a non-200 status code inside the event stream (e.g. `internalServerException`, `throttlingException`). This happens independently of the HTTP response status -- Bedrock signals these errors through the event stream protocol with the event's own `status_code` field.

The raw `ValueError` is uncatchable as a standard SDK error, gives no structured information to the caller, and surfaces as a confusing crash.

## Fix

Replace the `ValueError` with a proper `APIStatusError` subclass constructed from the event's `status_code` and parsed body:

- `429` -> `RateLimitError`
- `>= 500` -> `InternalServerError`  
- `400` -> `BadRequestError`
- anything else -> `APIStatusError`

A synthetic `httpx.Response` is built from the event's status code so the exception contract (`response`, `status_code`, `message`) is fully satisfied.

## Before / After

```python
# Before -- uncatchable, no structured info
ValueError: Bad response code, expected 200: {'status_code': 400, 'headers': {':exception-type': 'internalServerException', ...}, 'body': b'...'}

# After -- catchable, structured
anthropic.InternalServerError: The system encountered an unexpected error during processing. Try your request again.
```

Users can now handle these by type:
```python
from anthropic import InternalServerError, RateLimitError

async with client.messages.stream(...) as stream:
    try:
        async for chunk in stream:
            ...
    except RateLimitError:
        # retry
    except InternalServerError:
        # log and retry
```