### PR TITLE
docs(_files): replace dead README anchor with platform.claude.com link

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -36,7 +36,7 @@ def assert_is_file_content(obj: object, *, key: str | None = None) -> None:
     if not is_file_content(obj):
         prefix = f"Expected entry at `{key}`" if key is not None else f"Expected file input `{obj!r}`"
         raise RuntimeError(
-            f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://github.com/anthropics/anthropic-sdk-python/tree/main#file-uploads"
+            f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://platform.claude.com/docs/en/api/sdks/python for more details on file uploads."
         ) from None
 
 


### PR DESCRIPTION
## Summary

The `assert_is_file_content` helper in `src/anthropic/_files.py` raises a `RuntimeError` whose message ends with a link to a now-dead README anchor:

```
See https://github.com/anthropics/anthropic-sdk-python/tree/main#file-uploads
```

The README has since been reduced to a stub pointing at `platform.claude.com`, so the `#file-uploads` anchor no longer exists. Users hitting this error and clicking the link land at the top of the README with no guidance. (Sibling broken anchor `#long-requests` was reported in #1430.)

## Fix

Repoint the URL to the live docs site (same target the new README and `CONTRIBUTING.md` recommend):

```diff
-            f"... received {type(obj)} instead. See https://github.com/anthropics/anthropic-sdk-python/tree/main#file-uploads"
+            f"... received {type(obj)} instead. See https://platform.claude.com/docs/en/api/sdks/python for more details on file uploads."
```

## Notes

- Helper file (manual, not Stainless-generated). Pure docstring/error-message fix, no runtime behavior change.
- Verified: `import anthropic` succeeds; `assert_is_file_content(12345)` raises `RuntimeError` whose message now contains `platform.claude.com` and no longer contains `#file-uploads`; `ruff check src/anthropic/_files.py` passes.

## Test plan

- [x] `ruff check src/anthropic/_files.py` passes
- [x] Manual repro: `assert_is_file_content(12345)` raises with updated message
- [x] No behavior change beyond the URL string
