### PR TITLE
fix: copy mutable file tuple containers

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -170,4 +170,18 @@ def _deepcopy_with_paths(item: _T, paths: Sequence[Sequence[str]], index: int) -
         if not array_paths:
             return cast(_T, item)
         return cast(_T, [_deepcopy_with_paths(entry, array_paths, index + 1) for entry in item])
+    if is_tuple_t(item):
+        tuple_item = cast(tuple[object, ...], item)
+        return cast(_T, _copy_file_container(tuple_item))
+    return item
+
+
+def _copy_file_container(item: object) -> object:
+    if is_mapping(item):
+        return {key: _copy_file_container(value) for key, value in item.items()}
+    if is_list(item):
+        return [_copy_file_container(entry) for entry in item]
+    if is_tuple_t(item):
+        entries = cast(tuple[object, ...], item)
+        return tuple(_copy_file_container(entry) for entry in entries)
     return item

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -91,6 +91,19 @@ class TestDeepcopyWithPaths:
         assert_different_identities(result_items[0], elem1)
         assert_different_identities(result_items[1], elem2)
 
+    def test_copies_mutable_file_tuple_entries(self) -> None:
+        headers = {"x-test": "value"}
+        file = ("example.txt", b"contents", "text/plain", headers)
+        original = {"file": file}
+
+        result = deepcopy_with_paths(original, [["file"]])
+
+        assert_different_identities(result, original)
+        result_file = result["file"]
+        assert_different_identities(result_file, file)
+        assert result_file[:3] == file[:3]
+        assert_different_identities(result_file[3], headers)
+
     def test_empty_paths_returns_same_object(self) -> None:
         original = {"foo": "bar"}
         result = deepcopy_with_paths(original, [])


### PR DESCRIPTION
## Summary

Prevent file upload helpers from sharing mutable containers nested inside file tuples, such as per-file headers dictionaries.

## Changes

- Copy tuple entries that are on extracted file paths while preserving immutable file content references.
- Add regression coverage for a file tuple with mutable headers.

## Testing

- `uv run pyright src/anthropic/_files.py tests/test_files.py`
- `uv run ruff check src/anthropic/_files.py tests/test_files.py`
- `uv run pytest tests/test_files.py -q`

Fixes #1202