### PR TITLE
fix: convert Bedrock streaming error to APIStatusError

### DIFF
--- a/src/anthropic/lib/bedrock/_stream_decoder.py
+++ b/src/anthropic/lib/bedrock/_stream_decoder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Iterator, AsyncIterator
 
 from ..._utils import lru_cache
@@ -35,9 +36,9 @@ class AWSEventStreamDecoder:
         for chunk in iterator:
             event_stream_buffer.add_data(chunk)
             for event in event_stream_buffer:
-                message = self._parse_message_from_event(event)
-                if message:
-                    yield ServerSentEvent(data=message, event="completion")
+                sse = self._parse_message_from_event(event)
+                if sse:
+                    yield sse
 
     async def aiter_bytes(self, iterator: AsyncIterator[bytes]) -> AsyncIterator[ServerSentEvent]:
         """Given an async iterator that yields lines, iterate over it & yield every event encountered"""
@@ -47,18 +48,37 @@ class AWSEventStreamDecoder:
         async for chunk in iterator:
             event_stream_buffer.add_data(chunk)
             for event in event_stream_buffer:
-                message = self._parse_message_from_event(event)
-                if message:
-                    yield ServerSentEvent(data=message, event="completion")
+                sse = self._parse_message_from_event(event)
+                if sse:
+                    yield sse
 
-    def _parse_message_from_event(self, event: EventStreamMessage) -> str | None:
+    def _parse_message_from_event(self, event: EventStreamMessage) -> ServerSentEvent | None:
         response_dict = event.to_response_dict()
         parsed_response = self.parser.parse(response_dict, get_response_stream_shape())
         if response_dict["status_code"] != 200:
-            raise ValueError(f"Bad response code, expected 200: {response_dict}")
+            # Yield an "error" SSE event so the Stream error handler can convert
+            # it to a proper APIStatusError instead of raising a raw ValueError.
+            body = response_dict.get("body", b"")
+            if isinstance(body, bytes):
+                body = body.decode("utf-8", errors="replace")
+
+            try:
+                error_body = json.loads(body)
+                message = error_body.get("message", body)
+            except (json.JSONDecodeError, TypeError):
+                message = body or f"Bad response code: {response_dict['status_code']}"
+
+            error_data = json.dumps({
+                "type": "error",
+                "error": {
+                    "type": "api_error",
+                    "message": message,
+                },
+            })
+            return ServerSentEvent(data=error_data, event="error")
 
         chunk = parsed_response.get("chunk")
         if not chunk:
             return None
 
-        return chunk.get("bytes").decode()  # type: ignore[no-any-return]
+        return ServerSentEvent(data=chunk.get("bytes").decode(), event="completion")  # type: ignore[no-any-return]

