### PR TITLE
fix(_transform): guard bare dict annotation to avoid IndexError

### DIFF
--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -180,7 +180,8 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        items_type = args[1] if len(args) >= 2 else Any
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +347,8 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        items_type = args[1] if len(args) >= 2 else Any
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -458,3 +458,12 @@ async def test_strips_notgiven(use_async: bool) -> None:
 async def test_strips_omit(use_async: bool) -> None:
     assert await transform({"foo_bar": "bar"}, Foo1, use_async) == {"fooBar": "bar"}
     assert await transform({"foo_bar": omit}, Foo1, use_async) == {}
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_transform_recursive_bare_dict_no_index_error(use_async: bool) -> None:
+    # A bare (unparameterized) `dict` annotation must not raise IndexError when
+    # get_args(dict) returns () and the code tries to index position [1].
+    result = await transform({"key": "value"}, dict, use_async)
+    assert result == {"key": "value"}


### PR DESCRIPTION
## What's broken

`transform({"key": "value"}, dict)` raises `IndexError: tuple index out of range` in `_transform_recursive` (line 183) and `_async_transform_recursive` (line 349). Both branches unconditionally access `get_args(stripped_type)[1]` to get the value type. When the annotation is a bare `dict` rather than `Dict[K, V]`, `get_args(dict)` returns `()`, so the index fails.

```
IndexError: tuple index out of range
  File "_transform.py", line 183, in _transform_recursive
    items_type = get_args(stripped_type)[1]
```

## Why it happens

`get_args` on an unparameterized `dict` returns an empty tuple, and the code assumed at least two type arguments were always present.

## Fix

Added a `len(args) >= 2` guard before indexing. Falls back to `Any` for bare dicts, matching the same pattern already used in `_models.py`. Both sync and async variants are fixed.

## Test

Added `test_transform_recursive_bare_dict_no_index_error` which calls `transform({"key": "value"}, dict)` for both sync and async paths and asserts no exception and correct output.

Fixes #1628