### PR TITLE
fix(bedrock): drop metrics-only invocation trailer from stream decoder

### DIFF
--- a/src/anthropic/lib/bedrock/_stream_decoder.py
+++ b/src/anthropic/lib/bedrock/_stream_decoder.py
@@ -78,7 +78,16 @@ def _chunk_bytes_to_sse(raw: bytes) -> ServerSentEvent | None:
 
     payload = cast("Dict[str, Any]", data)
     event_type = payload.get("type")
-    if not isinstance(event_type, str):
-        event_type = "completion"
+    if isinstance(event_type, str):
+        return ServerSentEvent(data=decoded, event=event_type)
 
-    return ServerSentEvent(data=decoded, event=event_type)
+    # No typed discriminator. Two untyped payload shapes reach this point. Legacy
+    # text-completion chunks carry a "completion" field and belong on the completion
+    # path. Bedrock also appends an amazon-bedrock-invocationMetrics trailer that
+    # carries neither a type nor a completion field. Forwarding that trailer to the
+    # stream-event union makes it construct as a contract-violating
+    # RawMessageStartEvent(message=None), so drop it instead.
+    if "completion" in payload:
+        return ServerSentEvent(data=decoded, event="completion")
+
+    return None

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -307,6 +307,26 @@ def test_chunk_bytes_to_sse_legacy_completion_with_metrics() -> None:
     assert sse.event == "completion"
 
 
+def test_chunk_bytes_to_sse_drops_metrics_only_trailer() -> None:
+    # The amazon-bedrock-invocationMetrics trailer carries no type and no
+    # completion field. Forwarding it to the stream-event union constructs a
+    # contract-violating RawMessageStartEvent(message=None), so it must be dropped.
+    raw = b'{"amazon-bedrock-invocationMetrics":{"inputTokenCount":10,"outputTokenCount":5}}'
+    assert _chunk_bytes_to_sse(raw) is None
+
+
+def test_metrics_trailer_would_violate_stream_event_contract() -> None:
+    from anthropic.types import RawMessageStreamEvent
+    from anthropic._models import construct_type
+
+    # Documents why the trailer must be dropped. Were it forwarded to the
+    # stream-event union, the union has no discriminator to match it and falls
+    # back to its first member, RawMessageStartEvent, with a null message.
+    trailer = {"amazon-bedrock-invocationMetrics": {"inputTokenCount": 10, "outputTokenCount": 5}}
+    event = construct_type(value=trailer, type_=cast(t.Any, RawMessageStreamEvent))
+    assert getattr(event, "message", None) is None
+
+
 def test_copy_x_stainless_helper_header_appends() -> None:
     # `x-stainless-helper` accumulates across copies instead of being clobbered
     client = sync_client.with_options(default_headers={"x-stainless-helper": "parent"})


### PR DESCRIPTION
## Problem

Follow-up to #1682. That PR fixed typed-event routing by preserving each chunk's real event type, but the `amazon-bedrock-invocationMetrics` trailer is still forwarded as `event="completion"`. The trailer carries neither a `type` nor a `completion` field, so on a Messages stream the `"completion"` branch in `_streaming.py::__stream__` constructs it against the `RawMessageStreamEvent` union with no discriminator. The union falls back to its first member and yields a contract-violating `RawMessageStartEvent(message=None)`, which leaks to the consumer as an extra stream event.

Any consumer that trusts the type annotations (for example `event.message.usage`, as in the original report via pydantic-ai's streaming path on `AsyncAnthropicBedrock`) then crashes with `AttributeError: 'NoneType' object has no attribute 'usage'`. This is the same failure reported in #1647, still reproducible on `main`.

### Reproduction (end to end, offline)

Feeding a complete Messages stream plus the metrics trailer through the real `AnthropicBedrock` client (binary eventstream frames, decoder, raw `messages.create(stream=True)`):

```
BEFORE  total events: 8 | last = RawMessageStartEvent  type=None  message=None
        event.message.usage -> AttributeError: 'NoneType' object has no attribute 'usage'

AFTER   total events: 7 | stream is clean, no leaked event
```

## Fix

In `lib/bedrock/_stream_decoder.py` (hand-maintained, not Stainless-generated), `_chunk_bytes_to_sse` now drops the metrics-only trailer instead of forwarding it:

- typed Messages events keep their real event type (unchanged)
- legacy text-completion chunks (which carry a `completion` field) still route as `event="completion"` (unchanged)
- a legacy completion chunk that also carries the metrics trailer is kept (unchanged)
- a chunk with no `type` and no `completion` field, the metrics-only trailer, is dropped so it never reaches the stream-event union

## Tests

Adds two regression tests to `tests/lib/test_bedrock.py`:

- `test_chunk_bytes_to_sse_drops_metrics_only_trailer` asserts the decoder returns `None` for the trailer
- `test_metrics_trailer_would_violate_stream_event_contract` documents the union fallback the drop protects against

Full `tests/lib/test_bedrock.py` passes, and `ruff` and `pyright` are clean on the changed files.

Fixes #1647.