### PR TITLE
Fix MCP async tool_runner docs

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -162,7 +162,7 @@ async with stdio_client(StdioServerParameters(command="mcp-server")) as (read, w
         await mcp_client.initialize()
 
         tools_result = await mcp_client.list_tools()
-        runner = await client.beta.messages.tool_runner(
+        runner = client.beta.messages.tool_runner(
             model="claude-sonnet-5",
             max_tokens=1024,
             messages=[{"role": "user", "content": "Use the available tools"}],

--- a/src/anthropic/lib/tools/mcp.py
+++ b/src/anthropic/lib/tools/mcp.py
@@ -434,7 +434,7 @@ def async_mcp_tool(
         from anthropic.lib.tools.mcp import async_mcp_tool
 
         tools_result = await mcp_client.list_tools()
-        runner = await client.beta.messages.tool_runner(
+        runner = client.beta.messages.tool_runner(
             model="claude-sonnet-4-20250514",
             max_tokens=1024,
             tools=[async_mcp_tool(t, mcp_client) for t in tools_result.tools],


### PR DESCRIPTION
## Problem
Some MCP async examples show `await` on `client.beta.messages.tool_runner(...)`, but `tool_runner()` returns an async iterator and is not awaitable.

Users who copy that pattern hit a runtime `TypeError` before entering the runner loop.

## Fix
- Remove the incorrect `await` in the MCP helpers guide example (`helpers.md`).
- Remove the incorrect `await` from the `async_mcp_tool()` docstring example (`src/anthropic/lib/tools/mcp.py`).

Both examples now directly assign `runner = client.beta.messages.tool_runner(...)` and then iterate with `async for`.

## Testing
Not run (docs-only change).
