### PR TITLE
fix(bedrock): strip "caller: null" from tool_use blocks to prevent Bedrock HTTP 400

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -35,6 +35,30 @@ _HttpxClientT = TypeVar("_HttpxClientT", bound=Union[httpx.Client, httpx.AsyncCl
 _DefaultStreamT = TypeVar("_DefaultStreamT", bound=Union[Stream[Any], AsyncStream[Any]])
 
 
+def _strip_null_caller_from_tool_use(json_data: dict[object, object]) -> None:
+    # Bedrock rejects `"caller": null` in tool_use / server_tool_use content blocks
+    # with HTTP 400.  ToolUseBlock (response) has `caller: Optional[Caller]`, so
+    # `.to_dict()` includes the key when the value is None.  ToolUseBlockParam
+    # (request) treats `caller` as absent-or-valid, never null, so drop the key
+    # before the payload reaches the Bedrock endpoint.
+    messages = json_data.get("messages")
+    if not isinstance(messages, list):
+        return
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") in {"tool_use", "server_tool_use"}
+                and block.get("caller") is None
+            ):
+                block.pop("caller", None)
+
+
 def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     options = model_copy(input_options, deep=True)
 
@@ -57,6 +81,8 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
             options.url = f"/model/{model}/invoke-with-response-stream"
         else:
             options.url = f"/model/{model}/invoke"
+
+        _strip_null_caller_from_tool_use(options.json_data)
 
     if options.url.startswith("/v1/messages/batches"):
         raise AnthropicError("The Batch API is not supported in Bedrock yet")

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -1,4 +1,5 @@
 import re
+import json
 import typing as t
 import tempfile
 from typing import TypedDict, cast
@@ -275,3 +276,78 @@ def test_region_infer_from_specified_profile(
     client = AnthropicBedrock()
 
     assert client.aws_region == next(profile for profile in profiles if profile["name"] == aws_profile)["region"]
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.respx()
+def test_tool_use_null_caller_stripped(respx_mock: MockRouter) -> None:
+    """Bedrock rejects `"caller": null` in tool_use blocks; verify it is dropped."""
+    respx_mock.post(re.compile(r"https://bedrock-runtime\.us-east-1\.amazonaws\.com/model/.*/invoke")).mock(
+        return_value=httpx.Response(200, json={"foo": "bar"}),
+    )
+
+    sync_client.messages.create(
+        max_tokens=1024,
+        messages=[
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01",
+                        "name": "get_weather",
+                        "input": {"location": "SF"},
+                        "caller": None,
+                    }
+                ],
+            }
+        ],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+
+    calls = cast("list[MockRequestCall]", respx_mock.calls)
+    assert len(calls) == 1
+
+    body = json.loads(calls[0].request.content)
+    tool_use_block = body["messages"][0]["content"][0]
+    assert "caller" not in tool_use_block, (
+        "Bedrock request must not contain 'caller: null' in tool_use blocks"
+    )
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.respx()
+@pytest.mark.asyncio()
+async def test_tool_use_null_caller_stripped_async(respx_mock: MockRouter) -> None:
+    """Bedrock rejects `"caller": null` in tool_use blocks; verify it is dropped (async)."""
+    respx_mock.post(re.compile(r"https://bedrock-runtime\.us-east-1\.amazonaws\.com/model/.*/invoke")).mock(
+        return_value=httpx.Response(200, json={"foo": "bar"}),
+    )
+
+    await async_client.messages.create(
+        max_tokens=1024,
+        messages=[
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_01",
+                        "name": "get_weather",
+                        "input": {"location": "SF"},
+                        "caller": None,
+                    }
+                ],
+            }
+        ],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+
+    calls = cast("list[MockRequestCall]", respx_mock.calls)
+    assert len(calls) == 1
+
+    body = json.loads(calls[0].request.content)
+    tool_use_block = body["messages"][0]["content"][0]
+    assert "caller" not in tool_use_block, (
+        "Bedrock request must not contain 'caller: null' in tool_use blocks"
+    )


