### PR TITLE
fix(bedrock): detect region from AWS_DEFAULT_REGION and aws_profile arg

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -67,17 +67,17 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     return options
 
 
-def _infer_region() -> str:
+def _infer_region(aws_profile: str | None = None) -> str:
     """
     Infer the AWS region from the environment variables or
     from the boto3 session if available.
     """
-    aws_region = os.environ.get("AWS_REGION")
+    aws_region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
     if aws_region is None:
         try:
             import boto3
 
-            session = boto3.Session()
+            session = boto3.Session(profile_name=aws_profile)
             if session.region_name:
                 aws_region = session.region_name
         except ImportError:
@@ -178,7 +178,7 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token
@@ -343,7 +343,7 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -246,6 +246,13 @@ def test_api_key_env_mutual_exclusion(monkeypatch: t.Any) -> None:
         )
 
 
+def test_region_infer_from_aws_default_region_env(monkeypatch: t.Any) -> None:
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "ap-southeast-1")
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    client = AnthropicBedrock()
+    assert client.aws_region == "ap-southeast-1"
+
+
 def test_region_infer_from_profile(
     mock_aws_config: None,  # noqa: ARG001
     profiles: t.List[AwsConfigProfile],
@@ -273,5 +280,25 @@ def test_region_infer_from_specified_profile(
 ) -> None:
     monkeypatch.setenv("AWS_PROFILE", aws_profile)
     client = AnthropicBedrock()
+
+    assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]
+
+
+@pytest.mark.parametrize(
+    "profiles, aws_profile",
+    [
+        pytest.param(
+            [{"name": "default", "region": "us-east-2"}, {"name": "custom", "region": "us-west-1"}],
+            "custom",
+            id="custom profile via aws_profile arg",
+        ),
+    ],
+)
+def test_region_infer_from_aws_profile_arg(
+    mock_aws_config: None,  # noqa: ARG001
+    profiles: t.List[AwsConfigProfile],
+    aws_profile: str,
+) -> None:
+    client = AnthropicBedrock(aws_profile=aws_profile)
 
     assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]


### PR DESCRIPTION
The `_infer_region` function in `src/anthropic/lib/bedrock/_client.py` only checked `AWS_REGION` and ignored the standard `AWS_DEFAULT_REGION` environment variable, and did not pass the `aws_profile` argument to the boto3 session, so a non-default profile's region was never picked up. This PR adds `AWS_DEFAULT_REGION` as a fallback after `AWS_REGION`, updates `_infer_region` to accept and forward `aws_profile` to `boto3.Session`, and threads that argument through both `AnthropicBedrock` and `AsyncAnthropicBedrock`. Run `pytest tests/lib/test_bedrock.py` to verify the new `test_region_infer_from_aws_default_region_env` and `test_region_infer_from_aws_profile_arg` tests pass alongside the existing suite.

Fixes #892