### PR TITLE
Report UTF-8 bytes in MCP write tool

### DIFF
--- a/src/anthropic/lib/tools/agent_toolset.py
+++ b/src/anthropic/lib/tools/agent_toolset.py
@@ -544,7 +544,7 @@ def beta_write_tool(ctx: AgentToolContext) -> BetaAsyncFunctionTool[Any]:
             target.write_text(content)
         except OSError as e:
             raise _fs_error("write", file_path, e) from e
-        return f"wrote {len(content)} bytes to {file_path}"
+        return f"wrote {len(content.encode(\"utf-8\"))} bytes to {file_path}"
 
     return write
 


### PR DESCRIPTION
## Problem
The agent `write` tool returns a status string with `len(content)`, which is a character count, while write operations are byte-oriented.

For non-ASCII text this reports a smaller number than the actual persisted bytes, e.g. "é".

## Fix
- In `src/anthropic/lib/tools/agent_toolset.py`, update the return message to use UTF-8 encoded byte length:
  - `len(content.encode("utf-8"))`

This keeps the current `bytes` status wording accurate while preserving behavior of writing with UTF-8 (the same default used by `Path.write_text`).

## Testing
Not run (docs/runtime behavior change only).