### PR DESCRIPTION
## Summary

When a Bedrock streaming or non-streaming response includes a `tool_use` block where the `caller` field is `None` (the common case for model-invoked tools with no explicit caller), calling `.to_dict()` on the resulting `ToolUseBlock` object produces `{"caller": null, ...}`. When this dict is then passed back as part of a follow-up `messages.create` request, Bedrock returns HTTP 400 with `"messages.<n>.content.<m>.tool_use.caller: Input should be a valid dictionary or object to extract fields from"` and the conversation loop breaks.

The root cause is a type asymmetry between the response model (`ToolUseBlock.caller: Optional[Caller] = None`) and the request param type (`ToolUseBlockParam.caller: Caller` with `total=False`): the response type allows `None`, but the request type requires the key to be *absent* (not `null`) when there is no caller. The standard Anthropic and Vertex APIs are lenient about `caller: null`, but Bedrock validates the field strictly.

The fix adds `_strip_null_caller_from_tool_use()` — called inside `_prepare_options()` in the Bedrock client — to remove the `caller` key from any `tool_use` / `server_tool_use` content block where it is `None` before the payload is serialised and sent. The logic is intentionally scoped to the Bedrock code path because only Bedrock enforces this constraint.

## Issue

Fixes #1454

## Local verification

```
$ python -m pytest tests/lib/test_bedrock.py -v --override-ini="addopts="
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /tmp/anthropic-sdk-python
configfile: pyproject.toml
plugins: respx-0.22.0, anyio-4.12.1, time-machine-3.2.0, xdist-3.8.0, asyncio-1.3.0, inline-snapshot-0.32.5, http-snapshot-0.1.8
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
collecting ... collected 14 items

tests/lib/test_bedrock.py::test_messages_retries PASSED                  [  7%]
tests/lib/test_bedrock.py::test_messages_retries_async PASSED            [ 14%]
tests/lib/test_bedrock.py::test_application_inference_profile PASSED     [ 21%]
tests/lib/test_bedrock.py::test_api_key_auth PASSED                      [ 28%]
tests/lib/test_bedrock.py::test_api_key_auth_async PASSED                [ 35%]
tests/lib/test_bedrock.py::test_api_key_from_env PASSED                  [ 42%]
tests/lib/test_bedrock.py::test_api_key_mutual_exclusion PASSED          [ 50%]
tests/lib/test_bedrock.py::test_api_key_mutual_exclusion_async PASSED    [ 57%]
tests/lib/test_bedrock.py::test_api_key_env_mutual_exclusion PASSED      [ 64%]
tests/lib/test_bedrock.py::test_region_infer_from_profile PASSED         [ 71%]
tests/lib/test_bedrock.py::test_region_infer_from_specified_profile[default profile] PASSED [ 78%]
tests/lib/test_bedrock.py::test_region_infer_from_specified_profile[custom profile] PASSED [ 85%]
tests/lib/test_bedrock.py::test_tool_use_null_caller_stripped PASSED     [ 92%]
tests/lib/test_bedrock.py::test_tool_use_null_caller_stripped_async PASSED [100%]

============================== 14 passed in 0.48s ==============================

$ python -m ruff check src/anthropic/lib/bedrock/_client.py tests/lib/test_bedrock.py
All checks passed!

$ python -m mypy src/anthropic/lib/bedrock/_client.py
Success: no issues found in 1 source file
=== LOCAL_TEST_PASSED ===
```

## Risk

The change only affects the Bedrock code path (`_prepare_options` in `src/anthropic/lib/bedrock/_client.py`). It removes `caller: null` from `tool_use` and `server_tool_use` content blocks — a value that Bedrock already rejects with a 400, so no previously-working request can break. Users who explicitly set `caller` to a non-None `Caller` object are unaffected; only `None` values are dropped.
