### PR TITLE
fix: treat empty-string ANTHROPIC_API_KEY/AUTH_TOKEN env vars as absent

### DIFF
--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -211,8 +211,8 @@ class Anthropic(SyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---
@@ -628,8 +628,8 @@ class AsyncAnthropic(AsyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -434,6 +434,16 @@ class TestAnthropic:
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
 
+    def test_empty_string_env_credentials_treated_as_absent(self) -> None:
+        # Regression: ANTHROPIC_API_KEY="" / ANTHROPIC_AUTH_TOKEN="" must be
+        # treated as absent, not as a real (empty) credential. An empty string
+        # causes `Authorization: Bearer ` (trailing space) which h11 rejects.
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = Anthropic(base_url=base_url, _strict_response_validation=True)
+        assert client.api_key is None
+        assert client.auth_token is None
+
     def test_default_query_option(self) -> None:
         client = Anthropic(
             base_url=base_url, api_key=api_key, _strict_response_validation=True, default_query={"query_param": "bar"}
@@ -1545,6 +1555,16 @@ class TestAsyncAnthropic:
 
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
+
+    def test_empty_string_env_credentials_treated_as_absent(self) -> None:
+        # Regression: ANTHROPIC_API_KEY="" / ANTHROPIC_AUTH_TOKEN="" must be
+        # treated as absent, not as a real (empty) credential. An empty string
+        # causes `Authorization: Bearer ` (trailing space) which h11 rejects.
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = AsyncAnthropic(base_url=base_url, _strict_response_validation=True)
+        assert client.api_key is None
+        assert client.auth_token is None
 
     async def test_default_query_option(self) -> None:
         client = AsyncAnthropic(


### PR DESCRIPTION
## Summary

`os.environ.get("ANTHROPIC_API_KEY")` returns `""` when the variable is exported but set to an empty string. That empty string was stored as `self.api_key` / `self.auth_token` because the existing check only guarded against `None`. When building headers, `_bearer_auth` then produced `Authorization: Bearer ` (with a trailing space), which h11 rejects at write time with `LocalProtocolError: Illegal header value b'Bearer '`.

This is especially common in:
- CI containers where vars are exported empty as defaults
- The Claude Code CLI shell, which exports both `ANTHROPIC_AUTH_TOKEN=` and `ANTHROPIC_API_KEY=` into child processes

**Fix:** apply `or None` after `os.environ.get()` so empty strings are treated as absent, consistent with how every other env-var credential system works.

Both the `Anthropic` (sync) and `AsyncAnthropic` initializers had the same issue — both are fixed.

## Changes

- `src/anthropic/_client.py`: two-line fix in the hand-written credentials section (lines marked `# hand-written, upstream to Stainless`) — both sync and async clients
- `tests/test_client.py`: regression tests for `TestAnthropic` and `TestAsyncAnthropic` asserting that empty-string env vars leave `api_key` and `auth_token` as `None`

Closes #1640