### PR TITLE
fix(streaming): emit input_json events for server_tool_use blocks

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -365,7 +365,11 @@ def build_events(
                     )
                 )
         elif event.delta.type == "input_json_delta":
-            if content_block.type == "tool_use" or content_block.type == "mcp_tool_use":
+            # Emit `input_json` for every block whose input we accumulate below
+            # (see `accumulate_event`/`TRACKS_TOOL_INPUT`), not just `tool_use`
+            # and `mcp_tool_use` — otherwise `server_tool_use` blocks stream
+            # their input into the snapshot but never fire an `input_json` event.
+            if isinstance(content_block, TRACKS_TOOL_INPUT):
                 events_to_fire.append(
                     build(
                         BetaInputJsonEvent,

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -360,7 +360,11 @@ def build_events(
                     )
                 )
         elif event.delta.type == "input_json_delta":
-            if content_block.type == "tool_use":
+            # Emit `input_json` for every block whose input we accumulate below
+            # (see `accumulate_event`/`TRACKS_TOOL_INPUT`), not just client
+            # `tool_use` — otherwise `server_tool_use` blocks stream their input
+            # into the snapshot but never fire an `input_json` event.
+            if isinstance(content_block, TRACKS_TOOL_INPUT):
                 events_to_fire.append(
                     build(
                         InputJsonEvent,

--- a/tests/lib/streaming/fixtures/server_tool_use_response.txt
+++ b/tests/lib/streaming/fixtures/server_tool_use_response.txt
@@ -1,0 +1,35 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01ServerToolUseInputJson","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":42,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me search for that."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srvtoolu_01WebSearch","name":"web_search","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"query\": "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"weather "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"in Paris\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":40}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/tests/lib/streaming/test_beta_messages.py
+++ b/tests/lib/streaming/test_beta_messages.py
@@ -99,6 +99,49 @@ EXPECTED_TOOL_USE_EVENT_TYPES = [
     "message_delta",
 ]
 
+EXPECTED_SERVER_TOOL_USE_MESSAGE = {
+    "id": "msg_01ServerToolUseInputJson",
+    "model": "claude-sonnet-4-20250514",
+    "role": "assistant",
+    "stop_reason": "end_turn",
+    "type": "message",
+    "content": [
+        {"type": "text", "text": "Let me search for that."},
+        {
+            "type": "server_tool_use",
+            "id": "srvtoolu_01WebSearch",
+            "name": "web_search",
+            "input": {"query": "weather in Paris"},
+        },
+    ],
+    "usage": {
+        "input_tokens": 42,
+        "output_tokens": 40,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "service_tier": "standard",
+    },
+}
+
+EXPECTED_SERVER_TOOL_USE_EVENT_TYPES = [
+    "message_start",
+    "content_block_start",
+    "content_block_delta",
+    "text",
+    "content_block_stop",
+    "content_block_start",
+    "content_block_delta",
+    "input_json",
+    "content_block_delta",
+    "input_json",
+    "content_block_delta",
+    "input_json",
+    "content_block_delta",
+    "input_json",
+    "content_block_stop",
+    "message_delta",
+]
+
 EXPECTED_INCOMPLETE_MESSAGE = {
     "id": "msg_01UdjYBBipA9omjYhicnevgq",
     "model": "claude-3-7-sonnet-20250219",
@@ -211,6 +254,16 @@ def assert_tool_use_response(events: list[ParsedBetaMessageStreamEvent], message
     assert [e.type for e in events] == EXPECTED_TOOL_USE_EVENT_TYPES
 
 
+def assert_server_tool_use_response(events: list[ParsedBetaMessageStreamEvent], message: BetaMessage) -> None:
+    assert_message_matches(message, EXPECTED_SERVER_TOOL_USE_MESSAGE)
+    # `input_json` events must fire for `server_tool_use` blocks, not just
+    # `tool_use`/`mcp_tool_use` — the input is streamed and accumulated for all.
+    input_json_events = [e for e in events if e.type == "input_json"]
+    assert input_json_events, "expected input_json events for the server_tool_use block"
+    assert input_json_events[-1].snapshot == {"query": "weather in Paris"}
+    assert [e.type for e in events] == EXPECTED_SERVER_TOOL_USE_EVENT_TYPES
+
+
 def assert_incomplete_partial_input_response(events: list[ParsedBetaMessageStreamEvent], message: BetaMessage) -> None:
     assert_message_matches(message, EXPECTED_INCOMPLETE_MESSAGE)
     assert [e.type for e in events] == EXPECTED_INCOMPLETE_EVENT_TYPES
@@ -300,6 +353,19 @@ class TestSyncMessages:
             assert isinstance(cast(Any, stream), BetaMessageStream)
 
             assert_tool_use_response([event for event in stream], stream.get_final_message())
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_server_tool_use_input_json(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=get_response("server_tool_use_response.txt"))
+        )
+
+        with sync_client.beta.messages.stream(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+            model="claude-sonnet-4-5",
+        ) as stream:
+            assert_server_tool_use_response([event for event in stream], stream.get_final_message())
 
     @pytest.mark.respx(base_url=base_url)
     def test_context_manager(self, respx_mock: MockRouter) -> None:
@@ -463,6 +529,20 @@ class TestAsyncMessages:
             assert isinstance(cast(Any, stream), BetaAsyncMessageStream)
 
             assert_tool_use_response([event async for event in stream], await stream.get_final_message())
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx(base_url=base_url)
+    async def test_server_tool_use_input_json(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=to_async_iter(get_response("server_tool_use_response.txt")))
+        )
+
+        async with async_client.beta.messages.stream(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+            model="claude-sonnet-4-5",
+        ) as stream:
+            assert_server_tool_use_response([event async for event in stream], await stream.get_final_message())
 
     @pytest.mark.asyncio
     @pytest.mark.respx(base_url=base_url)

--- a/tests/lib/streaming/test_messages.py
+++ b/tests/lib/streaming/test_messages.py
@@ -105,6 +105,38 @@ def assert_tool_use_response(events: list[ParsedMessageStreamEvent[None]], messa
     ]
 
 
+def assert_server_tool_use_response(events: list[ParsedMessageStreamEvent[None]], message: Message) -> None:
+    server_tool_use = message.content[1]
+    assert server_tool_use.type == "server_tool_use"
+    assert server_tool_use.name == "web_search"
+    assert server_tool_use.input == {"query": "weather in Paris"}
+
+    # `input_json` events must fire for `server_tool_use` blocks, not just client
+    # `tool_use` — the input is streamed and accumulated for both.
+    input_json_events = [e for e in events if e.type == "input_json"]
+    assert input_json_events, "expected input_json events for the server_tool_use block"
+    assert input_json_events[-1].snapshot == {"query": "weather in Paris"}
+
+    assert [e.type for e in events] == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "text",
+        "content_block_stop",
+        "content_block_start",
+        "content_block_delta",
+        "input_json",
+        "content_block_delta",
+        "input_json",
+        "content_block_delta",
+        "input_json",
+        "content_block_delta",
+        "input_json",
+        "content_block_stop",
+        "message_delta",
+    ]
+
+
 def assert_refusal_response(message: Message) -> None:
     assert message.stop_reason == "refusal"
     assert message.stop_details is not None
@@ -192,6 +224,19 @@ class TestSyncMessages:
                 assert isinstance(cast(Any, stream), Stream)
 
             assert_tool_use_response([event for event in stream], stream.get_final_message())
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_server_tool_use_input_json(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=get_response("server_tool_use_response.txt"))
+        )
+
+        with sync_client.messages.stream(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+            model="claude-sonnet-4-5",
+        ) as stream:
+            assert_server_tool_use_response([event for event in stream], stream.get_final_message())
 
     @pytest.mark.respx(base_url=base_url)
     def test_refusal_stop_details_propagated(self, respx_mock: MockRouter) -> None:
