### PR TITLE
chore(examples): update messages_stream.py shebang from rye to uv

### DIFF
--- a/examples/messages_stream.py
+++ b/examples/messages_stream.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S rye run python
+#!/usr/bin/env -S uv run python
 
 import asyncio
 


### PR DESCRIPTION
## What

Updates the shebang line in `examples/messages_stream.py` from `#!/usr/bin/env -S rye run python` to `#!/usr/bin/env -S uv run python`.

## Why

The project migrated from rye to uv (documented in `CONTRIBUTING.md`), and newer examples like `agents.py`, `agents_comprehensive.py`, and `agents_with_files.py` already use the uv shebang. `messages_stream.py` was the only remaining example still using the rye shebang.

This is a companion fix to #1497, which converted four other older examples from `poetry` to `uv`. No `requirements-rye.lock` exists in the repo anymore, so running this example with `./examples/messages_stream.py` would fail unless a user happened to have rye installed globally.

## Verification

- Lint: `ruff check examples/messages_stream.py` → All checks passed!
- Format: `ruff format --check examples/messages_stream.py` → 1 file already formatted
- Syntax: `python -c "import ast; ast.parse(open('examples/messages_stream.py').read())"` → OK
- Scope: only the shebang line changed, no other modifications