### PR TITLE
fix(examples): replace dated model ID with non-dated alias in tools.py

### DIFF
--- a/examples/tools.py
+++ b/examples/tools.py
@@ -21,7 +21,7 @@ tools: list[ToolParam] = [
 ]
 
 message = client.messages.create(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
     max_tokens=1024,
     messages=[user_message],
     tools=tools,
@@ -32,7 +32,7 @@ assert message.stop_reason == "tool_use"
 
 tool = next(c for c in message.content if c.type == "tool_use")
 response = client.messages.create(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
     max_tokens=1024,
     messages=[
         user_message,


### PR DESCRIPTION
## Problem
`examples/tools.py` uses `claude-sonnet-4-5-20250929`, a dated model ID
that will return a 404 once that version snapshot is deprecated.

## Fix
Replaced with the stable non-dated alias `claude-sonnet-4-5` which
always resolves to the latest available version of that model family.

Closes #1596