### PR TITLE
fix(bedrock): tolerate a missing Connection header when signing

### DIFF
--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -56,10 +56,10 @@ def get_auth_headers(
     # The connection header may be stripped by a proxy somewhere, so the receiver
     # of this message may not see this header, so we remove it from the set of headers
     # that are signed.
-    headers = headers.copy()
-    del headers["connection"]
+    new_headers = headers.copy()
+    new_headers.pop("connection", None)
 
-    request = AWSRequest(method=method.upper(), url=url, headers=headers, data=data)
+    request = AWSRequest(method=method.upper(), url=url, headers=new_headers, data=data)
     credentials = session.get_credentials()
     if not credentials:
         raise RuntimeError("could not resolve credentials from session")

--- a/tests/lib/test_bedrock_auth.py
+++ b/tests/lib/test_bedrock_auth.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import re
+
+import httpx
+
+from anthropic.lib.bedrock._auth import get_auth_headers
+
+_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
+_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+
+class TestGetAuthHeaders:
+    def test_returns_authorization_and_date_headers(self) -> None:
+        headers = get_auth_headers(
+            method="POST",
+            url="https://bedrock-runtime.us-east-1.amazonaws.com/model/m/invoke",
+            headers=httpx.Headers({"content-type": "application/json"}),
+            aws_access_key=_ACCESS_KEY,
+            aws_secret_key=_SECRET_KEY,
+            aws_session_token=None,
+            region="us-east-1",
+            profile=None,
+            data='{"hello": "world"}',
+        )
+        assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
+        assert "X-Amz-Date" in headers
+
+    def test_strips_connection_header_from_signing(self) -> None:
+        """A present connection header must not be part of the signed set."""
+        headers = get_auth_headers(
+            method="POST",
+            url="https://bedrock-runtime.us-east-1.amazonaws.com/model/m/invoke",
+            headers=httpx.Headers({"content-type": "application/json", "Connection": "keep-alive"}),
+            aws_access_key=_ACCESS_KEY,
+            aws_secret_key=_SECRET_KEY,
+            aws_session_token=None,
+            region="us-east-1",
+            profile=None,
+            data='{"hello": "world"}',
+        )
+        signed = re.search(r"SignedHeaders=([^,]+)", headers["Authorization"])
+        assert signed is not None
+        assert "connection" not in signed.group(1).split(";")
+
+    def test_missing_connection_header_does_not_raise(self) -> None:
+        """Regression: signing must not require a connection header to be present.
+
+        A custom ``http_client`` may omit or strip ``Connection`` before the
+        request reaches signing; the previous ``del headers["connection"]`` raised
+        ``KeyError`` in that case.
+        """
+        headers = get_auth_headers(
+            method="POST",
+            url="https://bedrock-runtime.us-east-1.amazonaws.com/model/m/invoke",
+            headers=httpx.Headers({"content-type": "application/json"}),
+            aws_access_key=_ACCESS_KEY,
+            aws_secret_key=_SECRET_KEY,
+            aws_session_token=None,
+            region="us-east-1",
+            profile=None,
+            data='{"hello": "world"}',
+        )
+        assert "Authorization" in headers


### PR DESCRIPTION
## What this does

`get_auth_headers` strips `Connection` from the SigV4-signed set so a proxy that drops it cannot break signature verification. It used `del headers["connection"]`, which raises `KeyError` on `httpx.Headers` when the header is absent (a custom `http_client` may omit or strip it before signing).

**Fix:** remove the header only if present instead of deleting by an assumed key, so the signed set never includes `connection` and a missing `Connection` is a no-op, not a `KeyError`. Preserves the `httpx.Headers` container and case-insensitive match.

## Verification

Red on `main`, green after.

| Check | Result |
| --- | --- |
| missing-Connection regression | unpatched `KeyError`, patched signs |
| present mixed-case `Connection` | stays out of `SignedHeaders` |
| `ruff format`, `ruff check` | clean |
| `pytest test_bedrock_auth + test_aws_auth` | 62 passed |

## Review map

- `src/anthropic/lib/bedrock/_auth.py`: copy headers, then `pop("connection", None)` instead of `del`; sign `new_headers`.
- `tests/lib/test_bedrock_auth.py`: missing-Connection regression; mixed-case `Connection` excluded from `SignedHeaders`; sanity.
