### PR TITLE
chore(examples): update shebang from poetry to uv

### DIFF
--- a/examples/bedrock.py
+++ b/examples/bedrock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S poetry run python
+#!/usr/bin/env -S uv run python
 
 # Note: you must have installed `anthropic` with the `bedrock` extra
 # e.g. `pip install -U anthropic[bedrock]`

--- a/examples/text_completions_demo_async.py
+++ b/examples/text_completions_demo_async.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S poetry run python
+#!/usr/bin/env -S uv run python
 
 import asyncio
 

--- a/examples/text_completions_demo_sync.py
+++ b/examples/text_completions_demo_sync.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S poetry run python
+#!/usr/bin/env -S uv run python
 
 import anthropic
 from anthropic import Anthropic

--- a/examples/text_completions_streaming.py
+++ b/examples/text_completions_streaming.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S poetry run python
+#!/usr/bin/env -S uv run python
 
 import asyncio
 


### PR DESCRIPTION
## What

Updates the shebang line in 4 example files from `#!/usr/bin/env -S poetry run python` to `#!/usr/bin/env -S uv run python`.

## Why

The project migrated from poetry to uv (documented in CONTRIBUTING.md), and newer examples like `agents.py` already use the uv shebang. These 4 older examples were left behind:

- `examples/bedrock.py`
- `examples/text_completions_demo_async.py`
- `examples/text_completions_demo_sync.py`
- `examples/text_completions_streaming.py`

No `poetry.lock` exists in the repo anymore, so running these examples with `./examples/bedrock.py` would fail unless a user happened to have poetry installed globally.

## Verification

- Lint: ruff check passed
- Format: ruff format --check passed (no changes needed)
- Syntax: ast.parse verified all 4 files
- Scope: only shebang lines changed, no other modifications