### PR TITLE
fix(tools): percent-decode filename in mcp_resource_to_file

### DIFF
--- a/src/anthropic/lib/tools/mcp.py
+++ b/src/anthropic/lib/tools/mcp.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import base64
 from typing import Any, Iterable
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 from typing_extensions import Literal
 
 try:
@@ -289,9 +289,13 @@ def mcp_resource_to_file(
     resource = result.contents[0]
     uri_str = str(resource.uri)
 
-    # Extract filename from URI
+    # Extract filename from URI. urlparse() does NOT percent-decode the path,
+    # so we unquote here — otherwise a URI like file:///docs/my%20notes.txt
+    # would yield "my%20notes.txt" rather than "my notes.txt", which most
+    # downstream file-upload paths would reject or display wrong.
     path = urlparse(uri_str).path
-    name = path.rsplit("/", 1)[-1] if path else None
+    last_segment = path.rsplit("/", 1)[-1] if path else ""
+    name = unquote(last_segment) if last_segment else None
 
     # Get bytes
     if isinstance(resource, BlobResourceContents):

--- a/tests/lib/tools/test_mcp_tool.py
+++ b/tests/lib/tools/test_mcp_tool.py
@@ -273,6 +273,35 @@ class TestMCPResourceToFile:
         with pytest.raises(UnsupportedMCPValueError):
             mcp_resource_to_file(ReadResourceResult(contents=[]))
 
+    def test_percent_encoded_filename_is_decoded(self) -> None:
+        # urlparse() does not percent-decode the path, so without explicit
+        # unquoting a URI like file:///docs/my%20notes.txt would yield
+        # "my%20notes.txt" instead of "my notes.txt".
+        name, _, _ = mcp_resource_to_file(
+            _read_result(
+                [_text_resource(uri="file:///docs/my%20notes.txt", text="hi").model_dump()]
+            )
+        )
+        assert name == "my notes.txt"
+
+    def test_percent_encoded_unicode_filename_is_decoded(self) -> None:
+        # %E6%97%A5 is the UTF-8 percent-encoding for "日" (U+65E5).
+        name, _, _ = mcp_resource_to_file(
+            _read_result(
+                [_text_resource(uri="file:///%E6%97%A5%E8%A8%98.txt", text="x").model_dump()]
+            )
+        )
+        assert name == "日記.txt"
+
+    def test_uri_with_trailing_slash_yields_no_filename(self) -> None:
+        # Previously this returned "" (empty string), which downstream file-
+        # upload code would treat as a filename and likely reject. None is the
+        # documented signal for "no filename".
+        name, _, _ = mcp_resource_to_file(
+            _read_result([_text_resource(uri="file:///some/dir/", text="hi").model_dump()])
+        )
+        assert name is None
+
 
 # -----------------------------------------------------------------------
 # Tests: tool wrappers


### PR DESCRIPTION
## What's happening

`mcp_resource_to_file` in `src/anthropic/lib/tools/mcp.py` extracts a filename from the MCP resource's URI using `urlparse(uri_str).path`. `urlparse()` does **not** percent-decode the path component, so a resource URI like `file:///docs/my%20notes.txt` was returning a filename of `"my%20notes.txt"` instead of `"my notes.txt"`. The same affects any non-ASCII filename — e.g. `file:///%E6%97%A5%E8%A8%98.txt` was returning the literal percent-encoded string instead of `日記.txt`.

Downstream file-upload paths (the function's whole purpose is to feed `files.upload()`) generally don't recognize percent-encoded names, so the file ends up with a wrong-looking name on the user's account.

There's also a related smaller issue: when the URI ends with a `/` (so there is no last path segment), the previous code returned `""` rather than `None`. The function's return-type annotation already declares `tuple[str | None, bytes, str | None]`, so callers expect `None` as the "no filename" signal — getting `""` instead is a footgun that downstream code can treat as a real (empty) filename.

## The fix

```python
path = urlparse(uri_str).path
last_segment = path.rsplit("/", 1)[-1] if path else ""
name = unquote(last_segment) if last_segment else None
```

That's it. `urllib.parse.unquote` handles both ASCII percent-encoding (`%20` → space) and percent-encoded UTF-8 multi-byte sequences. The empty-string branch correctly collapses to `None`.

## Tests

Three new tests in `tests/lib/tools/test_mcp_tool.py::TestMCPResourceToFile`:

- `test_percent_encoded_filename_is_decoded` — `file:///docs/my%20notes.txt` → `"my notes.txt"`
- `test_percent_encoded_unicode_filename_is_decoded` — `file:///%E6%97%A5%E8%A8%98.txt` → `"日記.txt"`
- `test_uri_with_trailing_slash_yields_no_filename` — `file:///some/dir/` → `None`

The existing tests (which already cover plain ASCII filenames like `doc.txt` and `img.png`) keep passing, so this is purely additive on the behavior side.

```
$ uv run pytest tests/lib/tools/test_mcp_tool.py
..........................................                              [100%]
42 passed in 1.51s
```

No production code paths outside `mcp_resource_to_file` were touched.