### PR TITLE
fix(tools): append_messages() inside the tool runner loop no longer infinite-loops or drops the assistant turn

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -15,6 +15,7 @@ from typing import (
     Iterator,
     Coroutine,
     AsyncIterator,
+    cast,
 )
 from contextlib import contextmanager, asynccontextmanager
 from typing_extensions import TypedDict, override
@@ -55,6 +56,17 @@ RunnerItemT = TypeVar("RunnerItemT")
 log = logging.getLogger(__name__)
 
 
+def _has_tool_result(messages: List[BetaMessageParam]) -> bool:
+    """Return True if any message in the list contains a tool_result content block."""
+    for msg in messages:
+        content = msg.get("content", [])
+        if isinstance(content, list) and any(
+            isinstance(b, dict) and b.get("type") == "tool_result" for b in content
+        ):
+            return True
+    return False
+
+
 class RequestOptions(TypedDict, total=False):
     extra_headers: Headers | None
     extra_query: Query | None
@@ -85,7 +97,6 @@ class BaseToolRunner(Generic[AnyFunctionToolT, ResponseFormatT]):
             merged_headers = {**helper_header, **(options.get("extra_headers") or {})}
             options = {**options, "extra_headers": merged_headers}
         self._options = options
-        self._messages_modified = False
         self._cached_tool_call_response: BetaMessageParam | None = None
         self._max_iterations = max_iterations
         self._iteration_count = 0
@@ -116,9 +127,13 @@ class BaseToolRunner(Generic[AnyFunctionToolT, ResponseFormatT]):
             {"role": message.role, "content": message.content} if isinstance(message, BetaMessage) else message
             for message in messages
         ]
-        self._messages_modified = True
         self.set_messages_params(lambda params: {**params, "messages": [*params["messages"], *message_params]})
         self._cached_tool_call_response = None
+
+    def _set_messages_list(self, messages: List[BetaMessageParam]) -> None:
+        # `messages` is a parameter here (not a loop variable), so lambdas that
+        # capture it satisfy both ruff B023 and mypy's callable-type inference.
+        self.set_messages_params(lambda params: {**params, "messages": messages})
 
     def _should_stop(self) -> bool:
         if self._max_iterations is not None and self._iteration_count >= self._max_iterations:
@@ -260,6 +275,7 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
     def __run__(self) -> Iterator[RunnerItemT]:
         while not self._should_stop():
             with self._handle_request() as item:
+                pre_yield_message_count = len(cast(List[BetaMessageParam], self._params["messages"]))
                 yield item
                 message = self._get_last_message()
                 assert message is not None
@@ -273,15 +289,41 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
 
             # If the compaction was performed, skip tool call generation this iteration
             if not self._check_and_compact():
-                response = self.generate_tool_call_response()
-                if response is None:
-                    log.debug("Tool call was not requested, exiting from tool runner loop.")
-                    return
+                all_messages = list(self._params["messages"])
+                user_appended = all_messages[pre_yield_message_count:]
 
-                if not self._messages_modified:
-                    self.append_messages(message, response)
+                if _has_tool_result(user_appended):
+                    # User provided their own tool result. Ensure the assistant message
+                    # precedes it — insert it only when the user did not include it.
+                    if not any(m.get("role") == "assistant" for m in user_appended):
+                        asst_param: BetaMessageParam = {"role": message.role, "content": message.content}
+                        new_messages: List[BetaMessageParam] = [
+                            *all_messages[:pre_yield_message_count],
+                            asst_param,
+                            *user_appended,
+                        ]
+                        self._set_messages_list(new_messages)
+                else:
+                    response = self.generate_tool_call_response()
+                    if response is None:
+                        log.debug("Tool call was not requested, exiting from tool runner loop.")
+                        return
 
