### PR TITLE
docs: fix incorrect docstring in AsyncAnthropicFoundry.models

### DIFF
--- a/src/anthropic/lib/foundry.py
+++ b/src/anthropic/lib/foundry.py
@@ -363,7 +363,7 @@ class AsyncAnthropicFoundry(BaseFoundryClient[httpx.AsyncClient, AsyncStream[Any
     @cached_property
     @override
     def models(self) -> None:  # type: ignore[override]
-        """Models endpoint is not supported for Azure Anthropic client."""
+        """Models endpoint is not supported for Anthropic Foundry client."""
         return None
 
     @cached_property


### PR DESCRIPTION
## Problem

In `src/anthropic/lib/foundry.py`, the `AsyncAnthropicFoundry.models` stub docstring still says "Azure Anthropic client", while its synchronous counterpart `AnthropicFoundry.models` correctly says "Anthropic Foundry client". This looks like a leftover from the rename of the Azure client to the Foundry client.

## Evidence

`src/anthropic/lib/foundry.py:366` (async):

```python
def models(self) -> None:  # type: ignore[override]
    """Models endpoint is not supported for Azure Anthropic client."""
```

`src/anthropic/lib/foundry.py:183` (sync, the correct phrasing):

```python
def models(self) -> None:  # type: ignore[override]
    """Models endpoint is not supported for Anthropic Foundry client."""
```

All other "not supported" docstrings in this file consistently say "Anthropic Foundry client" — the async `models` stub is the only outlier.

## Fix

Align the async docstring with the sync one so the user-facing wording is consistent and accurately refers to the Foundry client.

## Why it's correct

- The class itself is `AsyncAnthropicFoundry`, not an Azure client.
- Every other stub in the file (`batches`, sync `models`, `messages`, `beta`) refers to the "Anthropic Foundry client".
- One-line, docs-only change — no behavioral or type impact.