### PR TITLE
Add HEIC/HEIF image format support to Vision API

### DIFF
--- a/src/anthropic/lib/tools/mcp.py
+++ b/src/anthropic/lib/tools/mcp.py
@@ -68,7 +68,7 @@ __all__ = [
 # Supported MIME types
 # -----------------------------------------------------------------------
 
-_SUPPORTED_IMAGE_TYPES = frozenset({"image/jpeg", "image/png", "image/gif", "image/webp"})
+_SUPPORTED_IMAGE_TYPES = frozenset({"image/jpeg", "image/png", "image/gif", "image/webp", "image/heic", "image/heif"})
 
 
 class _TaggedDict(dict):  # type: ignore[type-arg]

--- a/src/anthropic/types/base64_image_source_param.py
+++ b/src/anthropic/types/base64_image_source_param.py
@@ -15,7 +15,7 @@ __all__ = ["Base64ImageSourceParam"]
 class Base64ImageSourceParam(TypedDict, total=False):
     data: Required[Annotated[Union[str, Base64FileInput], PropertyInfo(format="base64")]]
 
-    media_type: Required[Literal["image/jpeg", "image/png", "image/gif", "image/webp"]]
+    media_type: Required[Literal["image/jpeg", "image/png", "image/gif", "image/webp", "image/heic", "image/heif"]]
 
     type: Required[Literal["base64"]]
 

--- a/src/anthropic/types/beta/beta_base64_image_source_param.py
+++ b/src/anthropic/types/beta/beta_base64_image_source_param.py
@@ -15,7 +15,7 @@ __all__ = ["BetaBase64ImageSourceParam"]
 class BetaBase64ImageSourceParam(TypedDict, total=False):
     data: Required[Annotated[Union[str, Base64FileInput], PropertyInfo(format="base64")]]
 
-    media_type: Required[Literal["image/jpeg", "image/png", "image/gif", "image/webp"]]
+    media_type: Required[Literal["image/jpeg", "image/png", "image/gif", "image/webp", "image/heic", "image/heif"]]
 
     type: Required[Literal["base64"]]
 

--- a/src/anthropic/types/beta/sessions/beta_managed_agents_base64_image_source.py
+++ b/src/anthropic/types/beta/sessions/beta_managed_agents_base64_image_source.py
@@ -16,7 +16,7 @@ class BetaManagedAgentsBase64ImageSource(BaseModel):
     media_type: str
     """
     MIME type of the image (e.g., "image/png", "image/jpeg", "image/gif",
-    "image/webp").
+    "image/webp", "image/heic", "image/heif").
     """
 
     type: Literal["base64"]

--- a/src/anthropic/types/beta/sessions/beta_managed_agents_base64_image_source_param.py
+++ b/src/anthropic/types/beta/sessions/beta_managed_agents_base64_image_source_param.py
@@ -16,7 +16,7 @@ class BetaManagedAgentsBase64ImageSourceParam(TypedDict, total=False):
     media_type: Required[str]
     """
     MIME type of the image (e.g., "image/png", "image/jpeg", "image/gif",
-    "image/webp").
+    "image/webp", "image/heic", "image/heif").
     """
 
     type: Required[Literal["base64"]]

--- a/tests/lib/tools/test_mcp_tool.py
+++ b/tests/lib/tools/test_mcp_tool.py
@@ -101,6 +101,16 @@ class TestMCPContent:
         result = mcp_content(ImageContent(type="image", data="abc", mimeType="image/webp"))
         assert result["type"] == "image"
 
+    def test_image_content_heic(self) -> None:
+        result = mcp_content(ImageContent(type="image", data="heicdata", mimeType="image/heic"))
+        assert result["type"] == "image"
+        assert result["source"]["media_type"] == "image/heic"
+
+    def test_image_content_heif(self) -> None:
+        result = mcp_content(ImageContent(type="image", data="heifdata", mimeType="image/heif"))
+        assert result["type"] == "image"
+        assert result["source"]["media_type"] == "image/heif"
+
     def test_image_unsupported_mime_type(self) -> None:
         with pytest.raises(UnsupportedMCPValueError, match="image/bmp"):
             mcp_content(ImageContent(type="image", data="abc", mimeType="image/bmp"))


### PR DESCRIPTION
## Summary

Adds `image/heic` and `image/heif` to the set of accepted image media types across the SDK. iOS devices have used HEIC as their default camera format since iOS 11 (2017), and HEIC files are ~50% smaller than JPEG at equivalent quality.

## Changes

| File | Change |
|------|--------|
| `src/anthropic/types/base64_image_source_param.py` | Added `"image/heic"` and `"image/heif"` to the `media_type` Literal |
| `src/anthropic/types/beta/beta_base64_image_source_param.py` | Same |
| `src/anthropic/lib/tools/mcp.py` | Added to `_SUPPORTED_IMAGE_TYPES` frozenset |
| `src/anthropic/types/beta/sessions/beta_managed_agents_base64_image_source_param.py` | Updated docstring |
| `src/anthropic/types/beta/sessions/beta_managed_agents_base64_image_source.py` | Updated docstring |
| `tests/lib/tools/test_mcp_tool.py` | Added `test_image_content_heic` and `test_image_content_heif` |

## Why this matters

- HEIC is the default camera format on every iPhone and iPad since 2017
- ~50% smaller file size vs JPEG at same quality means faster uploads and lower bandwidth
- Without SDK-level support, mobile web apps must ship a ~1.3MB transcoding library (heic2any)

Closes #1589