### PR TITLE
fix(streaming): guard against out-of-bounds content index; fix BetaAsyncAbstractMemoryTool docstring

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -482,6 +482,8 @@ def accumulate_event(
             ),
         )
     elif event.type == "content_block_delta":
+        if event.index >= len(current_snapshot.content):
+            return current_snapshot
         content = current_snapshot.content[event.index]
         if event.delta.type == "text_delta":
             if content.type == "text":
@@ -530,6 +532,8 @@ def accumulate_event(
             if TYPE_CHECKING:  # type: ignore[unreachable]
                 assert_never(event.delta)
     elif event.type == "content_block_stop":
+        if event.index >= len(current_snapshot.content):
+            return current_snapshot
         content_block = current_snapshot.content[event.index]
         if content_block.type == "text" and is_given(output_format):
             content_block.parsed_output = parse_text(content_block.text, output_format)

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -462,6 +462,8 @@ def accumulate_event(
             ),
         )
     elif event.type == "content_block_delta":
+        if event.index >= len(current_snapshot.content):
+            return current_snapshot
         content = current_snapshot.content[event.index]
         if event.delta.type == "text_delta":
             if content.type == "text":
@@ -497,6 +499,8 @@ def accumulate_event(
             if TYPE_CHECKING:  # type: ignore[unreachable]
                 assert_never(event.delta)
     elif event.type == "content_block_stop":
+        if event.index >= len(current_snapshot.content):
+            return current_snapshot
         content_block = current_snapshot.content[event.index]
         if content_block.type == "text" and is_given(output_format):
             content_block.parsed_output = parse_text(content_block.text, output_format)

--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -166,7 +166,7 @@ class BetaAbstractMemoryTool(BetaBuiltinFunctionTool):
 
 
 class BetaAsyncAbstractMemoryTool(BetaAsyncBuiltinFunctionTool):
-    """Abstract base class for memory tool implementations.
+    """Abstract base class for async memory tool implementations.
 
     This class provides the interface for implementing a custom memory backend for Claude.
 
@@ -175,25 +175,31 @@ class BetaAsyncAbstractMemoryTool(BetaAsyncBuiltinFunctionTool):
     Example usage:
 
     ```py
-    class MyMemoryTool(BetaAbstractMemoryTool):
-        def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
+    import asyncio
+    from anthropic import AsyncAnthropic
+
+    class MyMemoryTool(BetaAsyncAbstractMemoryTool):
+        async def view(self, command: BetaMemoryTool20250818ViewCommand) -> BetaFunctionToolResultType:
             ...
             return "view result"
 
-        def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
+        async def create(self, command: BetaMemoryTool20250818CreateCommand) -> BetaFunctionToolResultType:
             ...
             return "created successfully"
 
         # ... implement other abstract methods
 
 
-    client = Anthropic()
-    memory_tool = MyMemoryTool()
-    message = client.beta.messages.run_tools(
-        model="claude-sonnet-4-5",
-        messages=[{"role": "user", "content": "Remember that I like coffee"}],
-        tools=[memory_tool],
-    ).until_done()
+    async def main() -> None:
+        client = AsyncAnthropic()
+        memory_tool = MyMemoryTool()
+        message = await client.beta.messages.run_tools(
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "Remember that I like coffee"}],
+            tools=[memory_tool],
+        ).until_done()
+
+    asyncio.run(main())
     ```
     """
 


### PR DESCRIPTION
Two fixes in this PR.

---

## Fix 1 — `IndexError` when `content_block_delta`/`stop` arrives before `content_block_start` (fixes #1192)

**Files:** `src/anthropic/lib/streaming/_messages.py`, `src/anthropic/lib/streaming/_beta_messages.py`

`accumulate_event` indexes directly into `current_snapshot.content[event.index]` for both `content_block_delta` and `content_block_stop` events. If the server sends a delta or stop for an index that hasn't been populated by a preceding `content_block_start` (server error, reconnect, or race condition), an unhandled `IndexError` propagates to the caller.

Add a bounds guard and return the snapshot unchanged in that case:

```python
# BEFORE
elif event.type == "content_block_delta":
    content = current_snapshot.content[event.index]

# AFTER
elif event.type == "content_block_delta":
    if event.index >= len(current_snapshot.content):
        return current_snapshot
    content = current_snapshot.content[event.index]
```

Applied to both `content_block_delta` and `content_block_stop` in both `_messages.py` and `_beta_messages.py` (4 guards total).

---

## Fix 2 — `BetaAsyncAbstractMemoryTool` docstring is a copy-paste of the sync class (fixes #1290)

**File:** `src/anthropic/lib/tools/_beta_builtin_memory_tool.py`

The docstring for `BetaAsyncAbstractMemoryTool` was a verbatim copy of `BetaAbstractMemoryTool`'s docstring, instructing users to:
- Subclass `BetaAbstractMemoryTool` (the sync class) ❌
- Use `def view` / `def create` (sync methods) ❌  
- Use `Anthropic()` (sync client) ❌

Following the example verbatim raises `TypeError` at runtime. Updated to show the correct async class name, `async def` methods, `AsyncAnthropic` client, and `asyncio.run()` wrapper.