### PR TITLE
fix(bedrock): pass aws_profile to boto3.Session in _infer_region

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -69,7 +69,7 @@ def _prepare_options(input_options: FinalRequestOptions) -> FinalRequestOptions:
     return options
 
 
-def _infer_region() -> str:
+def _infer_region(aws_profile: str | None = None) -> str:
     """
     Infer the AWS region from the environment variables or
     from the boto3 session if available.
@@ -79,7 +79,7 @@ def _infer_region() -> str:
         try:
             import boto3
 
-            session = boto3.Session()
+            session = boto3.Session(profile_name=aws_profile)
             if session.region_name:
                 aws_region = session.region_name
         except ImportError:
@@ -181,7 +181,7 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token
@@ -361,7 +361,7 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
         self.aws_access_key = aws_access_key
 
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
         self.aws_profile = aws_profile
 
         self.aws_session_token = aws_session_token


### PR DESCRIPTION
Fixes #892

## Problem

`_infer_region()` creates a `boto3.Session()` without forwarding the `aws_profile` that was passed to the `AnthropicBedrock` / `AsyncAnthropicBedrock` constructor. This means the region is resolved from the **default** AWS profile, not the requested one — causing a 403 when the profile's region differs from the default.

Example: if `aws_profile='prod'` maps to `us-west-2` in `~/.aws/config`, the SDK still defaults to `us-east-1` because `boto3.Session()` ignores the profile name.

## Fix

Accept an optional `aws_profile: str | None = None` parameter in `_infer_region()` and pass it to `boto3.Session(profile_name=aws_profile)`. Both `AnthropicBedrock.__init__` and `AsyncAnthropicBedrock.__init__` now forward `aws_profile` to the helper.

```diff
-def _infer_region() -> str:
+def _infer_region(aws_profile: str | None = None) -> str:
     ...
-            session = boto3.Session()
+            session = boto3.Session(profile_name=aws_profile)
     ...
-        self.aws_region = _infer_region() if aws_region is None else aws_region
+        self.aws_region = _infer_region(aws_profile) if aws_region is None else aws_region
```

When `aws_profile` is `None` (the default), `boto3.Session(profile_name=None)` behaves identically to `boto3.Session()`, so there is no change for existing callers that don't use a profile.