### PR TITLE
fix: guard against bare unparameterized dict/list in construct_type and transform

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -647,7 +647,8 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        dict_args = get_args(type_)  # Dict[_, items_type]
+        items_type = dict_args[1] if len(dict_args) >= 2 else object
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (
@@ -668,7 +669,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_list(value):
             return value
 
-        inner_type = args[0]  # List[inner_type]
+        inner_type = args[0] if args else object  # List[inner_type]
         return [construct_type(value=entry, type_=inner_type) for entry in value]
 
     if origin == float:

--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -180,7 +180,8 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        _dict_args = get_args(stripped_type)
+        items_type = _dict_args[1] if len(_dict_args) >= 2 else object
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -348,7 +349,8 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        _dict_args = get_args(stripped_type)
+        items_type = _dict_args[1] if len(_dict_args) >= 2 else object
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1014,4 +1014,20 @@ def test_iterable_construction_str_falls_back_to_list() -> None:
 
     # falls back to list of chars rather than calling str(["h", "e", "l", "l", "o"])
     assert m.data["items"] == ["h", "e", "l", "l", "o"]
+
+
+def test_construct_type_bare_dict_does_not_crash() -> None:
+    # Bare `dict` (no type parameters) previously raised:
+    #   ValueError: not enough values to unpack (expected 2, got 0)
+    # because get_args(dict) returns () and the code unpacked it as two values.
+    result = construct_type(value={"key": "value"}, type_=dict)
+    assert result == {"key": "value"}
+
+
+def test_construct_type_bare_list_does_not_crash() -> None:
+    # Bare `list` (no type parameter) previously raised:
+    #   IndexError: tuple index out of range
+    # because get_args(list) returns () and the code indexed args[0].
+    result = construct_type(value=["a", "b", "c"], type_=list)
+    assert result == ["a", "b", "c"]
     assert m.model_dump()["data"]["items"] == ["h", "e", "l", "l", "o"]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -502,3 +502,13 @@ async def test_strips_notgiven(use_async: bool) -> None:
 async def test_strips_omit(use_async: bool) -> None:
     assert await transform({"foo_bar": "bar"}, Foo1, use_async) == {"fooBar": "bar"}
     assert await transform({"foo_bar": omit}, Foo1, use_async) == {}
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_dict_annotation_does_not_crash(use_async: bool) -> None:
+    # Bare `dict` (no type parameters) previously raised:
+    #   IndexError: tuple index out of range
+    # because get_args(dict) returns () and the code indexed [1] unconditionally.
+    result = await transform({"key": "value"}, dict, use_async)
+    assert result == {"key": "value"}


### PR DESCRIPTION
## Summary

Three code paths crash when a model field or transform annotation uses a bare, unparameterized `dict` or `list` type (i.e. `dict` instead of `Dict[str, T]`, or `list` instead of `List[T]`). This can happen when integrating with third-party schemas or when users annotate fields generically without type parameters.

`get_args(dict)` and `get_args(list)` return empty tuples `()` for bare types. The affected code assumed at least one or two elements were always present:

| File | Line | Crash | Type |
|---|---|---|---|
| `src/anthropic/_models.py` | 650 | `_, items_type = get_args(type_)` | `ValueError: not enough values to unpack` |
| `src/anthropic/_models.py` | 671 | `inner_type = args[0]` | `IndexError: tuple index out of range` |
| `src/anthropic/_utils/_transform.py` | 183, 351 | `get_args(stripped_type)[1]` | `IndexError: tuple index out of range` |

## Fix

Guard each site with a length check and fall back to `object` as the element/value type when no type arguments are present. This matches the behaviour a caller would expect from an unparameterized collection.

## Tests

- `test_construct_type_bare_dict_does_not_crash` — previously raised `ValueError`
- `test_construct_type_bare_list_does_not_crash` — previously raised `IndexError`  
- `test_bare_dict_annotation_does_not_crash` (sync + async) — previously raised `IndexError`

## Closes

Fixes #1619, #1626, #1628