### PR TITLE
ci: pin actions to full commit SHAs in claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
## Summary

Pins `actions/checkout` and `anthropics/claude-code-action` in the Claude workflow to immutable full commit SHAs.

## Vulnerability

Using mutable version tags (`@v4`, `@v1`) creates a supply-chain risk — if either action repository is compromised, an attacker could push malicious code under the same tag that would silently run in CI with access to `secrets.ANTHROPIC_API_KEY` and `write` permissions on contents, pull-requests, and issues.

The Claude workflow is particularly sensitive because it has broad permissions:
```yaml
permissions:
  contents: write
  pull-requests: write
  issues: write
  id-token: write
```

## Fix

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@34e1148` (v4) |
| `anthropics/claude-code-action` | `@v1` | `@a92e7c7` (v1) |

Both pins point to the exact same code as the current tags. Behaviour is unchanged.

## References
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
- [tj-actions supply chain incident (2025)](https://www.bleepingcomputer.com/news/security/popular-github-action-tjactionschanged-files-compromised-in-supply-chain-attack/)