### PR TITLE
Handle missing Connection header in Bedrock signing

### DIFF
--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -56,10 +56,9 @@ def get_auth_headers(
     # The connection header may be stripped by a proxy somewhere, so the receiver
     # of this message may not see this header, so we remove it from the set of headers
     # that are signed.
-    headers = headers.copy()
-    del headers["connection"]
+    new_headers = {k: v for k, v in dict(headers).items() if k.lower() != "connection"}
 
-    request = AWSRequest(method=method.upper(), url=url, headers=headers, data=data)
+    request = AWSRequest(method=method.upper(), url=url, headers=new_headers, data=data)
     credentials = session.get_credentials()
     if not credentials:
         raise RuntimeError("could not resolve credentials from session")


### PR DESCRIPTION
## Problem
Bedrock signing fails before the HTTP request in some cases with:
`KeyError: 'connection'`

The code in `src/anthropic/lib/bedrock/_auth.py` removes the header with `del headers["connection"]`. If `Connection` is absent (which can happen in normal httpx default header sets), `httpx.Headers.__delitem__` raises before any request is sent.

## Fix
- Replace direct deletion with a case-insensitive filter of headers before signing.
- Use a new header map that omits only `Connection` if present:
  `new_headers = {k: v for k, v in dict(headers).items() if k.lower() != "connection"}`
- Pass `new_headers` into `AWSRequest`.

This mirrors the existing guard pattern used by the AWS auth path in this repo and preserves the intent of excluding `Connection` from signed headers without crashing on missing keys.

## Scope & Behavior
- No functional behavior change when a `Connection` header exists.
- Safe no-op when `Connection` is absent.
- Prevents signing-time failures for Bedrock requests.

## File Changed
- `src/anthropic/lib/bedrock/_auth.py`

## Testing
Not run (per request).