-            self._messages_modified = False
+                    if user_appended:
+                        # User appended extra (non-tool_result) messages. Insert the
+                        # auto-generated (assistant, tool_result) pair before them so
+                        # message ordering stays valid for the API.
+                        asst_param = {"role": message.role, "content": message.content}
+                        new_messages = [
+                            *all_messages[:pre_yield_message_count],
+                            asst_param,
+                            response,
+                            *user_appended,
+                        ]
+                        self._set_messages_list(new_messages)
+                    else:
+                        self.append_messages(message, response)
+
             self._cached_tool_call_response = None
 
     def until_done(self) -> ParsedBetaMessage[ResponseFormatT]:
@@ -541,6 +583,7 @@ class BaseAsyncToolRunner(
     async def __run__(self) -> AsyncIterator[RunnerItemT]:
         while not self._should_stop():
             async with self._handle_request() as item:
+                pre_yield_message_count = len(cast(List[BetaMessageParam], self._params["messages"]))
                 yield item
                 message = await self._get_last_message()
                 assert message is not None
@@ -554,15 +597,41 @@ class BaseAsyncToolRunner(
 
             # If the compaction was performed, skip tool call generation this iteration
             if not await self._check_and_compact():
-                response = await self.generate_tool_call_response()
-                if response is None:
-                    log.debug("Tool call was not requested, exiting from tool runner loop.")
-                    return
+                all_messages = list(self._params["messages"])
+                user_appended = all_messages[pre_yield_message_count:]
 
-                if not self._messages_modified:
-                    self.append_messages(message, response)
+                if _has_tool_result(user_appended):
+                    # User provided their own tool result. Ensure the assistant message
+                    # precedes it — insert it only when the user did not include it.
+                    if not any(m.get("role") == "assistant" for m in user_appended):
+                        asst_param: BetaMessageParam = {"role": message.role, "content": message.content}
+                        new_messages: List[BetaMessageParam] = [
+                            *all_messages[:pre_yield_message_count],
+                            asst_param,
+                            *user_appended,
+                        ]
+                        self._set_messages_list(new_messages)
+                else:
+                    response = await self.generate_tool_call_response()
+                    if response is None:
+                        log.debug("Tool call was not requested, exiting from tool runner loop.")
+                        return
 
-            self._messages_modified = False
+                    if user_appended:
+                        # User appended extra (non-tool_result) messages. Insert the
+                        # auto-generated (assistant, tool_result) pair before them so
+                        # message ordering stays valid for the API.
+                        asst_param = {"role": message.role, "content": message.content}
+                        new_messages = [
+                            *all_messages[:pre_yield_message_count],
+                            asst_param,
+                            response,
+                            *user_appended,
+                        ]
+                        self._set_messages_list(new_messages)
+                    else:
+                        self.append_messages(message, response)
+
             self._cached_tool_call_response = None
 
     async def until_done(self) -> ParsedBetaMessage[ResponseFormatT]:

--- a/tests/lib/tools/__inline_snapshot__/test_runners/TestSyncRunTools/f59a9391-643b-422c-96dc-1f28bc7ea4d7.json
+++ b/tests/lib/tools/__inline_snapshot__/test_runners/TestSyncRunTools/f59a9391-643b-422c-96dc-1f28bc7ea4d7.json
@@ -137,7 +137,7 @@
         "anthropic-beta": "structured-outputs-2025-12-15",
         "x-stainless-retry-count": "0",
         "x-stainless-read-timeout": "600",
-        "content-length": "789"
+        "content-length": "598"
       },
       "body": {
         "max_tokens": 1024,
@@ -147,11 +147,28 @@
             "content": "What's the weather in SF in Celsius?"
           },
           {
+            "role": "assistant",
+            "content": [
+              {
+                "type": "tool_use",
+                "id": "toolu_01GHndag5wQmbzNihYmV2UBj",
+                "name": "get_weather",
+                "input": {
+                  "location": "San Francisco, CA",
+                  "units": "c"
+                },
+                "caller": {
+                  "type": "direct"
+                }
+              }
+            ]
+          },
+          {
             "role": "user",
             "content": [
               {
                 "tool_use_id": "toolu_01GHndag5wQmbzNihYmV2UBj",
-                "content": "The weather in San Francisco, CA is currently sunny with a temperature of 20°C.",
+                "content": "The weather in San Francisco, CA is currently sunny with a temperature of 20\u00b0C.",
                 "type": "tool_result"
               }
             ]
@@ -191,12 +208,10 @@
       }
     },
     "response": {
-      "status_code": 400,
+      "status_code": 200,
       "headers": {
         "content-type": "application/json",
-        "content-length": "316",
         "connection": "keep-alive",
-        "x-should-retry": "false",
         "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
         "server": "cloudflare",
         "cf-cache-status": "DYNAMIC",
@@ -204,12 +219,29 @@
         "content-security-policy": "default-src 'none'; frame-ancestors 'none'"
       },
       "body": {
-        "type": "error",
-        "error": {
-          "type": "invalid_request_error",
-          "message": "messages.0.content.1: unexpected `tool_use_id` found in `tool_result` blocks: toolu_01GHndag5wQmbzNihYmV2UBj. Each `tool_result` block must have a corresponding `tool_use` block in the previous message."
-        },
-        "request_id": "req_011CYHyk9NPsBYeGbC9LuDNK"
+        "model": "claude-haiku-4-5-20251001",
+        "id": "msg_01DSPL7PHKQYTe9VAFkHzsA3",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+          {
+            "type": "text",
+            "text": "The weather in San Francisco, CA is currently **20\u00b0C** and **Sunny**. Nice weather!"
+          }
+        ],
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "usage": {
+          "input_tokens": 787,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "cache_creation": {
+            "ephemeral_5m_input_tokens": 0,
+            "ephemeral_1h_input_tokens": 0
+          },
+          "output_tokens": 26,
+          "service_tier": "standard"
+        }
       }
     }
   }

