### PR TITLE
Add web search pause_turn resubmission example

### DIFF
--- a/examples/web_search_pause_turn.py
+++ b/examples/web_search_pause_turn.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from anthropic import Anthropic
+from anthropic.types import Message, MessageParam
+
+client = Anthropic()
+
+
+def assistant_turn_from_message(message: Message) -> MessageParam:
+    """Preserve paused server-tool blocks exactly as the SDK returned them."""
+    return {"role": "assistant", "content": message.content}
+
+
+messages: list[MessageParam] = [
+    {"role": "user", "content": "Search for the latest Claude web search documentation."}
+]
+
+while True:
+    message = client.messages.create(
+        model="claude-sonnet-4-5-20250929",
+        max_tokens=1024,
+        messages=messages,
+        tools=[
+            {
+                "name": "web_search",
+                "type": "web_search_20250305",
+            }
+        ],
+    )
+
+    if message.stop_reason != "pause_turn":
+        break
+
+    # Keep the full assistant turn intact. Splitting, filtering, or rewriting
+    # individual server_tool_use blocks can orphan tool state on the next request.
+    messages.append(assistant_turn_from_message(message))
+
+
+print(message.model_dump_json(indent=2))

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -8,6 +8,7 @@ from typing_extensions import Required, Annotated, TypedDict
 
 import pytest
 
+from anthropic.types import ServerToolUseBlock
 from anthropic._types import Base64FileInput, omit, not_given
 from anthropic._utils import (
     PropertyInfo,
@@ -17,6 +18,7 @@ from anthropic._utils import (
 )
 from anthropic._compat import PYDANTIC_V1
 from anthropic._models import BaseModel
+from anthropic.types.message_create_params import MessageCreateParamsNonStreaming
 
 _T = TypeVar("_T")
 
@@ -101,6 +103,48 @@ async def test_union_of_typeddict(use_async: bool) -> None:
     assert await transform({"foo": {"foo_baz": "baz"}}, Foo4, use_async) == {"foo": {"fooBaz": "baz"}}
     assert await transform({"foo": {"foo_baz": "baz", "foo_bar": "bar"}}, Foo4, use_async) == {
         "foo": {"fooBaz": "baz", "fooBar": "bar"}
+    }
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_message_params_preserve_server_tool_use_blocks(use_async: bool) -> None:
+    server_tool_use = ServerToolUseBlock(
+        id="srvtoolu_123",
+        input={"query": "latest Claude docs"},
+        name="web_search",
+        type="server_tool_use",
+    )
+
+    assert await transform(
+        {
+            "max_tokens": 1024,
+            "model": "claude-sonnet-4-5-20250929",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [server_tool_use],
+                }
+            ],
+        },
+        MessageCreateParamsNonStreaming,
+        use_async,
+    ) == {
+        "max_tokens": 1024,
+        "model": "claude-sonnet-4-5-20250929",
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "id": "srvtoolu_123",
+                        "input": {"query": "latest Claude docs"},
+                        "name": "web_search",
+                        "type": "server_tool_use",
+                    }
+                ],
+            }
+        ],
     }
 
 


### PR DESCRIPTION
Fixes #1339

## Summary

- Add a focused web-search `pause_turn` example that appends the paused assistant message as a complete assistant turn.
- Preserve returned server-tool content blocks instead of splitting, filtering, or rewriting individual `server_tool_use` blocks.
- Add regression coverage showing `MessageParam` request transformation preserves `ServerToolUseBlock` models when resubmitting assistant content.

## Verification

- `python -m pytest tests/test_transform.py -q -k server_tool_use` -> 2 passed
- `python -m ruff check tests/test_transform.py examples/web_search_pause_turn.py` -> passed
- `python -m py_compile examples/web_search_pause_turn.py` -> passed
- `git diff --check` -> passed
- AANA code-change guardrail -> pass / accept, AIx 1.0, no violations

Note: `python -m pytest tests/test_transform.py -q` also ran, but two pre-existing Windows-only failures appeared in `test_base64_file_input` because the checked-out `tests/sample_file.txt` has CRLF line endings locally, changing the expected base64 value. The new server-tool regression test passed independently.
