### PR TITLE
docs: update outdated model references from claude-3-5-sonnet to claude-sonnet-4-5

### DIFF
--- a/examples/tools_runner.py
+++ b/examples/tools_runner.py
@@ -44,7 +44,7 @@ def get_weather(location: str, units: Literal["c", "f"]) -> str:
 def main() -> None:
     runner = client.beta.messages.tool_runner(
         max_tokens=1024,
-        model="claude-3-5-sonnet-latest",
+        model="claude-sonnet-4-5-20250929",
         # alternatively, you can use `tools=[anthropic.beta_tool(get_weather)]`
         tools=[get_weather],
         messages=[{"role": "user", "content": "What is the weather in SF?"}],

--- a/helpers.md
+++ b/helpers.md
@@ -11,7 +11,7 @@ async with client.messages.stream(
             "content": "Say hello there!",
         }
     ],
-    model="claude-3-5-sonnet-latest",
+    model="claude-sonnet-4-5-20250929",
 ) as stream:
     async for text in stream.text_stream:
         print(text, end="", flush=True)
@@ -60,7 +60,7 @@ async with client.messages.stream(
             "content": "Say hello there!",
         }
     ],
-    model="claude-3-5-sonnet-latest",
+    model="claude-sonnet-4-5-20250929",
 ) as stream:
     async for event in stream:
         if event.type == "text":


### PR DESCRIPTION
## What

Updates outdated `claude-3-5-sonnet-latest` model references to `claude-sonnet-4-5-20250929` in `helpers.md` and `examples/tools_runner.py`, matching the model used in the majority of other examples.

## Changed files

- `helpers.md` (lines 14, 63): streaming code examples referenced `claude-3-5-sonnet-latest`
- `examples/tools_runner.py` (line 47): tool runner example referenced `claude-3-5-sonnet-latest`

## Verification
- Lint: pass (ruff check)
- Format: pass (ruff format --check)
- Syntax: pass (ast.parse)