### PR TITLE
fix(parse): add parentheses for operator precedence in minItems check

### DIFF
--- a/src/anthropic/lib/_parse/_transform.py
+++ b/src/anthropic/lib/_parse/_transform.py
@@ -146,7 +146,7 @@ def transform_schema(
             strict_schema["items"] = transform_schema(items)
 
         min_items = json_schema.pop("minItems", None)
-        if min_items is not None and min_items == 0 or min_items == 1:
+        if min_items is not None and (min_items == 0 or min_items == 1):
             strict_schema["minItems"] = min_items
         elif min_items is not None:
             # add it back so its treated as an extra property and appended to the description

--- a/tests/lib/_parse/test_transform.py
+++ b/tests/lib/_parse/test_transform.py
@@ -117,6 +117,38 @@ A list of strings
     )
 
 
+def test_array_schema_min_items_zero():
+    schema = {
+        "type": "array",
+        "items": {"type": "string"},
+        "minItems": 0,
+    }
+    result = transform_schema(schema)
+    assert result == snapshot(
+        {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 0,
+        }
+    )
+
+
+def test_array_schema_min_items_one():
+    schema = {
+        "type": "array",
+        "items": {"type": "string"},
+        "minItems": 1,
+    }
+    result = transform_schema(schema)
+    assert result == snapshot(
+        {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+        }
+    )
+
+
 def test_string_schema_with_format_and_default():
     schema = {
         "type": "string",


### PR DESCRIPTION
## What

Adds explicit parentheses to the `minItems` condition in `transform_schema()` to clarify operator precedence, and adds missing test coverage for `minItems: 0` and `minItems: 1`.

## Why

The condition on line 149 of `_transform.py`:

```python
if min_items is not None and min_items == 0 or min_items == 1:
```

evaluates as `(min_items is not None and min_items == 0) or (min_items == 1)` due to Python's operator precedence (`and` binds tighter than `or`). The intended grouping is `min_items is not None and (min_items == 0 or min_items == 1)`.

Both produce identical results for all practical inputs (`None`, `0`, `1`, `2+`), so this is not a behavioral bug — but the missing parentheses make the intent ambiguous and could mislead future readers or refactors.

## Changes

- **`src/anthropic/lib/_parse/_transform.py`**: Add parentheses around the `or` clause
- **`tests/lib/_parse/test_transform.py`**: Add `test_array_schema_min_items_zero` and `test_array_schema_min_items_one` to cover the previously untested code path

## Verification
- Build: pass
- Tests: pass (15 passed)
- Lint: pass
- Type check: pass (pyright 0 errors)