### PR TITLE
fix: treat empty-string ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN as absent

### DIFF
--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -211,8 +211,8 @@ class Anthropic(SyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---
@@ -628,8 +628,8 @@ class AsyncAnthropic(AsyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -434,6 +434,17 @@ class TestAnthropic:
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
 
+    def test_empty_string_env_credentials_treated_as_absent(self) -> None:
+        # An empty-string env var must not be used as a credential — it would
+        # produce a malformed "Authorization: Bearer " header rejected by h11.
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = Anthropic(base_url=base_url, _strict_response_validation=True)
+
+        assert client.api_key is None
+        assert client.auth_token is None
+        assert client.auth_headers == {}
+
     def test_default_query_option(self) -> None:
         client = Anthropic(
             base_url=base_url, api_key=api_key, _strict_response_validation=True, default_query={"query_param": "bar"}
@@ -1545,6 +1556,17 @@ class TestAsyncAnthropic:
 
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
+
+    def test_empty_string_env_credentials_treated_as_absent(self) -> None:
+        # An empty-string env var must not be used as a credential — it would
+        # produce a malformed "Authorization: Bearer " header rejected by h11.
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = AsyncAnthropic(base_url=base_url, _strict_response_validation=True)
+
+        assert client.api_key is None
+        assert client.auth_token is None
+        assert client.auth_headers == {}
 
     async def test_default_query_option(self) -> None:
         client = AsyncAnthropic(


### PR DESCRIPTION
## Summary

`os.environ.get()` returns `""` for an env var that is present but empty — not `None`. When either `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` was set to an empty string (common in CI, containers, and in the Claude Code shell which exports both as empty), the SDK stored `""` as the credential.

For `ANTHROPIC_AUTH_TOKEN`, `_bearer_auth` then built `{"Authorization": "Bearer "}` — a header with a trailing space and no token. h11 validates header values at write time and rejects `b'Bearer '`:

```
h11._util.LocalProtocolError: Illegal header value b'Bearer '
```

surfaced as `anthropic.APIConnectionError` on every request.

## Fix

Apply `or None` to both env reads in `Anthropic.__init__` and `AsyncAnthropic.__init__`:

```python
# before
api_key = os.environ.get("ANTHROPIC_API_KEY")
auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")

# after
api_key = os.environ.get("ANTHROPIC_API_KEY") or None
auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
```

This coerces empty strings to `None` so the SDK treats a present-but-empty var the same as unset.

## Tests

Added `test_empty_string_env_credentials_treated_as_absent` to both `TestAnthropic` and `TestAsyncAnthropic`, verifying that `api_key`, `auth_token`, and `auth_headers` are all `None` / `{}` when the env vars are set to `""`.

Closes #1640