### PR TITLE
feat(bedrock): support token counting

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,7 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    count_tokens = FirstPartyMessagesAPI.count_tokens
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +37,7 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    count_tokens = FirstPartyAsyncMessagesAPI.count_tokens
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:
@@ -64,6 +66,9 @@ class MessagesWithRawResponse:
         self.create = _legacy_response.to_raw_response_wrapper(
             messages.create,
         )
+        self.count_tokens = _legacy_response.to_raw_response_wrapper(
+            messages.count_tokens,
+        )
 
 
 class AsyncMessagesWithRawResponse:
@@ -72,6 +77,9 @@ class AsyncMessagesWithRawResponse:
 
         self.create = _legacy_response.async_to_raw_response_wrapper(
             messages.create,
+        )
+        self.count_tokens = _legacy_response.async_to_raw_response_wrapper(
+            messages.count_tokens,
         )
 
 
@@ -82,6 +90,9 @@ class MessagesWithStreamingResponse:
         self.create = to_streamed_response_wrapper(
             messages.create,
         )
+        self.count_tokens = to_streamed_response_wrapper(
+            messages.count_tokens,
+        )
 
 
 class AsyncMessagesWithStreamingResponse:
@@ -90,4 +101,7 @@ class AsyncMessagesWithStreamingResponse:
 
         self.create = async_to_streamed_response_wrapper(
             messages.create,
+        )
+        self.count_tokens = async_to_streamed_response_wrapper(
+            messages.count_tokens,
         )

--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -66,9 +66,6 @@ class MessagesWithRawResponse:
         self.create = _legacy_response.to_raw_response_wrapper(
             messages.create,
         )
-        self.count_tokens = _legacy_response.to_raw_response_wrapper(
-            messages.count_tokens,
-        )
 
 
 class AsyncMessagesWithRawResponse:
@@ -77,9 +74,6 @@ class AsyncMessagesWithRawResponse:
 
         self.create = _legacy_response.async_to_raw_response_wrapper(
             messages.create,
-        )
-        self.count_tokens = _legacy_response.async_to_raw_response_wrapper(
-            messages.count_tokens,
         )
 
 
@@ -90,9 +84,6 @@ class MessagesWithStreamingResponse:
         self.create = to_streamed_response_wrapper(
             messages.create,
         )
-        self.count_tokens = to_streamed_response_wrapper(
-            messages.count_tokens,
-        )
 
 
 class AsyncMessagesWithStreamingResponse:
@@ -101,7 +92,4 @@ class AsyncMessagesWithStreamingResponse:
 
         self.create = async_to_streamed_response_wrapper(
             messages.create,
-        )
-        self.count_tokens = async_to_streamed_response_wrapper(
-            messages.count_tokens,
         )

--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import json
+import base64
 import logging
 import urllib.parse
 from typing import Any, Union, Mapping, TypeVar
@@ -10,7 +12,7 @@ import httpx
 
 from ... import _exceptions
 from ._beta import Beta, AsyncBeta
-from ..._types import NOT_GIVEN, Timeout, NotGiven
+from ..._types import NOT_GIVEN, Timeout, NotGiven, ResponseT
 from ..._utils import is_dict, is_given
 from ..._compat import model_copy
 from ..._version import __version__
@@ -61,8 +63,20 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     if options.url.startswith("/v1/messages/batches"):
         raise AnthropicError("The Batch API is not supported in Bedrock yet")
 
-    if options.url == "/v1/messages/count_tokens":
-        raise AnthropicError("Token counting is not supported in Bedrock yet")
+    if options.url in {"/v1/messages/count_tokens", "/v1/messages/count_tokens?beta=true"} and options.method == "post":
+        if not is_dict(options.json_data):
+            raise RuntimeError("Expected dictionary json_data for post /v1/messages/count_tokens endpoint")
+
+        model = options.json_data.pop("model", None)
+        model = urllib.parse.quote(str(model), safe=":")
+        options.url = f"/model/{model}/count-tokens"
+        options.json_data = {
+            "input": {
+                "invokeModel": {
+                    "body": base64.b64encode(json.dumps(options.json_data).encode("utf-8")).decode("ascii"),
+                }
+            }
+        }
 
     return options
 
@@ -91,6 +105,20 @@ def _infer_region() -> str:
 
 
 class BaseBedrockClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
