### PR TITLE
Add structured output guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,43 @@ message = client.messages.create(
 print(message.content)
 ```
 
+## Structured outputs
+
+For JSON or schema-constrained responses, use `client.messages.parse()` with an `output_format`.
+This keeps structured output separate from normal tool-use transcripts, so you do not need to
+serialize a schema-only `tool_use` block or fabricate a `tool_result` when continuing a chat.
+
+```python
+import pydantic
+from anthropic import Anthropic
+
+
+class Order(pydantic.BaseModel):
+    product_name: str
+    price: float
+    quantity: int
+
+
+client = Anthropic()
+
+parsed_message = client.messages.parse(
+    model="claude-sonnet-4-5",
+    messages=[
+        {
+            "role": "user",
+            "content": "Extract the order from: 2 packs of Green Tea for 5.50 dollars each.",
+        }
+    ],
+    max_tokens=1024,
+    output_format=Order,
+)
+
+print(parsed_message.parsed_output)
+```
+
+See the runnable examples in [`examples/structured_outputs.py`](./examples/structured_outputs.py)
+and [`examples/structured_outputs_streaming.py`](./examples/structured_outputs_streaming.py).
+
 ## Requirements
 
 Python 3.9+

--- a/examples/structured_outputs.py
+++ b/examples/structured_outputs.py
@@ -11,6 +11,8 @@ class Order(pydantic.BaseModel):
 
 client = anthropic.Anthropic()
 
+# `messages.parse()` is the structured-output path for JSON/schema extraction.
+# It avoids treating a schema-only response as a tool call in later messages.
 prompt = """
 Extract the product name, price, and quantity from this customer message:
 "Hi, I’d like to order 2 packs of Green Tea for 5.50 dollars each."

--- a/examples/structured_outputs_streaming.py
+++ b/examples/structured_outputs_streaming.py
@@ -11,6 +11,8 @@ class Order(pydantic.BaseModel):
 
 client = anthropic.Anthropic()
 
+# `messages.stream()` accepts `output_format` too, so streaming structured output
+# can stay separate from normal tool-use transcripts.
 prompt = """
 Extract the product name, price, and quantity from this customer message:
 "Hi, I'd like to order 2 packs of Green Tea for 5.50 dollars each."


### PR DESCRIPTION
Closes #1034.

## Summary

- documents `client.messages.parse(..., output_format=...)` in the README for JSON/schema-constrained responses
- points readers to the existing structured output examples
- adds comments to the sync and streaming examples clarifying that structured output should stay separate from normal tool-use transcripts

The issue describes the friction of preserving a schema-only `tool_use` block and fabricating a matching `tool_result` when continuing a chat. This PR keeps the implementation unchanged and adds a small, reviewable docs/example path for the SDK's structured-output helper instead.

## Verification

- `python -m compileall examples\structured_outputs.py examples\structured_outputs_streaming.py`

## AANA gate

I used AANA as a verifier/correction gate before publishing this PR. The gate was limited to public repository evidence: the issue text, the README change, and the two existing structured-output examples. It does not certify API behavior, production readiness, compliance, or alignment; it only checked that the PR text stays within those evidence limits and avoids broader claims.
