### PR TITLE
fix: handle bare list in construct_type

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -588,7 +588,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_list(value):
             return value
 
-        inner_type = args[0]  # List[inner_type]
+        inner_type = args[0] if args else object
         return [construct_type(value=entry, type_=inner_type) for entry in value]
 
     if origin == float:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -961,3 +961,9 @@ def test_extra_properties() -> None:
     assert model.a.prop == 1
     assert isinstance(model.a, Item)
     assert model.other == "foo"
+
+
+def test_construct_type_with_bare_list() -> None:
+    value = ["a", "b", "c"]
+
+    assert construct_type(value=value, type_=list) == value


### PR DESCRIPTION
Fixes #1626

Treat bare `list` annotations as an untyped list in `construct_type()` instead of indexing missing type arguments. Adds a focused regression test for `construct_type(value=[...], type_=list)`.

Validation:
- `uv run pytest tests/test_models.py -k bare_list`
- `uv run ruff check src/anthropic/_models.py tests/test_models.py`