### PR TITLE
Accept auth_token in AnthropicFoundry.__init__ so .copy() doesn't crash

### DIFF
--- a/src/anthropic/lib/foundry.py
+++ b/src/anthropic/lib/foundry.py
@@ -126,6 +126,10 @@ class AnthropicFoundry(BaseFoundryClient[httpx.Client, Stream[Any]], Anthropic):
         resource: str | None = None,
         api_key: str | None = None,
         azure_ad_token_provider: AzureADTokenProvider | None = None,
+        # Passed through to parent but not used for Foundry auth; accepted so
+        # the parent's `copy()` (which forwards `auth_token=self.auth_token`)
+        # doesn't raise TypeError when called on a Foundry client.
+        auth_token: str | None = None,
         webhook_key: str | None = None,
         base_url: str | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
@@ -166,6 +170,7 @@ class AnthropicFoundry(BaseFoundryClient[httpx.Client, Stream[Any]], Anthropic):
 
         super().__init__(
             api_key=api_key,
+            auth_token=auth_token,
             webhook_key=webhook_key,
             base_url=base_url,
             timeout=timeout,
@@ -309,6 +314,10 @@ class AsyncAnthropicFoundry(BaseFoundryClient[httpx.AsyncClient, AsyncStream[Any
         resource: str | None = None,
         api_key: str | None = None,
         azure_ad_token_provider: AsyncAzureADTokenProvider | None = None,
+        # Passed through to parent but not used for Foundry auth; accepted so
+        # the parent's `copy()` (which forwards `auth_token=self.auth_token`)
+        # doesn't raise TypeError when called on a Foundry client.
+        auth_token: str | None = None,
         webhook_key: str | None = None,
         base_url: str | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
@@ -349,6 +358,7 @@ class AsyncAnthropicFoundry(BaseFoundryClient[httpx.AsyncClient, AsyncStream[Any
 
         super().__init__(
             api_key=api_key,
+            auth_token=auth_token,
             webhook_key=webhook_key,
             base_url=base_url,
             timeout=timeout,

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -65,6 +65,20 @@ class TestAnthropicFoundry:
                 api_key="test-key",
             )
 
+    def test_copy_does_not_crash(self) -> None:
+        """Regression: ``copy()`` forwards ``auth_token`` via the parent client,
+        so ``AnthropicFoundry.__init__`` must accept it (passed through but
+        unused), mirroring ``AnthropicAWS``. Previously raised
+        ``TypeError: ... got an unexpected keyword argument 'auth_token'``.
+        """
+        client = AnthropicFoundry(api_key="test-key", resource="example-resource")
+        copied = client.copy()
+        assert isinstance(copied, AnthropicFoundry)
+        assert copied.api_key == "test-key"
+
+        copied_with_override = client.copy(timeout=30)
+        assert copied_with_override.timeout == 30
+
 
 class TestAsyncAnthropicFoundry:
     @pytest.mark.asyncio
@@ -104,3 +118,17 @@ class TestAsyncAnthropicFoundry:
 
         assert client.api_key == "env-key"
         assert "env-resource.services.ai.azure.com" in str(client.base_url)
+
+    def test_copy_does_not_crash(self) -> None:
+        """Regression: ``copy()`` forwards ``auth_token`` via the parent client,
+        so ``AsyncAnthropicFoundry.__init__`` must accept it (passed through
+        but unused), mirroring ``AsyncAnthropicAWS``. Previously raised
+        ``TypeError: ... got an unexpected keyword argument 'auth_token'``.
+        """
+        client = AsyncAnthropicFoundry(api_key="test-key", resource="example-resource")
+        copied = client.copy()
+        assert isinstance(copied, AsyncAnthropicFoundry)
+        assert copied.api_key == "test-key"
+
+        copied_with_override = client.copy(timeout=30)
+        assert copied_with_override.timeout == 30


### PR DESCRIPTION
## Summary

Calling `.copy()` on an `AnthropicFoundry` (or `AsyncAnthropicFoundry`) client always raises:

```
TypeError: AnthropicFoundry.__init__() got an unexpected keyword argument 'auth_token'
```

The Foundry `copy()` overload (`src/anthropic/lib/foundry.py:204`) declares an `auth_token` parameter and forwards it via `super().copy(auth_token=auth_token, ...)`. The parent `Anthropic.copy()` (`src/anthropic/_client.py:477–479`) then unconditionally passes `auth_token=auth_token or self.auth_token` into `self.__class__(...)`. But `AnthropicFoundry.__init__` did not accept an `auth_token` kwarg, so the call exploded. The async client had the identical bug.

Trivial repro:

```python
from anthropic import AnthropicFoundry
AnthropicFoundry(api_key="…", resource="…").copy()
# TypeError: AnthropicFoundry.__init__() got an unexpected keyword argument 'auth_token'
```

## Fix

Mirror the existing pattern in `AnthropicAWS` / `AsyncAnthropicAWS`, which already accept `auth_token` for exactly this reason (`src/anthropic/lib/aws/_client.py:51` — *"Passed through to parent but not used for AWS auth"*). The implementation `__init__` of both `AnthropicFoundry` and `AsyncAnthropicFoundry` now accepts `auth_token: str | None = None` and forwards it to `super().__init__(auth_token=auth_token, ...)`. Foundry's own auth uses an API key / Azure AD token, so the value is plumbing-only — that's why the `@overload` signatures are left as-is (no public construction option).

## Test plan

Added `test_copy_does_not_crash` to both `TestAnthropicFoundry` and `TestAsyncAnthropicFoundry` in `tests/lib/test_azure.py`. They instantiate a client, call `.copy()` (and `.copy(timeout=...)`), and assert the result is a properly typed `AnthropicFoundry` / `AsyncAnthropicFoundry`.

- **On `main`:** both tests fail with `TypeError: ... got an unexpected keyword argument 'auth_token'`.
- **With this change:** `pytest tests/lib/test_azure.py` → 11 passed.
- `./scripts/lint` reports no new errors in the changed files; `ruff check` and `ruff format --check` clean.