### PR TITLE
fix(streaming): wrap from_json in try/except in non-beta message streaming

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,12 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":


### PR DESCRIPTION
## Summary

The beta streaming path (`_beta_messages.py`) already wraps `from_json` in a `try/except ValueError` that surfaces a clear, actionable error when the model emits malformed partial JSON during tool use. The non-beta path (`_messages.py`) made the same `from_json` call with no error handling, so malformed JSON propagated as a raw `jiter` internal error (`ValueError: expected ident at line 1 column 11`) with no context about what went wrong or what to do.

## Change

`src/anthropic/lib/streaming/_messages.py` — wrap the `from_json(json_buf, partial_mode=True)` call in `try/except ValueError` and re-raise with the raw JSON buffer and a retry suggestion, mirroring `_beta_messages.py` lines 500–510 exactly.

**Before:**
```python
if json_buf:
    content.input = from_json(json_buf, partial_mode=True)
```

**After:**
```python
if json_buf:
    try:
        content.input = from_json(json_buf, partial_mode=True)
    except ValueError as e:
        raise ValueError(
            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
        ) from e
```

The error message wording is copied verbatim from the beta path so error handling is consistent across both streaming code paths.