### PR TITLE
fix(examples): use non-dated model aliases

### DIFF
--- a/examples/images.py
+++ b/examples/images.py
@@ -25,6 +25,6 @@ response = client.messages.create(
             ],
         },
     ],
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
 )
 print(response.model_dump_json(indent=2))

--- a/examples/mcp_tool_runner.py
+++ b/examples/mcp_tool_runner.py
@@ -42,7 +42,7 @@ async def main() -> None:
 
             # Run a conversation with tool_runner()
             runner = client.beta.messages.tool_runner(
-                model="claude-sonnet-4-5-20250929",
+                model="claude-sonnet-4-5",
                 max_tokens=1024,
                 tools=tools,
                 messages=[{"role": "user", "content": "List the files in /tmp"}],

--- a/examples/messages.py
+++ b/examples/messages.py
@@ -10,7 +10,7 @@ response = client.messages.create(
             "content": "Hello!",
         }
     ],
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
 )
 print(response)
 
@@ -30,6 +30,6 @@ response2 = client.messages.create(
             "content": "How are you?",
         },
     ],
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
 )
 print(response2)

--- a/examples/messages_stream.py
+++ b/examples/messages_stream.py
@@ -16,7 +16,7 @@ async def main() -> None:
                 "content": "Say hello there!",
             }
         ],
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-5",
     ) as stream:
         async for event in stream:
             if event.type == "text":

--- a/examples/text_completions_demo_async.py
+++ b/examples/text_completions_demo_async.py
@@ -10,7 +10,7 @@ async def main() -> None:
     client = AsyncAnthropic()
 
     res = await client.completions.create(
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-5",
         prompt=f"{anthropic.HUMAN_PROMPT} how does a court case get to the Supreme Court? {anthropic.AI_PROMPT}",
         max_tokens_to_sample=1000,
     )

--- a/examples/text_completions_demo_sync.py
+++ b/examples/text_completions_demo_sync.py
@@ -8,7 +8,7 @@ def main() -> None:
     client = Anthropic()
 
     res = client.completions.create(
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-5",
         prompt=f"{anthropic.HUMAN_PROMPT} how does a court case get to the Supreme Court? {anthropic.AI_PROMPT}",
         max_tokens_to_sample=1000,
     )

--- a/examples/text_completions_streaming.py
+++ b/examples/text_completions_streaming.py
@@ -15,7 +15,7 @@ Hey Claude! How can I recursively list all files in a directory in Python?
 def sync_stream() -> None:
     stream = client.completions.create(
         prompt=f"{HUMAN_PROMPT} {question}{AI_PROMPT}",
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-5",
         stream=True,
         max_tokens_to_sample=300,
     )
@@ -29,7 +29,7 @@ def sync_stream() -> None:
 async def async_stream() -> None:
     stream = await async_client.completions.create(
         prompt=f"{HUMAN_PROMPT} {question}{AI_PROMPT}",
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-5",
         stream=True,
         max_tokens_to_sample=300,
     )

--- a/examples/thinking.py
+++ b/examples/thinking.py
@@ -3,7 +3,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 response = client.messages.create(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
     max_tokens=3200,
     thinking={"type": "enabled", "budget_tokens": 1600},
     messages=[{"role": "user", "content": "Create a haiku about Anthropic."}],

--- a/examples/thinking_stream.py
+++ b/examples/thinking_stream.py
@@ -3,7 +3,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 with client.messages.stream(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
     max_tokens=3200,
     thinking={"type": "enabled", "budget_tokens": 1600},
     messages=[{"role": "user", "content": "Create a haiku about Anthropic."}],

--- a/examples/tools.py
+++ b/examples/tools.py
@@ -21,7 +21,7 @@ tools: list[ToolParam] = [
 ]
 
 message = client.messages.create(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
     max_tokens=1024,
     messages=[user_message],
     tools=tools,
@@ -32,7 +32,7 @@ assert message.stop_reason == "tool_use"
 
 tool = next(c for c in message.content if c.type == "tool_use")
 response = client.messages.create(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
     max_tokens=1024,
     messages=[
         user_message,

--- a/examples/tools_runner_search_tool.py
+++ b/examples/tools_runner_search_tool.py
@@ -68,7 +68,7 @@ def main() -> None:
     ]
     runner = client.beta.messages.tool_runner(
         max_tokens=1024,
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-5",
         tools=[*tools, make_tool_searcher(tools)],
         messages=[{"role": "user", "content": "What is the weather in SF?"}],
         betas=["tool-search-tool-2025-10-19"],

--- a/examples/tools_stream.py
+++ b/examples/tools_stream.py
@@ -8,7 +8,7 @@ client = AsyncAnthropic()
 async def main() -> None:
     async with client.messages.stream(
         max_tokens=1024,
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-5",
         tools=[
             {
                 "name": "get_weather",

--- a/examples/web_search.py
+++ b/examples/web_search.py
@@ -6,7 +6,7 @@ client = Anthropic()
 
 # Create a message with web search enabled
 message = client.messages.create(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
     max_tokens=1024,
     messages=[{"role": "user", "content": "What's the weather in New York?"}],
     tools=[

--- a/examples/web_search_stream.py
+++ b/examples/web_search_stream.py
@@ -11,7 +11,7 @@ async def main() -> None:
 
     # Create an async stream with web search enabled
     async with client.beta.messages.stream(
-        model="claude-sonnet-4-5-20250929",
+        model="claude-sonnet-4-5",
         max_tokens=1024,
         messages=[{"role": "user", "content": "What's the weather in New York?"}],
         tools=[


### PR DESCRIPTION
Fixes #1596

## Summary
- replace dated `claude-sonnet-4-5-20250929` model snapshots in non-Bedrock examples with the stable `claude-sonnet-4-5` alias
- leave Bedrock example model IDs unchanged because Bedrock uses provider-specific model identifiers

## Tests
- `uv run ruff check examples/messages_stream.py examples/thinking_stream.py examples/text_completions_demo_sync.py examples/web_search_stream.py examples/tools.py examples/tools_runner_search_tool.py examples/thinking.py examples/text_completions_streaming.py examples/images.py examples/messages.py examples/web_search.py examples/mcp_tool_runner.py examples/text_completions_demo_async.py examples/tools_stream.py`
- `uv run python -m compileall -q examples`
