### PR TITLE
fix(client): treat empty-string env credentials as unset

### DIFF
--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -210,8 +210,13 @@ class Anthropic(SyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            # Treat an empty-string env var as unset. Empty values are common in
+            # CI/containers/wrapper shells (e.g. `export VAR=`), and a "present"
+            # empty credential would otherwise build a malformed `Bearer ` /
+            # empty `X-Api-Key` header that the HTTP layer rejects on every
+            # request, instead of falling through to credential auto-discovery.
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---
@@ -627,8 +632,13 @@ class AsyncAnthropic(AsyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            # Treat an empty-string env var as unset. Empty values are common in
+            # CI/containers/wrapper shells (e.g. `export VAR=`), and a "present"
+            # empty credential would otherwise build a malformed `Bearer ` /
+            # empty `X-Api-Key` header that the HTTP layer rejects on every
+            # request, instead of falling through to credential auto-discovery.
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -434,6 +434,15 @@ class TestAnthropic:
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
 
+    def test_empty_env_credentials_treated_as_unset(self) -> None:
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = Anthropic(base_url=base_url, _strict_response_validation=True)
+
+        assert client.api_key is None
+        assert client.auth_token is None
+        assert client.auth_headers == {}
+
     def test_default_query_option(self) -> None:
         client = Anthropic(
             base_url=base_url, api_key=api_key, _strict_response_validation=True, default_query={"query_param": "bar"}
@@ -1463,6 +1472,15 @@ class TestAsyncAnthropic:
 
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
+
+    def test_empty_env_credentials_treated_as_unset(self) -> None:
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = AsyncAnthropic(base_url=base_url, _strict_response_validation=True)
+
+        assert client.api_key is None
+        assert client.auth_token is None
+        assert client.auth_headers == {}
 
     async def test_default_query_option(self) -> None:
         client = AsyncAnthropic(


### PR DESCRIPTION
## Summary

Closes #1640.

When `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` are present in the environment but set to an **empty string**, the client treats the empty value as a real credential rather than as absent. It then builds an `Authorization: Bearer ` header (literally `Bearer` + trailing space) and an empty `X-Api-Key`. The HTTP layer (h11, via httpx) validates header values at write time and rejects the trailing space, so **every request fails**:

```
h11._util.LocalProtocolError: Illegal header value b'Bearer '
```

surfaced as `anthropic.APIConnectionError`. Empty-string env vars are common in CI, containers, and wrapper shells (`export VAR=`), and the Claude Code CLI exports both `ANTHROPIC_AUTH_TOKEN=` and `ANTHROPIC_API_KEY=` empty — so any script there that constructs `Anthropic()` without an explicit key fails on every call.

## Root cause

The env-credential guards use `is None`, so an empty string slips through every check: the env read keeps `""`, the "missing auth" fallback (`api_key is None and auth_token is None`) never fires, and the header builders emit on `is not None` — producing `{"X-Api-Key": "", "Authorization": "Bearer "}`.

## Fix

Coerce an empty env credential to `None` at read time in both the sync and async clients, so an empty value is treated as unset and credential auto-discovery runs as expected. Explicitly-passed credentials are untouched.

```python
api_key = os.environ.get("ANTHROPIC_API_KEY") or None
auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
```

## Verification

Reproduced the `LocalProtocolError` on `main` before the change; after the fix `auth_headers == {}` and auto-discovery runs. A real key still produces the correct `X-Api-Key` header.

- Added regression tests for both sync and async clients (`tests/test_client.py`).
- `pytest tests/test_client.py` — 170 passed.
- `ruff check` / `ruff format --check` clean; no new pyright errors on changed lines.