### PR TITLE
fix: update stale #long-requests anchor in timeout error message

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -736,7 +736,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         if expected_time > default_time or (max_nonstreaming_tokens and max_tokens > max_nonstreaming_tokens):
             raise ValueError(
                 "Streaming is required for operations that may take longer than 10 minutes. "
-                + "See https://github.com/anthropics/anthropic-sdk-python#long-requests for more details",
+                + "See https://github.com/anthropics/anthropic-sdk-python#streaming for more details",
             )
         return Timeout(
             default_time,


### PR DESCRIPTION
The error message in _base_client.py referenced `#long-requests` which no longer exists as an anchor in the README. Updated to `#streaming` which covers the relevant content.

Fixes #1430