### PR TITLE
fix(streaming): accumulate compaction_delta content and add JSON parse error context

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -525,7 +525,7 @@ def accumulate_event(
                 content.signature = event.delta.signature
         elif event.delta.type == "compaction_delta":
             if content.type == "compaction":
-                content.content = event.delta.content
+                content.content = (content.content or "") + (event.delta.content or "")
                 content.encrypted_content = event.delta.encrypted_content
         else:
             # we only want exhaustive checking for linters, not at runtime

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -477,7 +477,12 @@ def accumulate_event(
                 json_buf += bytes(event.delta.partial_json, "utf-8")
 
                 if json_buf:
-                    content.input = from_json(json_buf, partial_mode=True)
+                    try:
+                        content.input = from_json(json_buf, partial_mode=True)
+                    except ValueError as e:
+                        raise ValueError(
+                            f"Unable to parse tool parameter JSON from model. Please retry your request or adjust your prompt. Error: {e}. JSON: {json_buf.decode('utf-8')}"
+                        ) from e
 
                 setattr(content, JSON_BUF_PROPERTY, json_buf)
         elif event.delta.type == "citations_delta":


### PR DESCRIPTION
## Summary
- **Beta streaming**: `compaction_delta` handler used assignment (`=`) instead of accumulation (`+=`). If compaction content is streamed across multiple deltas, all but the last chunk were lost. The TypeScript SDK correctly concatenates: `(content || '') + delta.content`. This aligns with the pattern used by `text_delta` and `thinking_delta` in the same file.
- **GA streaming**: `from_json()` for `input_json_delta` lacked the try/except that the Beta path already has. When the model produces malformed JSON, GA users got a raw `ValueError` with no context instead of the helpful message the Beta path provides.