### PR TITLE
Fix: add missing .stream() method to Bedrock beta.messages

### DIFF
--- a/src/anthropic/lib/bedrock/_beta_messages.py
+++ b/src/anthropic/lib/bedrock/_beta_messages.py
@@ -13,6 +13,7 @@ __all__ = ["Messages", "AsyncMessages"]
 
 class Messages(SyncAPIResource):
     create = FirstPartyMessagesAPI.create
+    stream = FirstPartyMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> MessagesWithRawResponse:
@@ -36,6 +37,7 @@ class Messages(SyncAPIResource):
 
 class AsyncMessages(AsyncAPIResource):
     create = FirstPartyAsyncMessagesAPI.create
+    stream = FirstPartyAsyncMessagesAPI.stream
 
     @cached_property
     def with_raw_response(self) -> AsyncMessagesWithRawResponse:


### PR DESCRIPTION
## Summary
Adds the missing `.stream()` method to `AnthropicBedrock().beta.messages` for parity with `Anthropic().beta.messages`.

## Changes
- Added `stream` alias to `Messages` class in `src/anthropic/lib/bedrock/_beta_messages.py`
- Added `stream` alias to `AsyncMessages` class for async support

## Fixes
Closes #1210

## Testing
Verified that Bedrock's `create(stream=True)` returns the same event types as the first-party `stream()` method.