### PR TITLE
Reject empty old_string in edit tool

### DIFF
--- a/src/anthropic/lib/tools/agent_toolset.py
+++ b/src/anthropic/lib/tools/agent_toolset.py
@@ -557,6 +557,8 @@ def beta_edit_tool(ctx: AgentToolContext) -> BetaAsyncFunctionTool[Any]:
             target = resolve_path(ctx, file_path)
         except ValueError as e:
             raise ToolError(f"edit: {e}") from e
+        if old_string == "":
+            raise ToolError("edit: old_string must not be empty")
         try:
             # stat() before any open(): the size cap stops a multi-GB file from
             # OOM'ing the runner, and is_file() rejects FIFOs/devices/dirs


### PR DESCRIPTION
## Problem
`old_string` is accepted as empty in the `edit` tool. Python `str.replace` treats an empty string as a match between every character, which can rewrite a file at every boundary when this tool is misused.

## Fix
- Add an early guard in `beta_edit_tool`: `if old_string == "": raise ToolError("edit: old_string must not be empty")`.
- Preserve existing uniqueness/missing-match validation for non-empty strings.

## Scope
- Only `src/anthropic/lib/tools/agent_toolset.py` change.
- Existing behavior for valid (non-empty) replacements is unchanged.

## Testing
Not run (behavioral validation change).
