### PR TITLE
Fix construct_type() crash on bare list/dict types

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -647,7 +647,10 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        args_tuple = get_args(type_)
+        if len(args_tuple) < 2:
+            return value
+        _, items_type = args_tuple  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (
@@ -668,6 +671,8 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_list(value):
             return value
 
+        if not args:
+            return value
         inner_type = args[0]  # List[inner_type]
         return [construct_type(value=entry, type_=inner_type) for entry in value]
 


### PR DESCRIPTION
## Summary

\construct_type()\ crashes when given bare generic types (without type parameters):

1. bare \list\ → \IndexError\ at \rgs[0]\
2. bare \dict\ → \ValueError\ at \_, items_type = get_args(type_)\

## Fix

Both branches now guard against missing type arguments and return the value unchanged.

- \dict\ branch: guard with \if len(args_tuple) < 2: return value\
- \list\ branch: guard with \if not args: return value\

Fixes #1626.
Fixes #1619.