### PR TITLE
fix: handle bare dict in construct_type

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -567,7 +567,8 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        args = get_args(type_)
+        items_type = args[1] if len(args) >= 2 else object
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -710,6 +710,12 @@ def test_discriminated_unions_unknown_variant() -> None:
     assert m.new_thing == "bar"
 
 
+def test_construct_type_with_bare_dict() -> None:
+    value = {"key": "value"}
+
+    assert construct_type(value=value, type_=dict) == value
+
+
 def test_discriminated_unions_invalid_data_nested_unions() -> None:
     class A(BaseModel):
         type: Literal["a"]


### PR DESCRIPTION
Fixes #1619

Treat bare `dict` annotations as an untyped mapping in `construct_type()` instead of unpacking missing type arguments. Adds a focused regression test for `construct_type(value={...}, type_=dict)`.

Validation:
- `uv run pytest tests/test_models.py -k bare_dict`
- `uv run ruff check src/anthropic/_models.py tests/test_models.py`