### PR TITLE
fix(bedrock,vertex): map 413/529 to typed exceptions, matching canonical client

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -114,6 +114,9 @@ class BaseBedrockClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         if response.status_code == 409:
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
+        if response.status_code == 413:
+            return _exceptions.RequestTooLargeError(err_msg, response=response, body=body)
+
         if response.status_code == 422:
             return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
 
@@ -122,6 +125,9 @@ class BaseBedrockClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
 
         if response.status_code == 503:
             return _exceptions.ServiceUnavailableError(err_msg, response=response, body=body)
+
+        if response.status_code == 529:
+            return _exceptions.OverloadedError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)

--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -70,6 +70,9 @@ class BaseVertexClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         if response.status_code == 409:
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
+        if response.status_code == 413:
+            return _exceptions.RequestTooLargeError(err_msg, response=response, body=body)
+
         if response.status_code == 422:
             return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
 
@@ -81,6 +84,9 @@ class BaseVertexClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
 
         if response.status_code == 504:
             return _exceptions.DeadlineExceededError(err_msg, response=response, body=body)
+
+        if response.status_code == 529:
+            return _exceptions.OverloadedError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
             return _exceptions.InternalServerError(err_msg, response=response, body=body)

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -275,3 +275,37 @@ def test_region_infer_from_specified_profile(
     client = AnthropicBedrock()
 
     assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]
+
+
+@pytest.mark.parametrize(
+    "status_code,expected_type",
+    [
+        (400, "BadRequestError"),
+        (401, "AuthenticationError"),
+        (403, "PermissionDeniedError"),
+        (404, "NotFoundError"),
+        (409, "ConflictError"),
+        (413, "RequestTooLargeError"),
+        (422, "UnprocessableEntityError"),
+        (429, "RateLimitError"),
+        (500, "InternalServerError"),
+        (503, "ServiceUnavailableError"),
+        (529, "OverloadedError"),
+    ],
+)
+def test_bedrock_make_status_error_maps_codes_to_typed_exceptions(
+    status_code: int, expected_type: str
+) -> None:
+    # Bedrock surfaces Anthropic-API status codes; this test pins the mapping
+    # to match the canonical client (see tests/test_client.py) so the two
+    # don't drift. 413 and 529 had been missing on Bedrock — users got a
+    # generic APIStatusError / InternalServerError for request-too-large and
+    # overloaded responses.
+    response = httpx.Response(status_code, request=httpx.Request("GET", "/"))
+
+    for client in (sync_client, async_client):
+        err = client._make_status_error("msg", body=None, response=response)
+        assert type(err).__name__ == expected_type, (
+            f"status {status_code} on {type(client).__name__}: "
+            f"got {type(err).__name__}, expected {expected_type}"
+        )

--- a/tests/lib/test_vertex.py
+++ b/tests/lib/test_vertex.py
@@ -296,3 +296,42 @@ class TestAsyncAnthropicVertex:
             base_url="https://test.googleapis.com/v1",
         )
         assert str(client.base_url).rstrip("/") == "https://test.googleapis.com/v1"
+
+
+# Module-level fixtures for the status-error parity test
+_vertex_sync = AnthropicVertex(region="us-central1", project_id="proj", access_token="tok")
+_vertex_async = AsyncAnthropicVertex(region="us-central1", project_id="proj", access_token="tok")
+
+
+@pytest.mark.parametrize(
+    "status_code,expected_type",
+    [
+        (400, "BadRequestError"),
+        (401, "AuthenticationError"),
+        (403, "PermissionDeniedError"),
+        (404, "NotFoundError"),
+        (409, "ConflictError"),
+        (413, "RequestTooLargeError"),
+        (422, "UnprocessableEntityError"),
+        (429, "RateLimitError"),
+        (500, "InternalServerError"),
+        (503, "ServiceUnavailableError"),
+        (504, "DeadlineExceededError"),
+        (529, "OverloadedError"),
+    ],
+)
+def test_vertex_make_status_error_maps_codes_to_typed_exceptions(
+    status_code: int, expected_type: str
+) -> None:
+    # Pins the Vertex status-error mapping to match the canonical client
+    # plus its own 504 (Google-frontend deadline-exceeded) and 503 mappings.
+    # 413 and 529 had been missing — users got a generic APIStatusError /
+    # InternalServerError for request-too-large and overloaded responses.
+    response = httpx.Response(status_code, request=httpx.Request("GET", "/"))
+
+    for client in (_vertex_sync, _vertex_async):
+        err = client._make_status_error("msg", body=None, response=response)
+        assert type(err).__name__ == expected_type, (
+            f"status {status_code} on {type(client).__name__}: "
+            f"got {type(err).__name__}, expected {expected_type}"
+        )


### PR DESCRIPTION
## What's happening

The Bedrock and Vertex clients' `_make_status_error` methods are missing two status codes that the canonical `Anthropic` / `AsyncAnthropic` clients already map (and that the newer Mantle client also maps):

- **413** → `RequestTooLargeError`
- **529** → `OverloadedError`

So for users running on Bedrock or Vertex:

- A `413` from the upstream API comes back as a generic `APIStatusError` — no `RequestTooLargeError` handler ever fires.
- A `529` "Overloaded" falls into the `>= 500` branch as `InternalServerError` — so retry / backoff code that keys off `OverloadedError` is silently broken on these platforms.

This is purely a drift bug — the canonical client added both mappings ages ago and the platform-specific clients didn't get the same update.

## Comparison

| Code | `_client.py` | `lib/bedrock/_client.py` (before) | `lib/vertex/_client.py` (before) | `lib/bedrock/_mantle.py` |
|------|--------------|-----------------------------------|----------------------------------|--------------------------|
| 400 | ✓ | ✓ | ✓ | ✓ |
| 401 | ✓ | ✓ | ✓ | ✓ |
| 403 | ✓ | ✓ | ✓ | ✓ |
| 404 | ✓ | ✓ | ✓ | ✓ |
| 409 | ✓ | ✓ | ✓ | ✓ |
| **413** | ✓ | **—** | **—** | ✓ |
| 422 | ✓ | ✓ | ✓ | ✓ |
| 429 | ✓ | ✓ | ✓ | ✓ |
| 503 | — | ✓ | ✓ | — |
| 504 | — | — | ✓ | — |
| **529** | ✓ | **—** | **—** | ✓ |
| ≥500 | ✓ | ✓ | ✓ | ✓ |

Bold cells are what this PR adds.

## What this PR does

Adds the missing `413` and `529` mappings to both `lib/bedrock/_client.py` and `lib/vertex/_client.py`. The Bedrock-specific `503` and Vertex-specific `503`/`504` mappings are preserved — those are real platform-frontend statuses and removing them would be a breaking change for users who catch them specifically.

## Tests

Modeled on the existing `test_make_status_error_sync_async_parity` in `tests/test_client.py`, this PR adds parametrized tests that pin the full status-code mapping for both platforms — both sync and async variants:

- `tests/lib/test_bedrock.py::test_bedrock_make_status_error_maps_codes_to_typed_exceptions` — 11 status codes
- `tests/lib/test_vertex.py::test_vertex_make_status_error_maps_codes_to_typed_exceptions` — 12 status codes

```
$ uv run pytest tests/lib/test_bedrock.py tests/lib/test_vertex.py -k make_status_error
======================= 23 passed, 34 deselected in 0.21s ======================
```

The parametrized form will fail loudly the next time someone forgets to add a mapping in just one of the three places.