### PR TITLE
fix(bedrock): pass aws_profile to _infer_region() for correct region detection

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -67,7 +67,7 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     return options
 
 
-def _infer_region() -> str:
+def _infer_region(aws_profile: str | None = None) -> str:
     """
     Infer the AWS region from the environment variables or
     from the boto3 session if available.
@@ -77,7 +77,7 @@ def _infer_region() -> str:
         try:
             import boto3
 
-            session = boto3.Session()
+            session = boto3.Session(profile_name=aws_profile)
             if session.region_name:
                 aws_region = session.region_name
         except ImportError:
@@ -178,7 +178,7 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile=aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token
@@ -343,7 +343,7 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile=aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token


### PR DESCRIPTION
## Summary

When `aws_profile` is specified in `AnthropicBedrock` or `AnthropicBedrockClient` but `AWS_REGION` is not set, `_infer_region()` previously created a `boto3.Session()` without `profile_name`, defaulting to the 'default' profile and ignoring the caller's explicitly configured profile. This caused cross-region inference failures (HTTP 403) for users with non-default AWS profiles.

## Root cause

`_infer_region()` called `boto3.Session()` with no arguments, which uses the default profile regardless of what `aws_profile` the caller specified. The user's profile might have `region = us-west-2` configured, but `_infer_region` would still return `us-east-1`.

## Fix

- Accept an optional `aws_profile` parameter in `_infer_region()`
- Pass it through to `boto3.Session(profile_name=aws_profile)`
- Update both call sites (`AnthropicBedrock` and `AnthropicBedrockClient`) to pass `aws_profile`

## Test plan

The fix matches the verified solution from the issue thread (multiple users confirmed it works).

Before:
```python
# profile "prod" has region = us-west-2, but AWS_REGION is unset
client = AnthropicBedrock(aws_profile="prod")
print(client.aws_region)  # us-east-1 (WRONG)
```

After:
```python
client = AnthropicBedrock(aws_profile="prod")
print(client.aws_region)  # us-west-2 (CORRECT)
```

Closes #892.