--- a/tests/lib/tools/test_runners.py
+++ b/tests/lib/tools/test_runners.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from typing import Any, Dict, List, Union, cast
+from unittest.mock import NonCallableMagicMock, patch
 from typing_extensions import Literal
 
 import pytest
@@ -73,7 +74,39 @@ ParsedBetaMessage(
             ]
         ),
         "result": snapshot(
-            "ParsedBetaMessage(container=None, content=[ParsedBetaTextBlock(citations=None, parsed_output=None, text='The weather in San Francisco, CA is currently **20°C** and **Sunny**. Nice weather!', type='text')], context_management=None, id='msg_01DSPL7PHKQYTe9VAFkHzsA3', model='claude-haiku-4-5-20251001', role='assistant', stop_details=None, stop_reason='end_turn', stop_sequence=None, type='message', usage=BetaUsage(cache_creation=BetaCacheCreation(ephemeral_1h_input_tokens=0, ephemeral_5m_input_tokens=0), cache_creation_input_tokens=0, cache_read_input_tokens=0, inference_geo=None, input_tokens=787, iterations=None, output_tokens=26, server_tool_use=None, service_tier='standard', speed=None))\n"
+            """\
+ParsedBetaMessage(
+    container=None,
+    content=[
+        ParsedBetaTextBlock(
+            citations=None,
+            parsed_output=None,
+            text='The weather in San Francisco, CA is currently **20°C** and **Sunny**. Nice weather!',
+            type='text'
+        )
+    ],
+    context_management=None,
+    id='msg_01DSPL7PHKQYTe9VAFkHzsA3',
+    model='claude-haiku-4-5-20251001',
+    role='assistant',
+    stop_details=None,
+    stop_reason='end_turn',
+    stop_sequence=None,
+    type='message',
+    usage=BetaUsage(
+        cache_creation=BetaCacheCreation(ephemeral_1h_input_tokens=0, ephemeral_5m_input_tokens=0),
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        inference_geo=None,
+        input_tokens=787,
+        iterations=None,
+        output_tokens=26,
+        server_tool_use=None,
+        service_tier='standard',
+        speed=None
+    )
+)
+"""
         ),
     },
     "streaming": {
@@ -239,8 +272,6 @@ class TestSyncRunTools:
             cast(Any, external("uuid:f59a9391-643b-422c-96dc-1f28bc7ea4d7.json")),
         ],
     )
