### PR TITLE
fix(agent_toolset): grep tolerates extra model-supplied args

### DIFF
--- a/src/anthropic/lib/tools/agent_toolset.py
+++ b/src/anthropic/lib/tools/agent_toolset.py
@@ -645,8 +645,15 @@ def beta_glob_tool(ctx: AgentToolContext) -> BetaAsyncFunctionTool[Any]:
 
 def beta_grep_tool(ctx: AgentToolContext) -> BetaAsyncFunctionTool[Any]:
     @beta_async_tool(name="grep", input_schema=BetaManagedAgentsAgentToolset20260401GrepInput)
-    async def grep(pattern: str, path: Optional[str] = None) -> str:
-        """Search file contents for a regular expression."""
+    async def grep(pattern: str, path: Optional[str] = None, **_ignored: Any) -> str:
+        """Search file contents for a regular expression.
+
+        Extra keyword arguments are accepted and ignored. A model often passes
+        Claude-Code-style grep options (e.g. ``output_mode``, ``head_limit``,
+        ``-i``) that are not part of the ``agent_toolset_20260401`` grep schema
+        (``pattern``/``path`` only). Without swallowing them, ``validate_call``
+        rejects the call and the model gets a hard error instead of results.
+        """
         try:
             search = resolve_path(ctx, path) if path else Path(ctx.workdir).resolve()
         except ValueError as e:


### PR DESCRIPTION
## What

`beta_grep_tool`'s `grep(pattern, path)` is registered with the full `agent_toolset_20260401` grep schema, but its signature accepts only `pattern`/`path`. When a model calls `grep` with any other argument, `@beta_async_tool`'s `validate_call` rejects the whole call:

```
ValidationError: 2 validation errors for beta_grep_tool.<locals>.grep
head_limit    Unexpected keyword argument
output_mode   Unexpected keyword argument
ValueError: Invalid arguments for function grep
```

This is not hypothetical: it happens in a real self-hosted `EnvironmentWorker` session. The model routinely emits Claude-Code-style grep options (`output_mode`, `head_limit`, `-i`, context lines) that are not in the `GrepInput` schema (which is `pattern`/`path` only). Every such call fails and the model gets a hard error instead of search results, so `grep` is effectively unusable for those calls and the agent falls back to `bash`.

## Fix

Accept and ignore unknown keyword arguments in the reference `grep` implementation (`**_ignored`). The tool still searches by `pattern`/`path`; extra options are tolerated rather than fatal. Minimal, matches the schema's documented contract, and unblocks real agent runs.

## Notes

- Only `grep` is changed; the other toolset functions weren't observed failing.
- Honoring `output_mode`/`head_limit` for real could be a follow-up, but that would also need the `GrepInput` schema (Stainless-generated) to declare them.
