### PR TITLE
docs: clarify beta.skills upload directory requirement

### DIFF
--- a/src/anthropic/resources/beta/skills/skills.py
+++ b/src/anthropic/resources/beta/skills/skills.py
@@ -99,8 +99,10 @@ class Skills(SyncAPIResource):
 
           files: Files to upload for the skill.
 
-              All files must be in the same top-level directory and must include a SKILL.md
-              file at the root of that directory.
+              All files must be in the same top-level directory and must include a
+              `SKILL.md` file at the root of that directory. The top-level directory
+              name must match the `name:` field declared in `SKILL.md` (for example,
+              `my-skill/SKILL.md`).
 
           betas: Optional header to specify the beta version(s) you want to use.
 
@@ -370,8 +372,10 @@ class AsyncSkills(AsyncAPIResource):
 
           files: Files to upload for the skill.
 
-              All files must be in the same top-level directory and must include a SKILL.md
-              file at the root of that directory.
+              All files must be in the same top-level directory and must include a
+              `SKILL.md` file at the root of that directory. The top-level directory
+              name must match the `name:` field declared in `SKILL.md` (for example,
+              `my-skill/SKILL.md`).
 
           betas: Optional header to specify the beta version(s) you want to use.
 

--- a/src/anthropic/resources/beta/skills/versions.py
+++ b/src/anthropic/resources/beta/skills/versions.py
@@ -86,8 +86,10 @@ class Versions(SyncAPIResource):
 
           files: Files to upload for the skill.
 
-              All files must be in the same top-level directory and must include a SKILL.md
-              file at the root of that directory.
+              All files must be in the same top-level directory and must include a
+              `SKILL.md` file at the root of that directory. The top-level directory
+              name must match the `name:` field declared in `SKILL.md` (for example,
+              `my-skill/SKILL.md`).
 
           betas: Optional header to specify the beta version(s) you want to use.
 
@@ -358,8 +360,10 @@ class AsyncVersions(AsyncAPIResource):
 
           files: Files to upload for the skill.
 
-              All files must be in the same top-level directory and must include a SKILL.md
-              file at the root of that directory.
+              All files must be in the same top-level directory and must include a
+              `SKILL.md` file at the root of that directory. The top-level directory
+              name must match the `name:` field declared in `SKILL.md` (for example,
+              `my-skill/SKILL.md`).
 
           betas: Optional header to specify the beta version(s) you want to use.
 


### PR DESCRIPTION
Fixes #1575.

This makes the `beta.skills.create()` and `beta.skills.versions.create()` docstrings explicit about the exact archive layout the API expects: all files must live under one top-level directory, and that directory must match the `name:` field in `SKILL.md` (for example, `my-skill/SKILL.md`).

Validation:
- `PYTHONPATH=src python3 -m py_compile src/anthropic/resources/beta/skills/skills.py src/anthropic/resources/beta/skills/versions.py`