-    # TODO: fix the append_messages method
-    @pytest.mark.xfail(reason="bug in append messages")
     def test_custom_message_handling(self, snapshot_client: Anthropic) -> None:
         @beta_tool
         def get_weather(location: str, units: Literal["c", "f"]) -> BetaFunctionToolResultType:
@@ -279,6 +310,220 @@ class TestSyncRunTools:
         message = runner.until_done()
 
         assert print_obj(message) == snapshots["custom"]["result"]
+
+    def test_append_extra_message_does_not_cause_infinite_loop(self) -> None:
+        """append_messages() with a non-tool_result message must not skip the
+        auto-generated (assistant, tool_result) pair (regression for issue #1536)."""
+
+        @beta_tool
+        def get_weather(location: str) -> BetaFunctionToolResultType:
+            """Get the weather for a location."""
+            return f"Sunny in {location}"
+
+        tool_use_block = NonCallableMagicMock()
+        tool_use_block.type = "tool_use"
+        tool_use_block.id = "toolu_unit_001"
+        tool_use_block.name = "get_weather"
+        tool_use_block.input = {"location": "SF"}
+
+        tool_use_msg = NonCallableMagicMock()
+        tool_use_msg.role = "assistant"
+        tool_use_msg.stop_reason = "tool_use"
+        tool_use_msg.container = None
+        tool_use_msg.content = [tool_use_block]
+
+        text_block = NonCallableMagicMock()
+        text_block.type = "text"
+        text_block.text = "The weather is sunny."
+
+        end_turn_msg = NonCallableMagicMock()
+        end_turn_msg.role = "assistant"
+        end_turn_msg.stop_reason = "end_turn"
+        end_turn_msg.container = None
+        end_turn_msg.content = [text_block]
+
+        call_count = 0
+        parse_calls: List[Any] = []
+
+        def mock_parse(**kwargs: Any) -> Any:
+            nonlocal call_count
+            call_count += 1
+            parse_calls.append(kwargs)
+            return tool_use_msg if call_count == 1 else end_turn_msg
+
+        client = Anthropic(api_key="test-key", base_url="http://127.0.0.1:1")
+        runner = client.beta.messages.tool_runner(
+            model="claude-haiku-4-5",
+            max_tokens=1024,
+            tools=[get_weather],
+            messages=[{"role": "user", "content": "What's the weather in SF?"}],
+        )
+
+        with patch.object(client.beta.messages, "parse", side_effect=mock_parse):
+            for _ in runner:
+                runner.append_messages({"role": "user", "content": "Remember: be concise."})
+
+        assert call_count == 2, "Expected exactly 2 API calls, not an infinite loop"
+
+        second_messages: List[Any] = parse_calls[1]["messages"]
+        roles = [m["role"] for m in second_messages]
+        assert roles == ["user", "assistant", "user", "user"], (
+            "Expected [initial_user, asst(tool_use), user(tool_result), user(extra)]"
+        )
+        tool_result_content = second_messages[2].get("content", [])
+        assert isinstance(tool_result_content, list) and any(
+            isinstance(b, dict) and b.get("type") == "tool_result" for b in tool_result_content
+        ), "Third message must be the auto-generated tool_result"
+        assert second_messages[3].get("content") == "Remember: be concise.", (
+            "Extra user message must come after the tool_result"
+        )
+
+    def test_append_manual_tool_result_prepends_assistant_message(self) -> None:
+        """When the user provides a tool_result manually, the runner must insert
+        the assistant message before it (regression for issue #1536)."""
+
+        @beta_tool
+        def get_weather(location: str) -> BetaFunctionToolResultType:
+            """Get the weather for a location."""
+            return f"Sunny in {location}"
+
+        tool_use_block = NonCallableMagicMock()
+        tool_use_block.type = "tool_use"
+        tool_use_block.id = "toolu_unit_002"
+        tool_use_block.name = "get_weather"
+        tool_use_block.input = {"location": "SF"}
+
+        tool_use_msg = NonCallableMagicMock()
+        tool_use_msg.role = "assistant"
+        tool_use_msg.stop_reason = "tool_use"
+        tool_use_msg.container = None
+        tool_use_msg.content = [tool_use_block]
+
+        text_block = NonCallableMagicMock()
+        text_block.type = "text"
+        text_block.text = "The weather is sunny."
+
+        end_turn_msg = NonCallableMagicMock()
+        end_turn_msg.role = "assistant"
+        end_turn_msg.stop_reason = "end_turn"
+        end_turn_msg.container = None
+        end_turn_msg.content = [text_block]
+
+        call_count = 0
+        parse_calls: List[Any] = []
+
+        def mock_parse(**kwargs: Any) -> Any:
+            nonlocal call_count
+            call_count += 1
+            parse_calls.append(kwargs)
+            return tool_use_msg if call_count == 1 else end_turn_msg
+
+        client = Anthropic(api_key="test-key", base_url="http://127.0.0.1:1")
+        runner = client.beta.messages.tool_runner(
+            model="claude-haiku-4-5",
+            max_tokens=1024,
+            tools=[get_weather],
+            messages=[{"role": "user", "content": "What's the weather in SF?"}],
+        )
+
+        with patch.object(client.beta.messages, "parse", side_effect=mock_parse):
+            for msg in runner:
+                if msg.stop_reason == "tool_use":
+                    runner.append_messages(
+                        BetaMessageParam(
+                            role="user",
+                            content=[
+                                BetaToolResultBlockParam(
+                                    tool_use_id=msg.content[0].id,
+                                    content="20°C and sunny",
+                                    type="tool_result",
+                                )
+                            ],
+                        )
+                    )
+
+        assert call_count == 2, "Expected exactly 2 API calls"
+
+        second_messages: List[Any] = parse_calls[1]["messages"]
+        assert len(second_messages) == 3, "Expected [initial_user, asst(tool_use), user(tool_result)]"
+        assert second_messages[1]["role"] == "assistant", "Assistant message must be auto-inserted before tool_result"
+        tool_result_content = second_messages[2].get("content", [])
+        assert isinstance(tool_result_content, list) and any(
+            isinstance(b, dict) and b.get("type") == "tool_result" for b in tool_result_content
+        ), "Third message must contain the tool_result block"
+
+    def test_manual_tool_result_with_assistant_not_double_inserted(self) -> None:
+        """When the user provides both the assistant turn AND tool_result themselves,
+        the runner must not insert a second assistant message (regression guard for issue #1536)."""
+
+        @beta_tool
+        def get_weather(location: str) -> BetaFunctionToolResultType:
+            """Get the weather for a location."""
+            return f"Sunny in {location}"
+
+        tool_use_block = NonCallableMagicMock()
+        tool_use_block.type = "tool_use"
+        tool_use_block.id = "toolu_unit_003"
+        tool_use_block.name = "get_weather"
+        tool_use_block.input = {"location": "SF"}
+
+        tool_use_msg = NonCallableMagicMock()
+        tool_use_msg.role = "assistant"
+        tool_use_msg.stop_reason = "tool_use"
+        tool_use_msg.container = None
+        tool_use_msg.content = [tool_use_block]
+
+        text_block = NonCallableMagicMock()
+        text_block.type = "text"
+        text_block.text = "The weather is sunny."
+
+        end_turn_msg = NonCallableMagicMock()
+        end_turn_msg.role = "assistant"
+        end_turn_msg.stop_reason = "end_turn"
+        end_turn_msg.container = None
+        end_turn_msg.content = [text_block]
+
+        call_count = 0
+        parse_calls: List[Any] = []
+
+        def mock_parse(**kwargs: Any) -> Any:
+            nonlocal call_count
+            call_count += 1
+            parse_calls.append(kwargs)
+            return tool_use_msg if call_count == 1 else end_turn_msg
+
+        client = Anthropic(api_key="test-key", base_url="http://127.0.0.1:1")
+        runner = client.beta.messages.tool_runner(
+            model="claude-haiku-4-5",
+            max_tokens=1024,
+            tools=[get_weather],
+            messages=[{"role": "user", "content": "What's the weather in SF?"}],
+        )
+
+        with patch.object(client.beta.messages, "parse", side_effect=mock_parse):
+            for msg in runner:
+                if msg.stop_reason == "tool_use":
+                    # User manually builds the full (assistant, tool_result) pair.
+                    runner.append_messages(
+                        BetaMessageParam(role="assistant", content=msg.content),
+                        BetaMessageParam(
+                            role="user",
+                            content=[
+                                BetaToolResultBlockParam(
+                                    tool_use_id=msg.content[0].id,
+                                    content="20°C and sunny",
+                                    type="tool_result",
+                                )
+                            ],
+                        ),
+                    )
+
+        assert call_count == 2, "Expected exactly 2 API calls"
+
+        second_messages: List[Any] = parse_calls[1]["messages"]
+        assert len(second_messages) == 3, "Expected [initial_user, asst(tool_use), user(tool_result)] — no duplicates"
+        roles = [m["role"] for m in second_messages]
+        assert roles == ["user", "assistant", "user"], "Runner must not double-insert the assistant message"
 
     @pytest.mark.parametrize(
         "http_snapshot",


### PR DESCRIPTION
Fixes #1536.

## What was broken

Calling `append_messages()` inside a tool runner loop had two failure modes, depending on what you appended.

If you added a plain context message like `{"role": "user", "content": "Remember: be concise."}`, the loop ran forever. The runner used a `_messages_modified` flag to decide whether to skip the auto-generated `(assistant, tool_result)` pair. The problem was that both user appends and the auto-append itself set the flag to `True`, so once you called `append_messages()`, the flag never came back down and the loop never stopped.

If you manually provided a `tool_result` block (for cases where you want full control over what gets returned), the runner sent it to the API without the preceding assistant turn. That produced a 400 `unexpected tool_use_id` error every time.

## How the fix works

Before yielding in the loop, the runner now snapshots the current message count. After yield returns, anything between that index and the end of the list is what the user appended. The runner checks whether any of those messages contain a `tool_result` block.

If yes: the user is handling tool results themselves. The runner inserts the assistant turn before their result only if they didn't include it already.

If no: the runner generates tool responses as usual, then splices the auto-generated `(assistant, tool_result)` pair in before any extra messages the user added.

The logic is the same in both the sync (`BaseSyncToolRunner`) and async (`BaseAsyncToolRunner`) paths. `BetaStreamingToolRunner` and `BetaAsyncStreamingToolRunner` both inherit `__run__` from the base classes, so they get the fix for free.

The four call sites that set the full message list now use a private `_set_messages_list` helper instead of inline lambdas. Capturing a loop variable in a lambda triggers `ruff B023`, and the default-arg workaround (`msgs=new_messages`) confuses mypy's callable-type inference. A method parameter solves both at once.

## Tests

`test_custom_message_handling` was previously marked `xfail` with a `# TODO: fix the append_messages method` comment. The xfail is removed and the HTTP fixture updated to replay a proper 200 response instead of the 400 the bug used to produce.

Three new regression tests cover the scenarios from the issue: appending a plain user message (must not loop, must place the tool result correctly), providing a manual tool result (runner must prepend the assistant turn), and providing both the assistant turn and the tool result manually (runner must not insert a second assistant message).