### PR TITLE
docs: clarify skill upload file layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,36 @@ message = client.messages.create(
 print(message.content)
 ```
 
+## File uploads
+
+Request methods that accept `files` use the same tuple format as
+[httpx](https://www.python-httpx.org/advanced/clients/#multipart-file-encoding):
+`("filename", file_or_bytes, "content/type")`.
+
+Skill uploads require each filename to include a single top-level directory that
+contains `SKILL.md`. That directory name must exactly match the `name` field in
+`SKILL.md`. For example, if `SKILL.md` contains `name: greeting`, upload it as
+`greeting/SKILL.md`, not just `SKILL.md`:
+
+```python
+with open("SKILL.md", "rb") as skill_file:
+    client.beta.skills.create(
+        display_title="Greeting skill",
+        files=[("greeting/SKILL.md", skill_file, "text/markdown")],
+    )
+```
+
+For a skill directory on disk, `anthropic.lib.files_from_dir()` can build the
+proper paths for you:
+
+```python
+from anthropic.lib import files_from_dir
+
+client.beta.skills.create(
+    display_title="Greeting skill",
+    files=files_from_dir("greeting"),
+)
+```
 
 ## Requirements
 

--- a/examples/agents_comprehensive.py
+++ b/examples/agents_comprehensive.py
@@ -42,7 +42,8 @@ def main() -> None:
     )
     print("Created credential:", credential.id)
 
-    # Upload a custom skill
+    # Upload a custom skill. Skill file paths must be rooted in a directory whose
+    # name matches the `name` field in SKILL.md (`greeting` in this example).
     skill_md_path = os.path.join(os.path.dirname(__file__), "greeting-SKILL.md")
     with open(skill_md_path, "rb") as skill_file:
         skill = anthropic.beta.skills.create(

--- a/src/anthropic/resources/beta/skills/skills.py
+++ b/src/anthropic/resources/beta/skills/skills.py
@@ -88,7 +88,9 @@ class Skills(SyncAPIResource):
           files: Files to upload for the skill.
 
               All files must be in the same top-level directory and must include a SKILL.md
-              file at the root of that directory.
+              file at the root of that directory. The directory name must exactly match
+              the `name` field in SKILL.md (for example, `greeting/SKILL.md` for
+              `name: greeting`).
 
           display_title: Display title for the skill.
 
@@ -360,7 +362,9 @@ class AsyncSkills(AsyncAPIResource):
           files: Files to upload for the skill.
 
               All files must be in the same top-level directory and must include a SKILL.md
-              file at the root of that directory.
+              file at the root of that directory. The directory name must exactly match
+              the `name` field in SKILL.md (for example, `greeting/SKILL.md` for
+              `name: greeting`).
 
           display_title: Display title for the skill.
 

--- a/src/anthropic/resources/beta/skills/versions.py
+++ b/src/anthropic/resources/beta/skills/versions.py
@@ -91,7 +91,9 @@ class Versions(SyncAPIResource):
           files: Files to upload for the skill.
 
               All files must be in the same top-level directory and must include a SKILL.md
-              file at the root of that directory.
+              file at the root of that directory. The directory name must exactly match
+              the `name` field in SKILL.md (for example, `greeting/SKILL.md` for
+              `name: greeting`).
 
           betas: Optional header to specify the beta version(s) you want to use.
 
@@ -424,7 +426,9 @@ class AsyncVersions(AsyncAPIResource):
           files: Files to upload for the skill.
 
               All files must be in the same top-level directory and must include a SKILL.md
-              file at the root of that directory.
+              file at the root of that directory. The directory name must exactly match
+              the `name` field in SKILL.md (for example, `greeting/SKILL.md` for
+              `name: greeting`).
 
           betas: Optional header to specify the beta version(s) you want to use.
 

--- a/src/anthropic/types/beta/skill_create_params.py
+++ b/src/anthropic/types/beta/skill_create_params.py
@@ -17,7 +17,9 @@ class SkillCreateParams(TypedDict, total=False):
     """Files to upload for the skill.
 
     All files must be in the same top-level directory and must include a SKILL.md
-    file at the root of that directory.
+    file at the root of that directory. The directory name must exactly match the
+    `name` field in SKILL.md (for example, `greeting/SKILL.md` for
+    `name: greeting`).
     """
 
     display_title: Optional[str]

--- a/src/anthropic/types/beta/skills/version_create_params.py
+++ b/src/anthropic/types/beta/skills/version_create_params.py
@@ -17,7 +17,9 @@ class VersionCreateParams(TypedDict, total=False):
     """Files to upload for the skill.
 
     All files must be in the same top-level directory and must include a SKILL.md
-    file at the root of that directory.
+    file at the root of that directory. The directory name must exactly match the
+    `name` field in SKILL.md (for example, `greeting/SKILL.md` for
+    `name: greeting`).
     """
 
     betas: Annotated[List[AnthropicBetaParam], PropertyInfo(alias="anthropic-beta")]

--- a/tests/lib/test_files.py
+++ b/tests/lib/test_files.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+from collections.abc import Iterable
+
+import pytest
+
+from anthropic.lib import files_from_dir, async_files_from_dir
+
+
+def _write_skill_tree(root: Path) -> Path:
+    skill_dir = root / "greeting"
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: greeting\n---\n", encoding="utf-8")
+    (skill_dir / "scripts" / "hello.py").write_text("print('ahoy')\n", encoding="utf-8")
+    return skill_dir
+
+
+def _bytes_by_name(files: Iterable[object]) -> dict[str, bytes]:
+    result: dict[str, bytes] = {}
+    for file in files:
+        assert isinstance(file, tuple)
+        assert isinstance(file[0], str)
+        assert isinstance(file[1], bytes)
+        result[file[0]] = file[1]
+    return result
+
+
+def test_files_from_dir_preserves_skill_top_level(tmp_path: Path) -> None:
+    skill_dir = _write_skill_tree(tmp_path)
+
+    files = _bytes_by_name(files_from_dir(skill_dir))
+
+    assert files == {
+        "greeting/SKILL.md": b"---\nname: greeting\n---\n",
+        "greeting/scripts/hello.py": b"print('ahoy')\n",
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_files_from_dir_preserves_skill_top_level(tmp_path: Path) -> None:
+    skill_dir = _write_skill_tree(tmp_path)
+
+    files = _bytes_by_name(await async_files_from_dir(skill_dir))
+
+    assert files == {
+        "greeting/SKILL.md": b"---\nname: greeting\n---\n",
+        "greeting/scripts/hello.py": b"print('ahoy')\n",
+    }


### PR DESCRIPTION
## Summary
- document that skill upload paths must be rooted under a directory matching the `name` field in `SKILL.md`
- add a README file upload example and clarify the comprehensive agent example
- add regression coverage showing `anthropic.lib.files_from_dir()` preserves the skill top-level directory

Closes #1575.

## Tests
- `uv run pytest tests/lib/test_files.py -q`
- `uv run pytest tests/lib/test_files.py tests/lib/tools/test_skills.py -q`
- `uv run ruff check examples/agents_comprehensive.py src/anthropic/resources/beta/skills/skills.py src/anthropic/resources/beta/skills/versions.py src/anthropic/types/beta/skill_create_params.py src/anthropic/types/beta/skills/version_create_params.py tests/lib/test_files.py`
- `uv run pyright tests/lib/test_files.py`
- `git diff --check`