### PR TITLE
fix(aws): let AnthropicAWS.copy() accept credentials=None so environment helpers work on Claude Platform on AWS

### DIFF
--- a/src/anthropic/lib/aws/_client.py
+++ b/src/anthropic/lib/aws/_client.py
@@ -18,6 +18,7 @@ from ._credentials import (
 from ..._exceptions import AnthropicError
 from ..._middleware import MiddlewareInput
 from ..._base_client import DEFAULT_MAX_RETRIES
+from ..credentials._types import AccessTokenProvider
 
 
 class AnthropicAWS(Anthropic):
@@ -164,7 +165,7 @@ class AnthropicAWS(Anthropic):
         request.headers.update(headers)
 
     @override
-    def copy(  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride] — subclass intentionally drops `credentials`
+    def copy(  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride] — narrows `credentials` to None-only
         self,
         *,
         api_key: str | None = None,
@@ -176,6 +177,7 @@ class AnthropicAWS(Anthropic):
         workspace_id: str | None = None,
         skip_auth: bool | None = None,
         auth_token: str | None = None,
+        credentials: AccessTokenProvider | None = None,
         webhook_key: str | None = None,
         base_url: str | httpx.URL | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
@@ -188,6 +190,14 @@ class AnthropicAWS(Anthropic):
         middleware: Sequence[MiddlewareInput] | None | NotGiven = NOT_GIVEN,
         _extra_kwargs: Mapping[str, Any] = {},
     ) -> Self:
+        # The AWS client authenticates with SigV4 (or an API key), not a token
+        # provider, so it has no `credentials`. Accept the argument for signature
+        # compatibility with the base client — internal helpers such as
+        # `_copy_client_with_bearer_auth` call `copy(credentials=None, ...)` — but
+        # only as a no-op; reject a real provider rather than silently ignoring it.
+        if credentials is not None:
+            raise TypeError("AnthropicAWS does not support a `credentials` provider (it authenticates with AWS SigV4).")
+
         # If region is changing and no explicit base_url, let __init__ derive it
         resolved_base_url = base_url or (None if aws_region else self.base_url)
 
@@ -363,7 +373,7 @@ class AsyncAnthropicAWS(AsyncAnthropic):
         request.headers.update(headers)
 
     @override
-    def copy(  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride] — subclass intentionally drops `credentials`
+    def copy(  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride] — narrows `credentials` to None-only
         self,
         *,
         api_key: str | None = None,
@@ -375,6 +385,7 @@ class AsyncAnthropicAWS(AsyncAnthropic):
         workspace_id: str | None = None,
         skip_auth: bool | None = None,
         auth_token: str | None = None,
+        credentials: AccessTokenProvider | None = None,
         webhook_key: str | None = None,
         base_url: str | httpx.URL | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
@@ -387,6 +398,14 @@ class AsyncAnthropicAWS(AsyncAnthropic):
         middleware: Sequence[MiddlewareInput] | None | NotGiven = NOT_GIVEN,
         _extra_kwargs: Mapping[str, Any] = {},
     ) -> Self:
+        # The AWS client authenticates with SigV4 (or an API key), not a token
+        # provider, so it has no `credentials`. Accept the argument for signature
+        # compatibility with the base client — internal helpers such as
+        # `_copy_client_with_bearer_auth` call `copy(credentials=None, ...)` — but
+        # only as a no-op; reject a real provider rather than silently ignoring it.
+        if credentials is not None:
+            raise TypeError("AnthropicAWS does not support a `credentials` provider (it authenticates with AWS SigV4).")
+
         # If region is changing and no explicit base_url, let __init__ derive it
         resolved_base_url = base_url or (None if aws_region else self.base_url)
 

--- a/tests/lib/test_aws.py
+++ b/tests/lib/test_aws.py
@@ -370,3 +370,63 @@ def test_copy_overrides_aws_options() -> None:
         base_url="https://aws-external-anthropic.eu-west-1.api.aws",
     )
     assert str(copied2.base_url).rstrip("/") == "https://aws-external-anthropic.eu-west-1.api.aws"
