### PR TITLE
fix: resolve x-stainless-timeout when request timeout is NotGiven

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -456,11 +456,17 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
 
     def _build_headers(self, options: FinalRequestOptions, *, retries_taken: int = 0) -> httpx.Headers:
         custom_headers = options.headers or {}
+        req_timeout = self.timeout if isinstance(options.timeout, NotGiven) else options.timeout
+        if isinstance(req_timeout, Timeout):
+            stainless_timeout = str(req_timeout.read)
+        elif req_timeout is not None:
+            stainless_timeout = str(req_timeout)
+        else:
+            default_timeout = self.timeout
+            stainless_timeout = str(default_timeout.read if isinstance(default_timeout, Timeout) else default_timeout)
         headers_dict = _merge_mappings(
             {
-                "x-stainless-timeout": str(options.timeout.read)
-                if isinstance(options.timeout, Timeout)
-                else str(options.timeout),
+                "x-stainless-timeout": stainless_timeout,
                 **self.default_headers,
             },
             custom_headers,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -416,6 +416,13 @@ class TestAnthropic:
         test_client.close()
         test_client2.close()
 
+    def test_default_timeout_header_is_not_not_given(self) -> None:
+        client = Anthropic(base_url=base_url, api_key=api_key, _strict_response_validation=True)
+        request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
+        assert request.headers.get("x-stainless-timeout") != "NOT_GIVEN"
+        assert request.headers.get("x-stainless-timeout") == request.headers.get("x-stainless-read-timeout")
+        client.close()
+
     def test_validate_headers(self) -> None:
         client = Anthropic(base_url=base_url, api_key=api_key, _strict_response_validation=True)
         request = client._build_request(FinalRequestOptions(method="get", url="/foo"))


### PR DESCRIPTION
Fixes #1676

`x-stainless-timeout` now uses the same default-timeout fallback as `x-stainless-read-timeout` instead of the literal string `NOT_GIVEN`.

Proof:
```
PASS x-stainless-timeout= 600
```