### PR TITLE
fix(parse): treat empty/typeless schema as "any" in transform_schema

### DIFF
--- a/src/anthropic/lib/_parse/_transform.py
+++ b/src/anthropic/lib/_parse/_transform.py
@@ -107,11 +107,11 @@ def transform_schema(
         strict_schema["anyOf"] = [transform_schema(cast("dict[str, Any]", variant)) for variant in one_of]
     elif is_list(all_of):
         strict_schema["allOf"] = [transform_schema(cast("dict[str, Any]", variant)) for variant in all_of]
-    else:
-        if type_ is None:
-            raise ValueError("Schema must have a 'type', 'anyOf', 'oneOf', or 'allOf' field.")
-
+    elif type_ is not None:
         strict_schema["type"] = type_
+    # else: a typeless schema with no combinators — e.g. an empty `{}`, which pydantic
+    # emits for an `Any`-typed field or the items of an untyped `list`/`List[Any]`. This
+    # is a valid, unconstrained ("any") schema, so leave it untyped rather than raising.
 
     enum = json_schema.pop("enum", None)
     if is_list(enum):

--- a/tests/lib/_parse/test_transform.py
+++ b/tests/lib/_parse/test_transform.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
+from typing import Any, List
 
 import pytest
+import pydantic
 from inline_snapshot import snapshot
 
 from anthropic.lib._parse._transform import transform_schema
@@ -141,6 +143,57 @@ A list of strings
 {minItems: 2}\
 """,
             "items": {"type": "string"},
+        }
+    )
+
+
+def test_empty_schema():
+    # pydantic emits a bare `{}` for an `Any`-typed field; an empty schema is a
+    # valid, unconstrained ("any") schema and must not raise.
+    assert transform_schema({}) == snapshot({})
+
+
+def test_array_with_untyped_items():
+    # `list` / `List[Any]` produces `{"type": "array", "items": {}}`.
+    schema: dict[str, Any] = {"type": "array", "items": {}}
+    result = transform_schema(schema)
+    assert result == snapshot({"type": "array", "items": {}})
+
+
+def test_object_with_any_property():
+    schema: dict[str, Any] = {"type": "object", "properties": {"x": {}}, "required": ["x"], "title": "M"}
+    result = transform_schema(schema)
+    assert result == snapshot(
+        {
+            "type": "object",
+            "title": "M",
+            "properties": {"x": {}},
+            "additionalProperties": False,
+            "required": ["x"],
+        }
+    )
+
+
+def test_model_with_untyped_list_and_any_field():
+    # Regression: previously raised ValueError("Schema must have a 'type', ...") because
+    # the untyped `list` items / `Any` field transform to an empty `{}` sub-schema.
+    class Result(pydantic.BaseModel):
+        summary: str
+        tags: List[Any]
+        extra: Any
+
+    result = transform_schema(Result)
+    assert result == snapshot(
+        {
+            "type": "object",
+            "title": "Result",
+            "properties": {
+                "summary": {"type": "string", "title": "Summary"},
+                "tags": {"type": "array", "title": "Tags", "items": {}},
+                "extra": {"title": "Extra"},
+            },
+            "additionalProperties": False,
+            "required": ["summary", "tags", "extra"],
         }
     )
 


### PR DESCRIPTION
## What

`transform_schema` (the structured-output schema transformer used by `messages.parse` / `beta.messages.parse`) raised

```
ValueError: Schema must have a 'type', 'anyOf', 'oneOf', or 'allOf' field.
```

for any sub-schema that pydantic emits as an empty `{}` — namely an `Any`-typed field, or the `items` of an untyped `list` / `List[Any]`.

## Repro

```python
import pydantic
from typing import Any, List
import anthropic

class Result(pydantic.BaseModel):
    summary: str
    tags: List[Any]   # also: a bare `list`, or any `Any`-typed field

client = anthropic.Anthropic(api_key="sk-ant-...")
client.beta.messages.parse(
    model="claude-sonnet-4-5",
    max_tokens=100,
    messages=[{"role": "user", "content": "hi"}],
    output_format=Result,
)
# -> ValueError: Schema must have a 'type', 'anyOf', 'oneOf', or 'allOf' field.
```

The error is raised at request-build time, **before** any API call. Notably, an untyped `dict` / `Dict[str, Any]` field does *not* trip it (it keeps `type: object`), so the failure is specific to untyped lists and `Any` fields — surprising and easy to hit.

Root cause: in the array branch, `items: {}` recurses into `transform_schema({})`, and a schema with no `type`/`anyOf`/`oneOf`/`allOf` hit the `raise`. The same happens for an `Any` object property.

## Change

An empty `{}` is a valid, unconstrained ("any") JSON Schema. Instead of raising when there is no `type` and no combinator, leave the sub-schema untyped (permissive). One-line behavior change in `src/anthropic/lib/_parse/_transform.py`.

## Tests

Added to `tests/lib/_parse/test_transform.py`:
- empty `{}` schema
- untyped array items (`{"type": "array", "items": {}}`)
- an `Any` object property
- end-to-end pydantic model with `List[Any]` + `Any` field (regression for the original crash)

## Verification

- `uv run pytest tests/lib/_parse` → 26 passed
- `uv run ruff check` → all checks passed
- `uv run pyright` (strict) on changed files → 0 errors, 0 warnings