+
+
+def test_copy_accepts_credentials_none_noop() -> None:
+    # `credentials=None` is accepted as a no-op: the AWS client authenticates with
+    # SigV4, not a token provider, so there is nothing to clear. The copy stays SigV4.
+    client = AnthropicAWS(
+        aws_access_key="AKID",
+        aws_secret_key="secret",
+        aws_region="us-east-1",
+        workspace_id="ws-123",
+    )
+    copied = client.copy(credentials=None)
+    assert copied._use_sigv4 is True
+    assert copied.workspace_id == "ws-123"
+    assert copied.aws_region == "us-east-1"
+
+
+def test_copy_rejects_real_credentials_provider() -> None:
+    client = AnthropicAWS(
+        aws_access_key="AKID",
+        aws_secret_key="secret",
+        aws_region="us-east-1",
+        workspace_id="ws-123",
+    )
+    with pytest.raises(TypeError, match="does not support a `credentials` provider"):
+        client.copy(credentials=object())
+
+
+def test_scoped_bearer_client_helper_on_aws() -> None:
+    # Regression: the environment poller / worker / session-tool-runner build a
+    # scoped sub-client via `_copy_client_with_bearer_auth`, which calls
+    # `client.copy(credentials=None, ...)`. That must work on the AWS client and
+    # yield a client that still signs with SigV4 (the bearer token is unused).
+    from anthropic.lib._scoped_client import _copy_client_with_bearer_auth
+
+    client = AnthropicAWS(
+        aws_access_key="AKID",
+        aws_secret_key="secret",
+        aws_region="us-east-1",
+        workspace_id="ws-123",
+    )
+    scoped = _copy_client_with_bearer_auth(client, auth_token="unused-under-sigv4", helper="environments-work-poller")
+    assert isinstance(scoped, AnthropicAWS)
+    assert scoped._use_sigv4 is True
+    assert scoped.workspace_id == "ws-123"
+
+
+def test_scoped_bearer_client_helper_on_aws_async() -> None:
+    from anthropic.lib._scoped_client import _copy_client_with_bearer_auth
+
+    client = AsyncAnthropicAWS(
+        aws_access_key="AKID",
+        aws_secret_key="secret",
+        aws_region="us-east-1",
+        workspace_id="ws-123",
+    )
+    scoped = _copy_client_with_bearer_auth(client, auth_token="unused-under-sigv4", helper="environments-worker")
+    assert isinstance(scoped, AsyncAnthropicAWS)
+    assert scoped._use_sigv4 is True
+    assert scoped.workspace_id == "ws-123"

--- a/tests/lib/test_aws.py
+++ b/tests/lib/test_aws.py
@@ -8,6 +8,7 @@ from respx import MockRouter
 
 from anthropic import AnthropicAWS, AsyncAnthropicAWS
 from anthropic._exceptions import AnthropicError
+from anthropic.lib.credentials import StaticToken
 
 
 class MockRequestCall(Protocol):
@@ -387,6 +388,19 @@ def test_copy_accepts_credentials_none_noop() -> None:
     assert copied.aws_region == "us-east-1"
 
 
+def test_copy_accepts_credentials_none_noop_async() -> None:
+    client = AsyncAnthropicAWS(
+        aws_access_key="AKID",
+        aws_secret_key="secret",
+        aws_region="us-east-1",
+        workspace_id="ws-123",
+    )
+    copied = client.copy(credentials=None)
+    assert copied._use_sigv4 is True
+    assert copied.workspace_id == "ws-123"
+    assert copied.aws_region == "us-east-1"
+
+
 def test_copy_rejects_real_credentials_provider() -> None:
     client = AnthropicAWS(
         aws_access_key="AKID",
@@ -395,7 +409,18 @@ def test_copy_rejects_real_credentials_provider() -> None:
         workspace_id="ws-123",
     )
     with pytest.raises(TypeError, match="does not support a `credentials` provider"):
-        client.copy(credentials=object())
+        client.copy(credentials=StaticToken("token"))
+
+
+def test_copy_rejects_real_credentials_provider_async() -> None:
+    client = AsyncAnthropicAWS(
+        aws_access_key="AKID",
+        aws_secret_key="secret",
+        aws_region="us-east-1",
+        workspace_id="ws-123",
+    )
+    with pytest.raises(TypeError, match="does not support a `credentials` provider"):
+        client.copy(credentials=StaticToken("token"))
 
 
 def test_scoped_bearer_client_helper_on_aws() -> None:


### PR DESCRIPTION
Fixes #1736.

### Problem

The self-hosted environment work helpers — `client.beta.environments.work.poller()`, `EnvironmentWorker`, and `SessionToolRunner` — build a scoped sub-client via `_copy_client_with_bearer_auth`, which calls `client.copy(credentials=None, ...)`. `AnthropicAWS.copy()` / `AsyncAnthropicAWS.copy()` intentionally omit `credentials`, so on the AWS platform these helpers raise before making any request:

```
TypeError: AsyncAnthropicAWS.copy() got an unexpected keyword argument 'credentials'
```

This makes the self-hosted environment poller and worker unusable on Claude Platform on AWS. Reproduced on `anthropic==0.116.0` (latest release). Full repro in #1736.

### Fix

Accept `credentials` on the AWS `copy()` overrides:

- **`None` (the value the internal helper passes) → no-op.** The AWS client authenticates with SigV4 (or an API key) and has no token-provider credential to clear, so the scoped sub-client is returned unchanged auth-wise and keeps signing with SigV4.
- **A real provider → `TypeError`** with a clear message, rather than silently ignoring it.

The change is confined to `src/anthropic/lib/aws/_client.py` (which the code generator never touches) and fixes all four call sites at once.

### Tests

Added to `tests/lib/test_aws.py`:
- `test_copy_accepts_credentials_none_noop` — `copy(credentials=None)` stays SigV4, preserves workspace/region.
- `test_copy_rejects_real_credentials_provider` — a real provider raises `TypeError`.
- `test_scoped_bearer_client_helper_on_aws` / `_async` — the exact `_copy_client_with_bearer_auth` path the poller/worker use now works on both sync and async AWS clients.

`tests/lib/test_aws.py` passes (39 passed); full `tests/lib/` suite passes (752 passed, 1 skipped, 1 xfailed); `ruff check` and `ruff format` clean.
