### PR TITLE
fix(client): treat empty-string env credentials as unset

### DIFF
--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -208,8 +208,10 @@ class Anthropic(SyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            # An empty-string env credential is treated as unset — it would
+            # otherwise produce a malformed `Authorization: Bearer ` header.
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---
@@ -610,8 +612,10 @@ class AsyncAnthropic(AsyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            # An empty-string env credential is treated as unset — it would
+            # otherwise produce a malformed `Authorization: Bearer ` header.
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -434,6 +434,23 @@ class TestAnthropic:
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
 
+    def test_empty_env_credentials_treated_as_unset(self) -> None:
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = Anthropic(base_url=base_url, _strict_response_validation=True)
+
+        assert client.api_key is None
+        assert client.auth_token is None
+        # previously produced {'X-Api-Key': '', 'Authorization': 'Bearer '} —
+        # the trailing space is rejected by h11 at request-write time
+        assert client.auth_headers == {}
+
+        with pytest.raises(
+            TypeError,
+            match="Could not resolve authentication method. Expected one of api_key, auth_token, or credentials to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted",
+        ):
+            client._build_request(FinalRequestOptions(method="get", url="/foo"))
+
     def test_default_query_option(self) -> None:
         client = Anthropic(
             base_url=base_url, api_key=api_key, _strict_response_validation=True, default_query={"query_param": "bar"}
@@ -1463,6 +1480,23 @@ class TestAsyncAnthropic:
 
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
+
+    def test_empty_env_credentials_treated_as_unset(self) -> None:
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = AsyncAnthropic(base_url=base_url, _strict_response_validation=True)
+
+        assert client.api_key is None
+        assert client.auth_token is None
+        # previously produced {'X-Api-Key': '', 'Authorization': 'Bearer '} —
+        # the trailing space is rejected by h11 at request-write time
+        assert client.auth_headers == {}
+
+        with pytest.raises(
+            TypeError,
+            match="Could not resolve authentication method. Expected one of api_key, auth_token, or credentials to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted",
+        ):
+            client._build_request(FinalRequestOptions(method="get", url="/foo"))
 
     async def test_default_query_option(self) -> None:
         client = AsyncAnthropic(


### PR DESCRIPTION
## Summary

Fixes #1640.

When `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` are present in the environment but set to an **empty string** (common in CI, containers, and shells that `export VAR=` — including the Claude Code CLI shell), the client treated `""` as a real credential because every guard checks `is None`. It then built a malformed `Authorization: Bearer ` header (trailing space), which h11 rejects at request-write time — so every request failed with `APIConnectionError`.

## Change

Coerce empty-string env credentials to `None` at the read site, in both `Anthropic.__init__` and `AsyncAnthropic.__init__`:

```python
api_key = os.environ.get("ANTHROPIC_API_KEY") or None
auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
```

Empty env credentials now fall through to the normal no-credential path: `default_credentials()` auto-discovery (profile / federation), or a clear `Could not resolve authentication method` error — instead of emitting a malformed header.

This also makes `_client.py` consistent with the existing credential chain: `lib/credentials/_chain.py` already treats empty env vars as absent via truthy checks (`if os.environ.get(ENV_API_KEY):`), and uses the same `or None` idiom for `ANTHROPIC_WORKSPACE_ID`.

Explicitly-passed `api_key=""` / `auth_token=""` constructor arguments are intentionally left unchanged — this PR only normalizes the implicit env-var read.

## Tests

Added `test_empty_env_credentials_treated_as_unset` to both `TestAnthropic` and `TestAsyncAnthropic`, mirroring the existing `test_validate_headers` pattern (with `default_credentials` mocked out): asserts `api_key` / `auth_token` resolve to `None`, `auth_headers` is empty (previously `{"X-Api-Key": "", "Authorization": "Bearer "}`), and request building raises the standard auth-resolution `TypeError`.

`tests/test_client.py` passes; `ruff check`, `ruff format --check`, and `pyright` are clean on the touched files.