### PR TITLE
fix(client): handle bare dict/list annotations in construct_type and transform

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -647,7 +647,8 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        args = get_args(type_)
+        items_type = args[1] if len(args) >= 2 else object  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (
@@ -668,7 +669,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_list(value):
             return value
 
-        inner_type = args[0]  # List[inner_type]
+        inner_type = args[0] if args else object  # List[inner_type]
         return [construct_type(value=entry, type_=inner_type) for entry in value]
 
     if origin == float:

--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -180,7 +180,8 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        items_type = args[1] if len(args) >= 2 else object
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -348,7 +349,8 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        items_type = args[1] if len(args) >= 2 else object
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -655,6 +655,18 @@ def test_annotated_types() -> None:
     assert m.value == "foo"
 
 
+def test_bare_dict_annotation() -> None:
+    # a bare `dict` annotation (no type parameters) should not raise
+    m = construct_type(value={"key": "value", "n": 1}, type_=cast(Any, dict))
+    assert m == {"key": "value", "n": 1}
+
+
+def test_bare_list_annotation() -> None:
+    # a bare `list` annotation (no type parameters) should not raise
+    m = construct_type(value=["a", "b", 1], type_=cast(Any, list))
+    assert m == ["a", "b", 1]
+
+
 def test_discriminated_unions_invalid_data() -> None:
     class A(BaseModel):
         type: Literal["a"]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -63,6 +63,13 @@ class Baz2(TypedDict):
 
 @parametrize
 @pytest.mark.asyncio
+async def test_bare_dict_annotation(use_async: bool) -> None:
+    # a bare `dict` annotation (no type parameters) should pass values through unchanged
+    assert await transform({"key": "value", "n": 1}, cast(Any, dict), use_async) == {"key": "value", "n": 1}
+
+
+@parametrize
+@pytest.mark.asyncio
 async def test_recursive_typeddict(use_async: bool) -> None:
     assert await transform({"bar": {"this_thing": 1}}, Foo2, use_async) == {"bar": {"this__thing": 1}}
     assert await transform({"bar": {"baz": {"my_baz": "foo"}}}, Foo2, use_async) == {"bar": {"Baz": {"myBaz": "foo"}}}


### PR DESCRIPTION
## What

A field annotated with a bare, unparameterized `dict` or `list` (rather than `Dict[K, V]` / `List[T]`) crashes the runtime helpers, because `get_args()` returns an empty tuple in that case and the code indexes into it unconditionally.

Three reported crashes, one root cause:

- `construct_type(value={...}, type_=dict)` → `ValueError: not enough values to unpack (expected 2, got 0)` (`_models.py`) — #1619
- `construct_type(value=[...], type_=list)` → `IndexError: tuple index out of range` (`_models.py`) — #1626
- `transform({...}, dict)` → `IndexError: tuple index out of range`, in both the sync and async paths (`_transform.py`) — #1628

## Fix

Guard each `get_args()` lookup and fall back to `object` as the element type when no type parameters are present. With `object` as the element type, values pass straight through unchanged — which is the right behavior for an unparameterized container, since there's no inner type to coerce to.

## Repro (before)

```python
from anthropic._models import construct_type
from anthropic._utils._transform import transform

construct_type(value={"k": "v"}, type_=dict)   # ValueError
construct_type(value=["a", "b"], type_=list)   # IndexError
transform({"k": "v"}, dict)                     # IndexError
```

All three (plus the async transform path) now return the input unchanged.

## Tests

- `tests/test_models.py`: `test_bare_dict_annotation`, `test_bare_list_annotation`
- `tests/test_transform.py`: `test_bare_dict_annotation` (parametrized sync + async)

Full `test_models.py` and `test_transform.py` suites pass locally (122 tests); ruff check + format are clean.