### PR TITLE
docs(examples): bump workload_identity model to claude-opus-4-8

### DIFF
--- a/examples/workload_identity.py
+++ b/examples/workload_identity.py
@@ -169,7 +169,7 @@ async def main() -> None:
         ),
     )
     msg = await aclient.messages.create(
-        model="claude-opus-4-5",
+        model="claude-opus-4-8",
         max_tokens=1024,
         messages=[{"role": "user", "content": "Hello"}],
     )


### PR DESCRIPTION
The async example referenced the outdated `claude-opus-4-5`. Update it to the current `claude-opus-4-8` so the snippet uses an up-to-date model id.