### PR TITLE
fix: omit empty comma array query params

### DIFF
--- a/src/anthropic/_qs.py
+++ b/src/anthropic/_qs.py
@@ -85,12 +85,10 @@ class Querystring:
         if isinstance(value, (list, tuple)):
             array_format = opts.array_format
             if array_format == "comma":
-                return [
-                    (
-                        key,
-                        ",".join(self._primitive_value_to_str(item) for item in value if item is not None),
-                    ),
-                ]
+                serialised = ",".join(self._primitive_value_to_str(item) for item in value if item is not None)
+                if not serialised:
+                    return []
+                return [(key, serialised)]
             elif array_format == "repeat":
                 items = []
                 for item in value:

--- a/tests/test_qs.py
+++ b/tests/test_qs.py
@@ -52,6 +52,9 @@ def test_array_comma(method: str) -> None:
     assert unquote(serialise({"in": ["foo", "bar"]})) == "in=foo,bar"
     assert unquote(serialise({"a": {"b": [True, False]}})) == "a[b]=true,false"
     assert unquote(serialise({"a": {"b": [True, False, None, True]}})) == "a[b]=true,false,true"
+    assert unquote(serialise({"a": []})) == ""
+    assert unquote(serialise({"a": [None]})) == ""
+    assert unquote(serialise({"a": {"b": []}})) == ""
 
 
 def test_array_repeat() -> None:


### PR DESCRIPTION
## Summary
- omit comma-formatted array query params when the array has no serializable values
- add coverage for empty, None-only, and nested empty comma arrays

## Validation
- PYTHONPATH=src /tmp/anthropic-pdlc042-venv/bin/python -m pytest tests/test_qs.py -q
- PYTHONPATH=src /tmp/anthropic-pdlc042-venv/bin/python -m py_compile src/anthropic/_qs.py tests/test_qs.py
- git diff --check