### PR TITLE
fix: handle bare container types

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -647,6 +647,9 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
+        if not args:
+            return value
+
         _, items_type = get_args(type_)  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
@@ -666,6 +669,9 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
 
     if origin == list:
         if not is_list(value):
+            return value
+
+        if not args:
             return value
 
         inner_type = args[0]  # List[inner_type]

--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -180,7 +180,11 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if not args:
+            return cast(object, data)
+
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +350,11 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if not args:
+            return cast(object, data)
+
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -655,6 +655,14 @@ def test_annotated_types() -> None:
     assert m.value == "foo"
 
 
+def test_construct_type_bare_container_types() -> None:
+    list_value = ["a", {"nested": "value"}]
+    dict_value = {"foo": ["bar"]}
+
+    assert construct_type(value=list_value, type_=list) is list_value
+    assert construct_type(value=dict_value, type_=dict) is dict_value
+
+
 def test_discriminated_unions_invalid_data() -> None:
     class A(BaseModel):
         type: Literal["a"]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -397,6 +397,14 @@ async def test_dictionary_items(use_async: bool) -> None:
     assert await transform({"foo": {"foo_baz": "bar"}}, Dict[str, DictItems], use_async) == {"foo": {"fooBaz": "bar"}}
 
 
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_dict_type(use_async: bool) -> None:
+    data = {"foo_bar": {"baz_qux": "value"}}
+
+    assert await transform(data, dict, use_async) is data
+
+
 class TypedDictIterableUnionStr(TypedDict):
     foo: Annotated[Union[str, Iterable[Baz8]], PropertyInfo(alias="FOO")]
 


### PR DESCRIPTION
Fixes #1619.
Fixes #1626.
Fixes #1628.

## Summary
- treat bare `dict` and `list` annotations as untyped containers in `construct_type` instead of indexing missing type args
- treat bare `dict` annotations as untyped in sync and async transform paths
- add focused regression coverage for the reported bare-container crashes

## Testing
- `PYTHONPATH=src /tmp/anthropic-pdlc042-venv/bin/python -m pytest tests/test_models.py::test_construct_type_bare_container_types tests/test_transform.py::test_bare_dict_type -q` (3 passed)
- `PYTHONPATH=src /tmp/anthropic-pdlc042-venv/bin/python -m pytest tests/test_models.py tests/test_transform.py -q` (117 passed)
- `PYTHONPATH=src /tmp/anthropic-pdlc042-venv/bin/python -m py_compile src/anthropic/_models.py src/anthropic/_utils/_transform.py tests/test_models.py tests/test_transform.py`
- `git diff --check`