### PR TITLE
fix(client): handle bare dict/list annotations in construct_type and transform

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -647,7 +647,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        items_type = args[1] if len(args) >= 2 else object  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (
@@ -668,7 +668,7 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_list(value):
             return value
 
-        inner_type = args[0]  # List[inner_type]
+        inner_type = args[0] if args else object  # List[inner_type]
         return [construct_type(value=entry, type_=inner_type) for entry in value]
 
     if origin == float:

--- a/src/anthropic/_utils/_transform.py
+++ b/src/anthropic/_utils/_transform.py
@@ -180,7 +180,8 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        items_type = args[1] if len(args) >= 2 else object
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -348,7 +349,8 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        items_type = args[1] if len(args) >= 2 else object
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1015,3 +1015,15 @@ def test_iterable_construction_str_falls_back_to_list() -> None:
     # falls back to list of chars rather than calling str(["h", "e", "l", "l", "o"])
     assert m.data["items"] == ["h", "e", "l", "l", "o"]
     assert m.model_dump()["data"]["items"] == ["h", "e", "l", "l", "o"]
+
+
+def test_construct_bare_dict() -> None:
+    # a bare `dict` annotation (no type parameters) should be handled gracefully
+    # rather than raising `ValueError: not enough values to unpack`
+    assert construct_type(value={"key": "value"}, type_=dict) == {"key": "value"}
+
+
+def test_construct_bare_list() -> None:
+    # a bare `list` annotation (no type parameters) should be handled gracefully
+    # rather than raising `IndexError: tuple index out of range`
+    assert construct_type(value=["a", "b", "c"], type_=list) == ["a", "b", "c"]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -502,3 +502,11 @@ async def test_strips_notgiven(use_async: bool) -> None:
 async def test_strips_omit(use_async: bool) -> None:
     assert await transform({"foo_bar": "bar"}, Foo1, use_async) == {"fooBar": "bar"}
     assert await transform({"foo_bar": omit}, Foo1, use_async) == {}
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_dict(use_async: bool) -> None:
+    # a bare `dict` annotation (no type parameters) should be handled gracefully
+    # rather than raising `IndexError: tuple index out of range`
+    assert await transform({"key": "value"}, dict, use_async) == {"key": "value"}


### PR DESCRIPTION
Fixes #1619, #1626, #1628.

## Problem

`construct_type()` and `_transform_recursive` / `_async_transform_recursive` index the result of `get_args()` unconditionally. For an unparameterized annotation, `get_args(dict)` and `get_args(list)` return `()`, so the index access fails whenever a field is annotated as a bare `dict` or `list` instead of `Dict[K, V]` / `List[T]`:

- `construct_type(value={"k": "v"}, type_=dict)` → `ValueError: not enough values to unpack (expected 2, got 0)` (`_models.py`)
- `construct_type(value=["a", "b"], type_=list)` → `IndexError: tuple index out of range` (`_models.py`)
- `transform({"k": "v"}, dict)` / `async_transform({"k": "v"}, dict)` → `IndexError: tuple index out of range` (`_utils/_transform.py`)

## Fix

Guard each access and fall back to `object` as the item type when no type parameter is present. This matches the semantics of `Dict[str, object]` / `List[object]`: items are returned as-is with no further coercion. Parameterized annotations and the non-mapping / non-list passthrough branches are unchanged.

## Verification

- Added regression tests in `tests/test_models.py` and `tests/test_transform.py` (sync + async). They fail on `main` and pass with this change.
- `tests/test_models.py` + `tests/test_transform.py`: 122 passed.
- `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)