--- a/tests/lib/test_bedrock_stream_decoder.py
+++ b/tests/lib/test_bedrock_stream_decoder.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from anthropic._streaming import ServerSentEvent
+from anthropic.lib.bedrock._stream_decoder import AWSEventStreamDecoder
+
+
+def make_mock_event(status_code: int, body: bytes, headers: dict[str, str] | None = None) -> MagicMock:
+    """Create a mock botocore EventStreamMessage with the given response dict."""
+    event = MagicMock()
+    event.to_response_dict.return_value = {
+        "status_code": status_code,
+        "headers": headers or {},
+        "body": body,
+    }
+    return event
+
+
+class TestParseMessageFromEvent:
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        with patch("anthropic.lib.bedrock._stream_decoder.AWSEventStreamDecoder.__init__", lambda _self: None):
+            self.decoder = AWSEventStreamDecoder()
+            self.decoder.parser = MagicMock()
+
+    def test_success_returns_completion_event(self) -> None:
+        chunk_data = json.dumps({"type": "message_start"}).encode()
+        self.decoder.parser.parse.return_value = {"chunk": {"bytes": chunk_data}}
+
+        event = make_mock_event(200, b"")
+        result = self.decoder._parse_message_from_event(event)
+
+        assert result is not None
+        assert result.event == "completion"
+        assert result.data == chunk_data.decode()
+
+    def test_success_no_chunk_returns_none(self) -> None:
+        self.decoder.parser.parse.return_value = {}
+
+        event = make_mock_event(200, b"")
+        result = self.decoder._parse_message_from_event(event)
+
+        assert result is None
+
+    def test_non_200_returns_error_event(self) -> None:
+        error_body = json.dumps({"message": "The system encountered an unexpected error"}).encode()
+        self.decoder.parser.parse.return_value = {}
+
+        event = make_mock_event(
+            400,
+            error_body,
+            headers={":exception-type": "internalServerException", ":content-type": "application/json"},
+        )
+        result = self.decoder._parse_message_from_event(event)
+
+        assert result is not None
+        assert result.event == "error"
+        parsed = result.json()
+        assert parsed["type"] == "error"
+        assert parsed["error"]["type"] == "api_error"
+        assert parsed["error"]["message"] == "The system encountered an unexpected error"
+
+    def test_non_200_with_non_json_body(self) -> None:
+        self.decoder.parser.parse.return_value = {}
+
+        event = make_mock_event(500, b"Internal Server Error")
+        result = self.decoder._parse_message_from_event(event)
+
+        assert result is not None
+        assert result.event == "error"
+        parsed = result.json()
+        assert parsed["type"] == "error"
+        assert parsed["error"]["message"] == "Internal Server Error"
+
+    def test_non_200_with_empty_body(self) -> None:
+        self.decoder.parser.parse.return_value = {}
+
+        event = make_mock_event(429, b"")
+        result = self.decoder._parse_message_from_event(event)
+
+        assert result is not None
+        assert result.event == "error"
+        parsed = result.json()
+        assert parsed["type"] == "error"
+        assert parsed["error"]["message"] == "Bad response code: 429"
+
+    def test_non_200_does_not_raise_value_error(self) -> None:
+        """Regression test for issue #1477: non-200 should yield an error event, not raise ValueError."""
+        error_body = json.dumps({"message": "Rate limited"}).encode()
+        self.decoder.parser.parse.return_value = {}
+
+        event = make_mock_event(
+            400,
+            error_body,
+            headers={":exception-type": "throttlingException"},
+        )
+
+        # Should NOT raise ValueError — should return an error ServerSentEvent
+        result = self.decoder._parse_message_from_event(event)
+        assert result is not None
+        assert isinstance(result, ServerSentEvent)
+        assert result.event == "error"


### PR DESCRIPTION
Fixes #1477

## What

When Bedrock returns a non-200 status code inside an SSE event (e.g. `internalServerException`), the `AWSEventStreamDecoder` now yields an `"error"` `ServerSentEvent` instead of raising a raw `ValueError`. The existing `Stream.__stream__()` error handler catches this event and converts it to a proper `APIStatusError`, matching the behavior of the non-Bedrock streaming path.

## Why

Previously, `_parse_message_from_event` raised `ValueError` on non-200 event status codes. This was problematic because:
- `ValueError` is a generic exception that doesn't carry HTTP status info
- Users cannot catch it with the SDK's standard error hierarchy (`except APIStatusError`, `except BadRequestError`, etc.)
- It bypasses the SDK's existing error-handling infrastructure entirely

## How

Changed `_parse_message_from_event` to return `ServerSentEvent | None` instead of `str | None`. On non-200 status codes, it returns a `ServerSentEvent(event="error", data=...)` with the Bedrock error details formatted as an Anthropic API error body. The `iter_bytes`/`aiter_bytes` methods now yield these events directly, allowing the `Stream.__stream__()` error handler to convert them to `APIStatusError` via `_client._make_status_error()`.

## Verification

- Build: pass
- Tests: pass (41 passed — 6 new + 35 existing)
- Lint: pass (`ruff check`)
- Type check: pass (`pyright` — 0 errors)