+    @override
+    def _process_response_data(
+        self,
+        *,
+        data: object,
+        cast_to: type[ResponseT],
+        response: httpx.Response,
+    ) -> ResponseT:
+        # the Bedrock CountTokens API returns `inputTokens` instead of `input_tokens`
+        if response.request.url.path.endswith("/count-tokens") and is_dict(data) and "inputTokens" in data:
+            data = {"input_tokens": data["inputTokens"]}
+
+        return super()._process_response_data(data=data, cast_to=cast_to, response=response)
+
     @override
     def _make_status_error(
         self,

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -1,4 +1,6 @@
 import re
+import json
+import base64
 import typing as t
 import tempfile
 from typing import TypedDict, cast
@@ -163,6 +165,92 @@ def test_application_inference_profile(respx_mock: MockRouter) -> None:
     assert (
         calls[1].request.url
         == "https://bedrock-runtime.us-east-1.amazonaws.com/model/arn:aws:bedrock:us-east-1:123456789012:application-inference-profile%2Fjf2sje1c0jnb/invoke"
+    )
+
+
+@pytest.mark.respx()
+def test_count_tokens(respx_mock: MockRouter) -> None:
+    respx_mock.post(re.compile(r"https://bedrock-runtime\.us-east-1\.amazonaws\.com/model/.*/count-tokens")).mock(
+        return_value=httpx.Response(200, json={"inputTokens": 42}),
+    )
+
+    count = sync_client.messages.count_tokens(
+        messages=[
+            {
+                "role": "user",
+                "content": "Say hello there!",
+            }
+        ],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+
+    assert count.input_tokens == 42
+
+    calls = cast("list[MockRequestCall]", respx_mock.calls)
+    assert len(calls) == 1
+    assert (
+        calls[0].request.url
+        == "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-5-sonnet-20241022-v2:0/count-tokens"
+    )
+
+    request_body = json.loads(calls[0].request.read())
+    inner_body = json.loads(base64.b64decode(request_body["input"]["invokeModel"]["body"]))
+    assert inner_body == {
+        "messages": [{"role": "user", "content": "Say hello there!"}],
+        "anthropic_version": "bedrock-2023-05-31",
+    }
+
+
+@pytest.mark.respx()
+@pytest.mark.asyncio()
+async def test_count_tokens_async(respx_mock: MockRouter) -> None:
+    respx_mock.post(re.compile(r"https://bedrock-runtime\.us-east-1\.amazonaws\.com/model/.*/count-tokens")).mock(
+        return_value=httpx.Response(200, json={"inputTokens": 42}),
+    )
+
+    count = await async_client.messages.count_tokens(
+        messages=[
+            {
+                "role": "user",
+                "content": "Say hello there!",
+            }
+        ],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+
+    assert count.input_tokens == 42
+
+    calls = cast("list[MockRequestCall]", respx_mock.calls)
+    assert len(calls) == 1
+    assert (
+        calls[0].request.url
+        == "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-5-sonnet-20241022-v2:0/count-tokens"
+    )
+
+
+@pytest.mark.respx()
+def test_count_tokens_beta(respx_mock: MockRouter) -> None:
+    respx_mock.post(re.compile(r"https://bedrock-runtime\.us-east-1\.amazonaws\.com/model/.*/count-tokens")).mock(
+        return_value=httpx.Response(200, json={"inputTokens": 42}),
+    )
+
+    count = sync_client.beta.messages.count_tokens(
+        messages=[
+            {
+                "role": "user",
+                "content": "Say hello there!",
+            }
+        ],
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+
+    assert count.input_tokens == 42
+
+    calls = cast("list[MockRequestCall]", respx_mock.calls)
+    assert len(calls) == 1
+    assert (
+        calls[0].request.url
+        == "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-5-sonnet-20241022-v2:0/count-tokens"
     )
 
 


### PR DESCRIPTION
Amazon Bedrock now supports token counting via the [CountTokens API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CountTokens.html), so the SDK no longer needs to reject `count_tokens()` calls on the Bedrock client.

## What changed

- `_prepare_options` now rewrites `POST /v1/messages/count_tokens` (and the `?beta=true` variant) to Bedrock's `POST /model/{modelId}/count-tokens` endpoint. The Anthropic-format request body is wrapped in Bedrock's `CountTokensInput` shape as a base64-encoded `invokeModel` body. The model ID is URL-quoted the same way as for `create`, so inference profile ARNs work.
- `BaseBedrockClient` gains a `_process_response_data` override that maps Bedrock's `{"inputTokens": N}` response to `{"input_tokens": N}`, so callers get the same `MessageTokensCount` type as the first-party API.
- The Bedrock beta messages resource previously only exposed `create`; it now also exposes `count_tokens` (including raw/streaming response wrappers).

## Usage

```python
from anthropic import AnthropicBedrock

client = AnthropicBedrock()
count = client.messages.count_tokens(
    model="anthropic.claude-3-5-sonnet-20241022-v2:0",
    messages=[{"role": "user", "content": "Hello, world"}],
)
print(count.input_tokens)
```

## Tests

Added sync, async, and beta tests covering the URL rewrite, the base64-wrapped request body, and response parsing. All AWS-related tests pass (139 passed).