@@ -290,6 +335,20 @@ class TestAsyncMessages:
                 assert isinstance(cast(Any, stream), AsyncStream)
 
             assert_tool_use_response([event async for event in stream], await stream.get_final_message())
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx(base_url=base_url)
+    async def test_server_tool_use_input_json(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=to_async_iter(get_response("server_tool_use_response.txt")))
+        )
+
+        async with async_client.messages.stream(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+            model="claude-sonnet-4-5",
+        ) as stream:
+            assert_server_tool_use_response([event async for event in stream], await stream.get_final_message())
 
     @pytest.mark.asyncio
     @pytest.mark.respx(base_url=base_url)


### PR DESCRIPTION
## What

When streaming a message that contains a **server-side tool call** (`server_tool_use`, e.g. `web_search`), the SDK accumulates the tool's streamed input into the message snapshot but never emits an `input_json` stream event for it. `on_input_json` callbacks and code iterating the event stream therefore never see the input of server tools — only client `tool_use` (and, in the beta path, `mcp_tool_use`) fire `input_json`.

## Root cause

`accumulate_event` decides *what to accumulate* with `TRACKS_TOOL_INPUT`:

```python
# src/anthropic/lib/streaming/_messages.py
TRACKS_TOOL_INPUT = (ToolUseBlock, ServerToolUseBlock)
...
if isinstance(content, TRACKS_TOOL_INPUT):
    ...  # build up content.input from input_json_delta
```

But `build_events` decides *what to emit* with a narrower, hard-coded check:

```python
elif event.delta.type == "input_json_delta":
    if content_block.type == "tool_use":          # non-beta: server_tool_use missing
        events_to_fire.append(build(InputJsonEvent, ...))
```

The beta path (`_beta_messages.py`) tracks `(BetaToolUseBlock, BetaServerToolUseBlock, BetaMCPToolUseBlock)` but only emits for `tool_use` / `mcp_tool_use` — again dropping `server_tool_use`. So the emitter and the accumulator disagree about which blocks carry input.

## Fix

Emit `input_json` for exactly the block types whose input is accumulated, by reusing `TRACKS_TOOL_INPUT` via `isinstance` in `build_events` (both non-beta and beta). Emission and accumulation now share one source of truth and can't drift apart.

## Tests

- New fixture `tests/lib/streaming/fixtures/server_tool_use_response.txt` — a stream with a `web_search` `server_tool_use` block whose input streams in as `{"query": "weather in Paris"}`.
- `test_server_tool_use_input_json` (sync + async) in both `test_messages.py` and `test_beta_messages.py`, asserting `input_json` events fire and the final snapshot equals the accumulated input.
- Verified RED→GREEN: without the fix, `input_json_events == []` for the `server_tool_use` block in all four tests; with it, they fire.
- Full `tests/lib/streaming/` suite (44 tests) passes; `./scripts/lint` (ruff + pyright + mypy) clean.
