### PR TITLE
fix(streaming): align non-beta accumulator with beta implementation

### DIFF
--- a/examples/messages_stream.py
+++ b/examples/messages_stream.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S rye run python
+#!/usr/bin/env -S uv run python
 
 import asyncio
 

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Type, Generic, Callable, cast
 from typing_extensions import Self, Iterator, Awaitable, AsyncIterator, assert_never
@@ -445,7 +446,9 @@ def accumulate_event(
             ),
         )
         if not isinstance(cast(Any, event), BaseModel):
-            raise TypeError(f"Unexpected event runtime type, after deserialising twice - {event} - {type(event)}")
+            raise TypeError(
+                f"Unexpected event runtime type, after deserialising twice - {event} - {builtins.type(event)}"
+            )
 
     if current_snapshot is None:
         if event.type == "message_start":
@@ -458,7 +461,7 @@ def accumulate_event(
         current_snapshot.content.append(
             cast(
                 Any,  # Pydantic does not support generic unions at runtime
-                construct_type(type_=ParsedContentBlock, value=event.content_block.model_dump()),
+                construct_type(type_=ParsedContentBlock, value=event.content_block.to_dict()),
             ),
         )
     elif event.type == "content_block_delta":


### PR DESCRIPTION
## What

Fixes three inconsistencies between `_messages.py` (non-beta) and `_beta_messages.py` (beta) in the streaming accumulator:

1. **`model_dump()` → `to_dict()`** in the `content_block_start` handler — `to_dict()` defaults to `use_api_names=True` and `exclude_unset=True`, which is correct for `construct_type()` and consistent with both the `message_start` handler in the same file (line 452) and the beta version.

2. **`type(event)` → `builtins.type(event)`** in the error path — prevents potential shadowing of the `type` builtin, matching the beta implementation.

3. **`rye` → `uv`** shebang in `examples/messages_stream.py` — the only example still referencing `rye` after the project migrated to `uv` (per CONTRIBUTING.md line 52).

## Why

The beta streaming accumulator appears to have received these fixes independently, but the non-beta version was not updated to match. The `model_dump()` vs `to_dict()` difference is the most significant: if a content block type ever introduces field aliasing, `model_dump()` would pass Python-style keys while `construct_type()` expects API-style keys, causing silent field drops.

## Verification

- Build: pass
- Tests: pass (31 passed — 13 non-beta + 18 beta streaming tests)
- Lint: pass (ruff)
- Type check: pass (pyright 0 errors, mypy 0 errors)