### PR TITLE
fix(tools): raise a graceful ToolError when a memory file is not valid UTF-8

### DIFF
--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -327,6 +327,8 @@ def _read_file_content(full_path: Path, memory_path: str) -> str:
         raise ToolError(
             f"The file {memory_path} no longer exists (may have been deleted or renamed concurrently)."
         ) from err
+    except UnicodeDecodeError as err:
+        raise ToolError(f"The file {memory_path} is not a valid UTF-8 text file and cannot be read as memory.") from err
 
 
 def _format_file_size(bytes_size: int) -> str:
@@ -620,6 +622,8 @@ async def _async_read_file_content(full_path: AsyncPath, memory_path: str) -> st
         raise ToolError(
             f"The file {memory_path} no longer exists (may have been deleted or renamed concurrently)."
         ) from err
+    except UnicodeDecodeError as err:
+        raise ToolError(f"The file {memory_path} is not a valid UTF-8 text file and cannot be read as memory.") from err
 
 
 class BetaAsyncLocalFilesystemMemoryTool(BetaAsyncAbstractMemoryTool):

--- a/tests/lib/tools/memory_tools/test_filesystem.py
+++ b/tests/lib/tools/memory_tools/test_filesystem.py
@@ -164,6 +164,16 @@ class TestBetaLocalFilesystemMemoryTool:
                 BetaMemoryTool20250818ViewCommand(command="view", path="/memories/nonexistent.txt")
             )
 
+    def test_view_error_for_non_utf8_file(self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool) -> None:
+        memory_root = sync_local_filesystem_tool.memory_root
+        memory_root.mkdir(parents=True, exist_ok=True)
+        (memory_root / "binary.dat").write_bytes(b"\xff\xfe\x80 not utf-8")
+
+        with pytest.raises(ToolError, match="is not a valid UTF-8 text file"):
+            sync_local_filesystem_tool.view(
+                BetaMemoryTool20250818ViewCommand(command="view", path="/memories/binary.dat")
+            )
+
     def test_view_error_for_files_with_too_many_lines(
         self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool
     ) -> None:
@@ -633,6 +643,18 @@ class TestBetaAsyncLocalFilesystemMemoryTool:
         ):
             await async_local_filesystem_tool.view(
                 BetaMemoryTool20250818ViewCommand(command="view", path="/memories/nonexistent.txt")
+            )
+
+    async def test_view_error_for_non_utf8_file(
+        self, async_local_filesystem_tool: BetaAsyncLocalFilesystemMemoryTool
+    ) -> None:
+        memory_root = Path(str(async_local_filesystem_tool.memory_root))
+        memory_root.mkdir(parents=True, exist_ok=True)
+        (memory_root / "binary.dat").write_bytes(b"\xff\xfe\x80 not utf-8")
+
+        with pytest.raises(ToolError, match="is not a valid UTF-8 text file"):
+            await async_local_filesystem_tool.view(
+                BetaMemoryTool20250818ViewCommand(command="view", path="/memories/binary.dat")
             )
 
     async def test_view_error_for_files_with_too_many_lines(


### PR DESCRIPTION
## What

The local-filesystem memory tool reads files through `_read_file_content` (and its async twin `_async_read_file_content`), which decodes strict UTF-8 and only catches `FileNotFoundError`:

```python
def _read_file_content(full_path: Path, memory_path: str) -> str:
    try:
        return full_path.read_text(encoding="utf-8")
    except FileNotFoundError as err:
        raise ToolError(...) from err
```

A memory file containing non-UTF-8 bytes therefore raised an uncaught `UnicodeDecodeError` out of `view` / `str_replace` / `insert`, instead of the normalized `ToolError` used for every other failure mode. Because the encoding is hard-coded to `utf-8`, this reproduces on **all** platforms.

## Repro

```python
import tempfile
from pathlib import Path
from anthropic.lib.tools._beta_builtin_memory_tool import BetaLocalFilesystemMemoryTool
from anthropic.types.beta import BetaMemoryTool20250818ViewCommand

tool = BetaLocalFilesystemMemoryTool(base_path=tempfile.mkdtemp())
tool.memory_root.mkdir(parents=True, exist_ok=True)
(tool.memory_root / "note.dat").write_bytes(b"\xff\xfe\x80 binary")

tool.view(BetaMemoryTool20250818ViewCommand(command="view", path="/memories/note.dat"))
# -> UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff ...  (uncaught)
```

## Change

Catch `UnicodeDecodeError` in both the sync and async readers and surface it as a `ToolError` ("… is not a valid UTF-8 text file …"). Added sync + async regression tests that write a binary file and assert the graceful `ToolError`.

## Verification

- `uv run pytest -k non_utf8 tests/lib/tools/memory_tools/test_filesystem.py` → 2 passed
- `uv run ruff check` → all checks passed
- `uv run pyright` (strict) → 0 errors, 0 warnings

> Note: this repo's memory-tool filesystem suite has pre-existing failures on Windows (symlink/permission-mode tests) unrelated to this change; the two added tests pass and no previously-passing test regresses.