### PR TITLE
fix(bedrock): pass aws_profile to boto3.Session in _infer_region

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -67,7 +67,7 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     return options
 
 
-def _infer_region() -> str:
+def _infer_region(aws_profile: str | None = None) -> str:
     """
     Infer the AWS region from the environment variables or
     from the boto3 session if available.
@@ -77,7 +77,7 @@ def _infer_region() -> str:
         try:
             import boto3
 
-            session = boto3.Session()
+            session = boto3.Session(profile_name=aws_profile)
             if session.region_name:
                 aws_region = session.region_name
         except ImportError:
@@ -178,7 +178,7 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token
@@ -343,7 +343,7 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token


### PR DESCRIPTION
## Problem

When a user passes `aws_profile` to `AnthropicBedrock` or `AsyncAnthropicBedrock` without an explicit `aws_region`, `_infer_region()` is called to look up the region. However `_infer_region()` creates `boto3.Session()` with no arguments, so the named profile's configured region is silently ignored. The client then falls back to `AWS_REGION` env var or hard-coded `us-east-1`.

Minimal reproduction:
```python
# ~/.aws/config has [profile my-profile] with region = eu-west-1
client = AnthropicBedrock(aws_profile="my-profile")
print(client.aws_region)  # prints "us-east-1" instead of "eu-west-1"
```

Fixes #892.

## Fix

Add `aws_profile: str | None = None` to `_infer_region()` and forward it to `boto3.Session(profile_name=aws_profile)`. Update both `AnthropicBedrock.__init__` and `AsyncAnthropicBedrock.__init__` call sites from `_infer_region()` to `_infer_region(aws_profile)`.

```python
# before
session = boto3.Session()

# after
session = boto3.Session(profile_name=aws_profile)
```

The change is backward-compatible: when `aws_profile` is `None` (the default), `boto3.Session(profile_name=None)` behaves identically to `boto3.Session()`.
