### PR TITLE
fix: guard ParsedMessageStopEvent.message type to suppress Pydantic warnings

### DIFF
--- a/src/anthropic/lib/streaming/_types.py
+++ b/src/anthropic/lib/streaming/_types.py
@@ -110,7 +110,10 @@ MessageStreamEvent = Annotated[
 class ParsedMessageStopEvent(RawMessageStopEvent, GenericModel, Generic[ResponseFormatT]):
     type: Literal["message_stop"]
 
-    message: ParsedMessage[ResponseFormatT]
+    if TYPE_CHECKING:
+        message: ParsedMessage[ResponseFormatT]
+    else:
+        message: ParsedMessage
 
 
 class ParsedContentBlockStopEvent(RawContentBlockStopEvent, GenericModel, Generic[ResponseFormatT]):


### PR DESCRIPTION

`model_dump()` on `ParsedMessageStopEvent` emits `PydanticSerializationUnexpectedValue` warnings on every streamed response because the unresolved generic in message: `ParsedMessage[ResponseFormatT]` confuses Pydantic’s serializer at runtime (see [Pydantic ref](https://github.com/pydantic/pydantic-core/blob/main/src/serializers/type_serializers/union.rs#L104-L117))

The fix is the same `TYPE_CHECKING` guard already used for `ParsedContentBlockStopEvent.content_block` right below, it was just missed here:

```python
if TYPE_CHECKING:
    message: ParsedMessage[ResponseFormatT]
else:
    message: ParsedMessage
```

It looks like this inconsistency was introduced in https://github.com/anthropics/anthropic-sdk-python/commit/ad5667774ad2e7efd181bcfda03fab3ea50630b9 and only shows up at serialization time rather than typechecking or validation, likely explaining why this was not caught

Reproduced on every SDK version from 0.84.0 through 0.113.0 with pydantic 2.9–2.13.

### Testing

Verified with the following across multiple SDK/pydantic version combinations:

```python
import warnings
from anthropic.types.parsed_message import ParsedTextBlock, ParsedMessage
from anthropic.lib.streaming._types import ParsedMessageStopEvent
from anthropic._models import build
import anthropic

parsed_msg = ParsedMessage.construct(
    id="msg_test", type="message", role="assistant",
    content=[ParsedTextBlock.construct(type="text", text="Hello!")],
    model="claude-sonnet-4-20250514", stop_reason="end_turn",
    usage=anthropic.types.Usage.construct(input_tokens=10, output_tokens=5),
)
event = build(ParsedMessageStopEvent, type="message_stop", message=parsed_msg)

with warnings.catch_warnings(record=True) as caught:
    warnings.simplefilter("always")
    event.model_dump()

assert len(caught) == 0  # 12 sub-warnings before fix, 0 after
```

Also confirmed:
- `ruff check` / `ruff format` pass
- `pyright` / `mypy` pass with 0 errors
- `tests/test_streaming.py` — 23 tests pass

Related: #1175, #1422
Resolves: https://github.com/anthropics/anthropic-sdk-python/issues/1715