### PR TITLE
test: cover indexed query array parameters

### DIFF
--- a/tests/test_qs.py
+++ b/tests/test_qs.py
@@ -73,6 +73,18 @@ def test_array_brackets(method: str) -> None:
     assert unquote(serialise({"a": {"b": [True, False, None, True]}})) == "a[b][]=true&a[b][]=false&a[b][]=true"
 
 
+@pytest.mark.parametrize("method", ["class", "function"])
+def test_array_indices(method: str) -> None:
+    if method == "class":
+        serialise = Querystring(array_format="indices").stringify
+    else:
+        serialise = partial(stringify, array_format="indices")
+
+    assert unquote(serialise({"in": ["foo", "bar"]})) == "in[0]=foo&in[1]=bar"
+    assert unquote(serialise({"a": {"b": [True, False]}})) == "a[b][0]=true&a[b][1]=false"
+    assert unquote(serialise({"a": {"b": [True, False, None, True]}})) == "a[b][0]=true&a[b][1]=false&a[b][3]=true"
+
+
 def test_unknown_array_format() -> None:
     with pytest.raises(NotImplementedError, match="Unknown array_format value: foo, choose from comma, repeat"):
         stringify({"a": ["foo", "bar"]}, array_format=cast(Any, "foo"))


### PR DESCRIPTION
## Summary
- add coverage for the supported indexed query array format
- verify both the `Querystring` instance path and module-level `stringify` helper preserve indexes, including skipped `None` values

## Validation
- `/tmp/anthropic-pdlc042-venv/bin/python -m pytest tests/test_qs.py -q`
- `git diff --check`