### PR TITLE
fix(tools): resume paused turns in the beta tool runner

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -294,10 +294,18 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
             if not self._check_and_compact():
                 response = self.generate_tool_call_response()
                 if response is None:
-                    log.debug("Tool call was not requested, exiting from tool runner loop.")
-                    return
-
-                if not self._messages_modified:
+                    # A `pause_turn` stop reason means the model paused a long-running
+                    # turn (e.g. while a server-side tool such as web_search or web_fetch
+                    # is still running). There are no client-side tool calls to satisfy,
+                    # but the turn isn't finished, so we resume it by sending the paused
+                    # assistant message back unchanged instead of exiting the loop.
+                    if message.stop_reason == "pause_turn":
+                        if not self._messages_modified:
+                            self.append_messages(message)
+                    else:
+                        log.debug("Tool call was not requested, exiting from tool runner loop.")
+                        return
+                elif not self._messages_modified:
                     self.append_messages(message, response)
 
             self._messages_modified = False
@@ -583,10 +591,18 @@ class BaseAsyncToolRunner(
             if not await self._check_and_compact():
                 response = await self.generate_tool_call_response()
                 if response is None:
-                    log.debug("Tool call was not requested, exiting from tool runner loop.")
-                    return
-
-                if not self._messages_modified:
+                    # A `pause_turn` stop reason means the model paused a long-running
+                    # turn (e.g. while a server-side tool such as web_search or web_fetch
+                    # is still running). There are no client-side tool calls to satisfy,
+                    # but the turn isn't finished, so we resume it by sending the paused
+                    # assistant message back unchanged instead of exiting the loop.
+                    if message.stop_reason == "pause_turn":
+                        if not self._messages_modified:
+                            self.append_messages(message)
+                    else:
+                        log.debug("Tool call was not requested, exiting from tool runner loop.")
+                        return
+                elif not self._messages_modified:
                     self.append_messages(message, response)
 
             self._messages_modified = False

--- a/tests/lib/tools/test_runners.py
+++ b/tests/lib/tools/test_runners.py
@@ -737,6 +737,83 @@ def test_refusal_ends_runner_without_executing_tools_sync(respx_mock: MockRouter
     assert len(respx_mock.calls) == 1
 
 
+# Regression fixtures for #1170: a `pause_turn` stop reason carrying only a
+# server tool use block (e.g. web_search/web_fetch), followed by the final answer.
+_PAUSE_TURN_RESPONSE: Dict[str, Any] = {
+    "id": "msg_pause_turn_01",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-haiku-4-5-20251001",
+    "content": [
+        {
+            "type": "server_tool_use",
+            "id": "srvtoolu_01",
+            "name": "web_search",
+            "input": {"query": "brownie recipe"},
+        }
+    ],
+    "stop_reason": "pause_turn",
+    "stop_sequence": None,
+    "usage": {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "service_tier": "standard",
+    },
+}
+
+_FINAL_TEXT_RESPONSE: Dict[str, Any] = {
+    "id": "msg_final_01",
+    "type": "message",
+    "role": "assistant",
+    "model": "claude-haiku-4-5-20251001",
+    "content": [{"type": "text", "text": "Here is a brownie recipe you can try."}],
+    "stop_reason": "end_turn",
+    "stop_sequence": None,
+    "usage": {
+        "input_tokens": 120,
+        "output_tokens": 15,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "service_tier": "standard",
+    },
+}
+
+
+@pytest.mark.skipif(PYDANTIC_V1, reason="tool runner not supported with pydantic v1")
+@pytest.mark.respx(base_url=base_url)
+def test_pause_turn_resumes_loop_sync(client: Anthropic, respx_mock: MockRouter) -> None:
+    # Regression test for #1170: a `pause_turn` stop reason with only server tool
+    # use blocks (e.g. web_search) must not exit the tool runner loop early. The
+    # runner should resume the paused turn until the server produces a final answer.
+    respx_mock.post("/v1/messages").mock(
+        side_effect=[
+            httpx.Response(200, json=_PAUSE_TURN_RESPONSE),
+            httpx.Response(200, json=_FINAL_TEXT_RESPONSE),
+        ]
+    )
+
+    message = client.beta.messages.tool_runner(
+        max_tokens=1024,
+        model="claude-haiku-4-5",
+        tools=[{"type": "web_search_20250305", "name": "web_search"}],
+        messages=[{"role": "user", "content": "Find a brownie recipe"}],
+    ).until_done()
+
+    # The runner must make a second request to resume the paused turn rather than
+    # returning the intermediate `server_tool_use` block as the final message.
+    assert respx_mock.calls.call_count == 2
+    assert message.stop_reason == "end_turn"
+    assert [block.type for block in message.content] == ["text"]
+
+    # The paused turn must be resumed by sending the assistant message back, so the
+    # second request carries it (with the server tool use block) as the last message.
+    second_request = json.loads(respx_mock.calls[1].request.content)
+    assert second_request["messages"][-1]["role"] == "assistant"
+    assert any(block["type"] == "server_tool_use" for block in second_request["messages"][-1]["content"])
+
+
 @pytest.mark.skipif(PYDANTIC_V1, reason="tool runner not supported with pydantic v1")
 @pytest.mark.respx(base_url=base_url)
 async def test_refusal_ends_runner_without_executing_tools_async(respx_mock: MockRouter) -> None:
@@ -840,6 +917,29 @@ def _run_sync_tool_use(
         if response is not None:
             responses.append(response)
     return responses
+@pytest.mark.skipif(PYDANTIC_V1, reason="tool runner not supported with pydantic v1")
+@pytest.mark.respx(base_url=base_url)
+def test_pause_turn_chained_sync(client: Anthropic, respx_mock: MockRouter) -> None:
+    # A long-running server tool may pause more than once before finishing; the
+    # runner must keep resuming until a terminal stop reason is reached.
+    respx_mock.post("/v1/messages").mock(
+        side_effect=[
+            httpx.Response(200, json=_PAUSE_TURN_RESPONSE),
+            httpx.Response(200, json=_PAUSE_TURN_RESPONSE),
+            httpx.Response(200, json=_FINAL_TEXT_RESPONSE),
+        ]
+    )
+
+    message = client.beta.messages.tool_runner(
+        max_tokens=1024,
+        model="claude-haiku-4-5",
+        tools=[{"type": "web_search_20250305", "name": "web_search"}],
+        messages=[{"role": "user", "content": "Find a brownie recipe"}],
+    ).until_done()
+
+    assert respx_mock.calls.call_count == 3
+    assert message.stop_reason == "end_turn"
+    assert [block.type for block in message.content] == ["text"]
 
 
 @pytest.mark.skipif(PYDANTIC_V1, reason="tool runner not supported with pydantic v1")
@@ -1274,6 +1374,29 @@ def test_tool_addition_nested_in_mid_conv_system_block() -> None:
         },
     ]
     assert available_tool_names(messages, ["get_weather"]) == {"get_weather"}
+async def test_pause_turn_resumes_loop_async(async_client: AsyncAnthropic, respx_mock: MockRouter) -> None:
+    # Async counterpart of the #1170 regression test.
+    respx_mock.post("/v1/messages").mock(
+        side_effect=[
+            httpx.Response(200, json=_PAUSE_TURN_RESPONSE),
+            httpx.Response(200, json=_FINAL_TEXT_RESPONSE),
+        ]
+    )
+
+    message = await async_client.beta.messages.tool_runner(
+        max_tokens=1024,
+        model="claude-haiku-4-5",
+        tools=[{"type": "web_search_20250305", "name": "web_search"}],
+        messages=[{"role": "user", "content": "Find a brownie recipe"}],
+    ).until_done()
+
+    assert respx_mock.calls.call_count == 2
+    assert message.stop_reason == "end_turn"
+    assert [block.type for block in message.content] == ["text"]
+
+    second_request = json.loads(respx_mock.calls[1].request.content)
+    assert second_request["messages"][-1]["role"] == "assistant"
+    assert any(block["type"] == "server_tool_use" for block in second_request["messages"][-1]["content"])
 
 
 def _get_weather(location: str, units: Literal["c", "f"]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

`client.beta.messages.tool_runner(...)` exits the loop too early when a response contains only **server-side** tool use blocks (e.g. `web_search`, `web_fetch`) with `stop_reason: "pause_turn"`. `until_done()` then returns the intermediate `server_tool_use` message instead of the model's final answer, so accessing e.g. `response.content[0].text` raises `AttributeError`.

Fixes #1170.

## Root cause

After each turn, `__run__` calls `generate_tool_call_response()`, which returns `None` whenever there are no client-side `tool_use` blocks to satisfy. The loop treated `None` as "the model is done" and returned — regardless of `stop_reason`. But `"pause_turn"` means the turn is still in progress (the server is running a long-running tool); per the documented contract you continue it by sending the partial response back:

> `"pause_turn"`: we paused a long-running turn. You may provide the response back as-is in a subsequent request to let the model continue.
>
> — `BetaMessage.stop_reason` docstring

## Fix

When there are no client-side tool calls **and** `stop_reason == "pause_turn"`, the runner now appends the paused assistant message unchanged and continues the loop, only exiting on a genuinely terminal stop reason. Applied symmetrically to the sync (`BaseSyncToolRunner`) and async (`BaseAsyncToolRunner`) runners.

- The existing `_messages_modified` guard is preserved, so callers that manage their own message history are unaffected.
- `pause_turn` iterations increment `_iteration_count`, so any `max_iterations` ceiling bounds them exactly like regular tool-use iterations.

## Tests

Added offline regression tests (sync + async, via `respx`) in `tests/lib/tools/test_runners.py`:

- `test_pause_turn_resumes_loop_sync` / `test_pause_turn_resumes_loop_async` — a `pause_turn` response (server tool only) followed by an `end_turn` answer; assert the runner makes the second request, returns the final text, and re-sends the paused assistant turn.
- `test_pause_turn_chained_sync` — two `pause_turn` responses before `end_turn`, covering a long server-tool wait.

These fail on `main` (the runner stops after the first response) and pass with the fix. `ruff`, `pyright`, and `mypy` are all clean.
