### PR TITLE
fix: only suppress auto-append when caller explicitly provides a tool result

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -111,12 +111,32 @@ class BaseToolRunner(Generic[AnyFunctionToolT, ResponseFormatT]):
 
         This invalidates the cached tool response, i.e. if tools were already called, then they will
         be called again on the next loop iteration.
+
+        If any of the appended messages contain a ``tool_result`` content block, the runner treats
+        this as the caller manually handling the tool response and will skip its own auto-append of
+        the assistant message and tool result for that iteration.  Appending messages that do *not*
+        contain tool results (e.g. an extra user instruction) leaves the auto-append behaviour
+        unchanged so the loop continues correctly.
         """
         message_params: List[BetaMessageParam] = [
             {"role": message.role, "content": message.content} if isinstance(message, BetaMessage) else message
             for message in messages
         ]
-        self._messages_modified = True
+        # Only suppress the runner's auto-append when the caller is explicitly providing a tool
+        # result.  Previously this flag was always set, which caused an infinite loop when callers
+        # appended non-tool-result messages (e.g. extra instructions) inside the loop because the
+        # tool result was never added to the conversation history.
+        has_tool_result = any(
+            isinstance(msg, dict)
+            and isinstance(msg.get("content"), list)
+            and any(
+                isinstance(block, dict) and block.get("type") == "tool_result"
+                for block in msg.get("content", [])
+            )
+            for msg in message_params
+        )
+        if has_tool_result:
+            self._messages_modified = True
         self.set_messages_params(lambda params: {**params, "messages": [*params["messages"], *message_params]})
         self._cached_tool_call_response = None
 

--- a/tests/lib/tools/test_runners.py
+++ b/tests/lib/tools/test_runners.py
@@ -235,6 +235,56 @@ class TestSyncRunTools:
 """
         )
 
+    def test_append_messages_non_tool_result_does_not_suppress_auto_append(self) -> None:
+        """Appending a plain user message must not suppress the runner's auto-append of tool results.
+
+        Regression test for https://github.com/anthropics/anthropic-sdk-python/issues/1536
+
+        Before the fix, *any* call to append_messages() set _messages_modified=True, which caused
+        the runner to skip auto-appending the assistant message + tool result.  The next iteration
+        therefore sent a request with no tool result in history, Claude saw the original question
+        unanswered, made the same tool call again, and the loop never terminated.
+        """
+        from unittest.mock import MagicMock
+
+        from anthropic.lib.tools._beta_runner import BetaToolRunner
+
+        mock_client = MagicMock(spec=Anthropic)
+        runner: BetaToolRunner[None] = BetaToolRunner(
+            params={
+                "model": "claude-haiku-4-5",
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": "What's the weather in SF?"}],
+            },
+            options={},
+            tools=[],
+            client=mock_client,
+        )
+
+        assert runner._messages_modified is False
+
+        # A plain user instruction must NOT flip the flag — the runner still needs to
+        # auto-append the tool result for the loop to terminate.
+        runner.append_messages({"role": "user", "content": "Please be concise."})
+        assert runner._messages_modified is False, (
+            "append_messages() with a non-tool-result message set _messages_modified=True, "
+            "which would suppress the runner's auto-append and cause an infinite loop (issue #1536)"
+        )
+
+        # Manually providing a tool result MUST flip the flag so the runner skips its own
+        # auto-append (the caller is handling the tool result themselves).
+        runner._messages_modified = False  # reset for this sub-check
+        runner.append_messages(
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "fake_id", "content": "sunny"}],
+            }
+        )
+        assert runner._messages_modified is True, (
+            "append_messages() with a tool_result message must set _messages_modified=True "
+            "so the runner skips its own auto-append"
+        )
+
     @pytest.mark.parametrize(
         "http_snapshot",
         [


### PR DESCRIPTION
## Summary

Fixes #1536.

Calling `runner.append_messages()` with a plain user message inside the tool runner loop caused an infinite loop. Any call to `append_messages()` unconditionally set `_messages_modified = True`, which the runner interpreted as the caller manually handling the tool result. It would skip its own auto-append of the assistant message and tool result, so the next iteration sent a request with no tool result in history — Claude saw the original question unanswered, re-issued the same tool call, and the loop never terminated.

## Root cause

`_messages_modified` was serving two distinct purposes with no way to tell them apart:

1. **Caller is adding extra context** (e.g. `append_messages({"role": "user", "content": "be concise"})`) — runner should still auto-append the tool result
2. **Caller is manually providing the tool result** (e.g. `append_messages(assistant_msg, tool_result_msg)`) — runner should skip auto-append

Both paths set the flag, so the runner always skipped auto-append regardless of intent.

## Fix

`_messages_modified` is now only set when at least one of the appended messages contains a `tool_result` content block — the unambiguous signal that the caller is handling the tool result themselves. Appending messages without tool results leaves the flag untouched and the loop continues correctly.

## What this affects

- Sync runner (`BetaToolRunner`) ✅
- Async runner (`BetaAsyncToolRunner`) ✅ — both share the same `append_messages()` on the base class
- The working "Modifying tool results" pattern (passing both assistant message + tool result) continues to work unchanged
- `set_messages_params()` is unaffected — it never touches the flag

## Tests

Added `test_append_messages_non_tool_result_does_not_suppress_auto_append` — a pure unit test (no API calls required) that directly asserts the flag behaviour for both the plain-message case and the tool-result case.

The existing `test_custom_message_handling` (marked `xfail`) is a related but separate issue and remains untouched.