### PR TITLE
Propagate output_tokens_details onto the accumulated streaming Message

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -559,5 +559,7 @@ def accumulate_event(
             current_snapshot.usage.server_tool_use = event.usage.server_tool_use
         if event.usage.iterations is not None:
             current_snapshot.usage.iterations = event.usage.iterations
+        if event.usage.output_tokens_details is not None:
+            current_snapshot.usage.output_tokens_details = event.usage.output_tokens_details
 
     return current_snapshot

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -516,5 +516,7 @@ def accumulate_event(
             current_snapshot.usage.cache_read_input_tokens = event.usage.cache_read_input_tokens
         if event.usage.server_tool_use is not None:
             current_snapshot.usage.server_tool_use = event.usage.server_tool_use
+        if event.usage.output_tokens_details is not None:
+            current_snapshot.usage.output_tokens_details = event.usage.output_tokens_details
 
     return current_snapshot

--- a/tests/lib/streaming/fixtures/refusal_response.txt
+++ b/tests/lib/streaming/fixtures/refusal_response.txt
@@ -8,7 +8,7 @@ event: content_block_stop
 data: {"type":"content_block_stop","index":0}
 
 event: message_delta
-data: {"type":"message_delta","delta":{"stop_reason":"refusal","stop_sequence":null,"stop_details":{"type":"refusal","category":"cyber","explanation":"This request was refused due to policy."}},"usage":{"output_tokens":0}}
+data: {"type":"message_delta","delta":{"stop_reason":"refusal","stop_sequence":null,"stop_details":{"type":"refusal","category":"cyber","explanation":"This request was refused due to policy."}},"usage":{"output_tokens":120,"output_tokens_details":{"thinking_tokens":67}}}
 
 event: message_stop
 data: {"type":"message_stop"}

--- a/tests/lib/streaming/test_beta_messages.py
+++ b/tests/lib/streaming/test_beta_messages.py
@@ -232,6 +232,9 @@ def assert_refusal_response(message: BetaMessage) -> None:
     assert message.stop_details.type == "refusal"
     assert message.stop_details.category == "cyber"
     assert message.stop_details.explanation == "This request was refused due to policy."
+    assert message.usage.output_tokens == 120
+    assert message.usage.output_tokens_details is not None
+    assert message.usage.output_tokens_details.thinking_tokens == 67
 
 
 EXPECTED_FALLBACK_EVENT_TYPES = [

--- a/tests/lib/streaming/test_messages.py
+++ b/tests/lib/streaming/test_messages.py
@@ -111,6 +111,9 @@ def assert_refusal_response(message: Message) -> None:
     assert message.stop_details.type == "refusal"
     assert message.stop_details.category == "cyber"
     assert message.stop_details.explanation == "This request was refused due to policy."
+    assert message.usage.output_tokens == 120
+    assert message.usage.output_tokens_details is not None
+    assert message.usage.output_tokens_details.thinking_tokens == 67
 
 
 class TestSyncMessages:


### PR DESCRIPTION
## Problem

The streaming accumulator copies most `usage` fields from `message_delta` onto the accumulated `Message`, but it never copies `output_tokens_details`. That field carries the reasoning token breakdown (`thinking_tokens`) the API reports for extended-thinking responses.

As a result the final snapshot from a stream disagrees with the equivalent non-streamed `Message`. A caller reading `stream.get_final_message().usage.output_tokens_details` gets `None` even when the API reported the breakdown, so cost and reasoning-token observability is silently lost on the streaming path.

`MessageDeltaUsage` (and the beta variant) already declares `output_tokens_details`, and the API sends it on `message_delta`. The repo's own fable-fallback fixtures carry it, for example `"output_tokens_details":{"thinking_tokens":67}`.

This is the same class of gap that #1725 fixed for `stop_details` in the same `message_delta` branch.

## Fix

Propagate `output_tokens_details` from `message_delta` onto the accumulated snapshot in both `lib/streaming/_messages.py` and `lib/streaming/_beta_messages.py`, mirroring the existing `stop_details` and `server_tool_use` propagation.

## Tests

The `refusal_response.txt` streaming fixture now carries `output_tokens_details` on its `message_delta`, and `assert_refusal_response` in both `test_messages.py` and `test_beta_messages.py` asserts it reaches the final message. The four refusal tests (sync and async, beta and non-beta) fail without the fix and pass with it. `ruff` and `pyright` are clean on the changed files.