### PR TITLE
fix: handle error SSE events from Bedrock without AttributeError

### DIFF
--- a/src/anthropic/lib/bedrock/_stream_decoder.py
+++ b/src/anthropic/lib/bedrock/_stream_decoder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Iterator, AsyncIterator
 
 from ..._utils import lru_cache
@@ -37,7 +38,7 @@ class AWSEventStreamDecoder:
             for event in event_stream_buffer:
                 message = self._parse_message_from_event(event)
                 if message:
-                    yield ServerSentEvent(data=message, event="completion")
+                    yield ServerSentEvent(data=message, event=self._sse_event_type(message))
 
     async def aiter_bytes(self, iterator: AsyncIterator[bytes]) -> AsyncIterator[ServerSentEvent]:
         """Given an async iterator that yields lines, iterate over it & yield every event encountered"""
@@ -49,7 +50,25 @@ class AWSEventStreamDecoder:
             for event in event_stream_buffer:
                 message = self._parse_message_from_event(event)
                 if message:
-                    yield ServerSentEvent(data=message, event="completion")
+                    yield ServerSentEvent(data=message, event=self._sse_event_type(message))
+
+    def _sse_event_type(self, message: str) -> str:
+        """Return the SSE event type for a decoded Bedrock message string.
+
+        Bedrock wraps all SSE payloads (including error events) in its binary
+        event-stream framing and delivers them over HTTP 200.  We need to
+        inspect the ``type`` field of the inner JSON so that error payloads are
+        surfaced as ``event="error"`` rather than ``event="completion"``.  The
+        standard ``_streaming.py`` error-handling path already converts
+        ``event="error"`` into the correct ``APIStatusError``.
+        """
+        try:
+            data = json.loads(message)
+            if isinstance(data, dict) and data.get("type") == "error":
+                return "error"
+        except Exception:
+            pass
+        return "completion"
 
     def _parse_message_from_event(self, event: EventStreamMessage) -> str | None:
         response_dict = event.to_response_dict()


### PR DESCRIPTION
## Problem

Bedrock delivers all event-stream frames over HTTP 200, including error payloads (rate-limit, model-not-found, etc.).  `AWSEventStreamDecoder` previously emitted every decoded frame as `ServerSentEvent(event=\"completion\")`, so a Bedrock error payload such as:

```json
{"type": "error", "error": {"type": "rate_limit_error", "message": "Rate limited", "details": null}, "request_id": "req_..."}
```

was routed to `_process_response_data` and cast to the stream event union type.  The cast produced a `RawMessageStartEvent` whose required `message` field was `None`, causing:

```
AttributeError: 'NoneType' object has no attribute 'model'
AttributeError: 'NoneType' object has no attribute 'usage'
```

This was intermittently reproducible with `global.anthropic.claude-opus-4-7` cross-region inference profiles on Bedrock.

## Fix

Add `_sse_event_type()` to `AWSEventStreamDecoder` which inspects the decoded JSON and returns `"error"` when `type == "error"`.  The existing `Stream.__stream__` / `AsyncStream.__stream__` methods in `_streaming.py` already contain a handler for `sse.event == \"error\"` that raises `_make_status_error`, so this routes the payload through the correct path and surfaces a clean `APIStatusError` instead of an `AttributeError`.

No changes to the streaming core are required; the fix is entirely contained in `src/anthropic/lib/bedrock/_stream_decoder.py`.

Fixes #1472