### PR TITLE
fix: guard against bare unparameterized dict/list in construct_type and transform

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -647,7 +647,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        items_type = args[1] if len(args) >= 2 else object  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (
@@ -668,7 +668,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_list(value):
             return value
 
-        inner_type = args[0]  # List[inner_type]
+        inner_type = args[0] if args else object  # List[inner_type]
         return [construct_type(value=entry, type_=inner_type) for entry in value]
 
     if origin == float:

--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -180,8 +180,8 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        _args = get_args(stripped_type)
-        items_type = _args[1] if len(_args) >= 2 else object
+        args = get_args(stripped_type)
+        items_type = args[1] if len(args) >= 2 else object
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -347,9 +347,9 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        _args = get_args(stripped_type)
-        items_type = _args[1] if len(_args) >= 2 else object
-        return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        args = get_args(stripped_type)
+        items_type = args[1] if len(args) >= 2 else object
+        return {key: await _async_transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
         # List[T]

--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -180,7 +180,8 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        _args = get_args(stripped_type)
+        items_type = _args[1] if len(_args) >= 2 else object
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +347,8 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        _args = get_args(stripped_type)
+        items_type = _args[1] if len(_args) >= 2 else object
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (


### PR DESCRIPTION
`get_args(dict)` and `get_args(list)` return empty tuples when no type parameters are present. Four sites were unconditionally indexing into those tuples, raising `ValueError` or `IndexError` when a model field is annotated as a bare `dict` or `list` instead of `Dict[K, V]` or `List[T]`.

## Crash sites fixed

**`src/anthropic/_models.py`**
- `construct_type`: `_, items_type = get_args(type_)` → `ValueError` on bare `dict` (issue #1619)
- `construct_type`: `inner_type = args[0]` → `IndexError` on bare `list` (issue #1626)

**`src/anthropic/_utils/_transform.py`**
- `_transform_recursive` (sync): `get_args(stripped_type)[1]` → `IndexError` on bare `dict` (issue #1628)
- `_async_transform_recursive`: same pattern, same fix

## Fix

Guard each index access with a length check and fall back to `object` when no type args are present — preserving the value as-is, which is the correct behaviour for unparameterized containers.

## Reproduction

```python
from anthropic._models import construct_type
construct_type(value={"key": "value"}, type_=dict)  # was: ValueError
construct_type(value=["a", "b"], type_=list)         # was: IndexError

from anthropic._utils._transform import transform
transform({"key": "value"}, dict)                    # was: IndexError
```

Fixes #1619, #1626, #1628