### PR TITLE
fix(credentials): match parsed host in cleartext-HTTP guard

### DIFF
--- a/src/anthropic/lib/credentials/_constants.py
+++ b/src/anthropic/lib/credentials/_constants.py
@@ -4,6 +4,7 @@ import os
 import sys
 import pathlib
 from typing import Optional
+from urllib.parse import urlsplit
 
 from ..._exceptions import AnthropicError
 
@@ -113,6 +114,10 @@ def _active_profile() -> str:  # pyright: ignore[reportUnusedFunction] — used 
     return name
 
 
+# Loopback hosts that may be reached over cleartext HTTP for local testing.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
 def _require_https(url: str, *, field: str) -> None:  # pyright: ignore[reportUnusedFunction] — used by _workload/_providers
     """Reject non-``https://`` token-endpoint URLs.
 
@@ -120,11 +125,18 @@ def _require_https(url: str, *, field: str) -> None:  # pyright: ignore[reportUn
     works against a local ``oauth_server`` instance; everything else must be
     TLS-encrypted because the body of these POSTs carries the assertion JWT
     or a long-lived refresh token.
+
+    The loopback exemption matches the *parsed* host, not a string prefix: a
+    check like ``url.startswith("http://localhost")`` also accepts
+    ``http://localhost.evil.com`` and ``http://localhost@evil.com`` (whose real
+    host is ``evil.com``), which would POST the secret to an attacker-controlled
+    host in cleartext.
     """
-    lowered = url.lower().rstrip("/")
-    if lowered.startswith("https://"):
+    parts = urlsplit(url)
+    scheme = parts.scheme.lower()
+    if scheme == "https":
         return
-    if lowered.startswith(("http://localhost", "http://127.0.0.1", "http://[::1]")):
+    if scheme == "http" and (parts.hostname or "").lower() in _LOOPBACK_HOSTS:
         return
     raise AnthropicError(
         f"{field} must use https (got {url!r}); the token-exchange endpoint "

--- a/tests/lib/test_credentials.py
+++ b/tests/lib/test_credentials.py
@@ -36,6 +36,7 @@ from anthropic.lib.credentials._constants import (
     GRANT_TYPE_JWT_BEARER,
     OAUTH_API_BETA_HEADER,
     FEDERATION_BETA_HEADER,
+    _require_https,
 )
 
 BASE_URL = "https://api.anthropic.com"
@@ -729,6 +730,43 @@ class TestCredentialsFile:
         )
         with pytest.raises(AnthropicError, match="must use https"):
             creds.bind_base_url("http://evil.example.com")
+
+    @pytest.mark.parametrize(
+        "malicious_url",
+        [
+            "http://localhost.evil.com/token",  # look-alike subdomain, real host is under evil.com
+            "http://localhost@evil.com/token",  # userinfo trick, real host is evil.com
+            "http://localhost.evil.com",
+            "http://127.0.0.1.evil.com/token",  # loopback look-alike, real host is under evil.com
+            "http://127.0.0.1@evil.com/token",
+            "http://localhostx:8080",  # bare prefix look-alike, real host is localhostx
+        ],
+    )
+    def test_localhost_lookalike_http_rejected(self, malicious_url: str) -> None:
+        """Cleartext HTTP is only tolerated for the loopback host. A prefix check
+        like ``url.startswith("http://localhost")`` also accepts hosts such as
+        ``localhost.evil.com`` or ``localhost@evil.com`` (whose real host is
+        ``evil.com``) — sending the assertion JWT / refresh token to an
+        attacker-controlled host in cleartext. Match the parsed host instead."""
+        with pytest.raises(AnthropicError, match="must use https"):
+            _require_https(malicious_url, field="base_url")
+
+    @pytest.mark.parametrize(
+        "loopback_url",
+        [
+            "http://localhost",
+            "http://localhost:8080",
+            "http://localhost:8080/v1/oauth/token",
+            "http://LocalHost:8080",  # host comparison is case-insensitive
+            "http://127.0.0.1",
+            "http://127.0.0.1:8080",
+            "http://[::1]:8080",
+            "https://api.anthropic.com",  # https is always allowed
+        ],
+    )
+    def test_loopback_and_https_allowed(self, loopback_url: str) -> None:
+        """Genuine loopback HTTP endpoints and any https URL must keep working."""
+        _require_https(loopback_url, field="base_url")
 
     # -- security: profile-name validation --------------------------------
 


### PR DESCRIPTION
### What

`_require_https` (`src/anthropic/lib/credentials/_constants.py`) gates the credential token-exchange `base_url`: `https://` is always allowed, and cleartext `http://` is tolerated only for a loopback host so `base_url="http://localhost:8080"` works against a local `oauth_server` during testing.

The loopback exemption was a raw string prefix check:

```python
lowered = url.lower().rstrip("/")
if lowered.startswith("https://"):
    return
if lowered.startswith(("http://localhost", "http://127.0.0.1", "http://[::1]")):
    return
```

A string prefix isn't a host. The following all pass the exemption today but are **not** loopback:

| `base_url` | real host (`urlsplit(url).hostname`) |
|---|---|
| `http://localhost.evil.com/token` | `localhost.evil.com` |
| `http://localhost@evil.com/token` | `evil.com` |
| `http://127.0.0.1.evil.com/token` | `127.0.0.1.evil.com` |
| `http://127.0.0.1@evil.com/token` | `evil.com` |
| `http://localhostx:8080` | `localhostx` |

So a misconfigured `base_url` pointing at any `localhost`/`127.0.0.1`-prefixed hostname — or one using a `localhost@…` userinfo segment whose real authority is elsewhere — sends the Workload Identity assertion JWT or a long-lived refresh token to that host over **cleartext HTTP**, the exact CWE-319 leak this guard exists to prevent. This tightens the defense-in-depth hardening added for #1578.

### Fix

Parse the URL and compare the exact host against the loopback allowlist instead of prefix-matching the raw string:

```python
_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})

parts = urlsplit(url)
scheme = parts.scheme.lower()
if scheme == "https":
    return
if scheme == "http" and (parts.hostname or "").lower() in _LOOPBACK_HOSTS:
    return
raise AnthropicError(...)
```

`urlsplit` drops any `userinfo@` segment from `.hostname`, so `http://localhost@evil.com` resolves to host `evil.com` and is rejected. `https://` URLs and genuine loopback HTTP endpoints (`http://localhost[:port][/path]`, `http://127.0.0.1`, `http://[::1]`) are unaffected.

### Tests

`tests/lib/test_credentials.py`, in the existing HTTPS-enforcement section:

- `test_localhost_lookalike_http_rejected` — the look-alike hosts above now raise `AnthropicError` (fail without this change).
- `test_loopback_and_https_allowed` — genuine loopback HTTP endpoints and any `https://` URL still pass (regression guard, including case-insensitive host matching and `[::1]`).

Full `tests/lib/test_credentials.py` (193 tests) passes; `./scripts/lint` (ruff + pyright + mypy) is clean.

Related: #1578.
