### PR TITLE
use 'is not None' for max_nonstreaming_tokens check in timeout calculation

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -733,7 +733,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         default_time = 60 * 10
 
         expected_time = maximum_time * max_tokens / 128_000
-        if expected_time > default_time or (max_nonstreaming_tokens and max_tokens > max_nonstreaming_tokens):
+        if expected_time > default_time or (max_nonstreaming_tokens is not None and max_tokens > max_nonstreaming_tokens):
             raise ValueError(
                 "Streaming is required for operations that may take longer than 10 minutes. "
                 + "See https://github.com/anthropics/anthropic-sdk-python#long-requests for more details",


### PR DESCRIPTION
## Problem

`_calculate_nonstreaming_timeout` uses a truthiness guard on `max_nonstreaming_tokens`:

```python
# _base_client.py line 736
if expected_time > default_time or (max_nonstreaming_tokens and max_tokens > max_nonstreaming_tokens):
```

The parameter is typed `int | None`. Checking truthiness silently skips the guard when the value is `0` — a value that would mean "streaming is always required regardless of token count." The condition evaluates to `False` and no `ValueError` is raised.

## Fix

```python
if expected_time > default_time or (max_nonstreaming_tokens is not None and max_tokens > max_nonstreaming_tokens):
```

`is not None` matches the type annotation, makes the intent explicit, and correctly handles a hypothetical `max_nonstreaming_tokens=0` entry in `MODEL_NONSTREAMING_TOKENS`.