### PR TITLE
fix(bedrock): don't raise KeyError when signing requests lacking a connection header

### DIFF
--- a/src/anthropic/lib/bedrock/_auth.py
+++ b/src/anthropic/lib/bedrock/_auth.py
@@ -56,10 +56,9 @@ def get_auth_headers(
     # The connection header may be stripped by a proxy somewhere, so the receiver
     # of this message may not see this header, so we remove it from the set of headers
     # that are signed.
-    headers = headers.copy()
-    del headers["connection"]
+    new_headers = {k: v for k, v in dict(headers).items() if k.lower() != "connection"}
 
-    request = AWSRequest(method=method.upper(), url=url, headers=headers, data=data)
+    request = AWSRequest(method=method.upper(), url=url, headers=new_headers, data=data)
     credentials = session.get_credentials()
     if not credentials:
         raise RuntimeError("could not resolve credentials from session")

--- a/tests/lib/test_bedrock.py
+++ b/tests/lib/test_bedrock.py
@@ -9,6 +9,7 @@ import pytest
 from respx import MockRouter
 
 from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
+from anthropic.lib.bedrock._auth import get_auth_headers
 from anthropic.lib.bedrock._stream_decoder import _chunk_bytes_to_sse
 
 sync_client = AnthropicBedrock(
@@ -319,3 +320,39 @@ def test_async_copy_x_stainless_helper_header_appends() -> None:
     client = async_client.with_options(default_headers={"x-stainless-helper": "parent"})
     copied = client.with_options(default_headers={"x-stainless-helper": "child"})
     assert copied.default_headers["x-stainless-helper"] == "parent, child"
+
+
+def test_get_auth_headers_without_connection_header() -> None:
+    # Signing must not require a `connection` header to be present. HTTP/2 requests
+    # forbid the header entirely, so `request.headers` can legitimately lack it; the
+    # previous `del headers["connection"]` raised `KeyError` in that case.
+    headers = get_auth_headers(
+        method="POST",
+        url="https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/invoke",
+        headers=httpx.Headers({"content-type": "application/json"}),
+        aws_access_key="AKIAIOSFODNN7EXAMPLE",
+        aws_secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        aws_session_token=None,
+        region="us-east-1",
+        profile=None,
+        data='{"hello": "world"}',
+    )
+    assert "Authorization" in headers
+
+
+def test_get_auth_headers_strips_connection_header() -> None:
+    # Connection header must not be signed (may be stripped by proxies).
+    headers = get_auth_headers(
+        method="POST",
+        url="https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/invoke",
+        headers=httpx.Headers({"content-type": "application/json", "connection": "keep-alive"}),
+        aws_access_key="AKIAIOSFODNN7EXAMPLE",
+        aws_secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        aws_session_token=None,
+        region="us-east-1",
+        profile=None,
+        data='{"hello": "world"}',
+    )
+    signed_headers_match = re.search(r"SignedHeaders=([^,]+)", headers["Authorization"])
+    assert signed_headers_match is not None
+    assert "connection" not in signed_headers_match.group(1).split(";")


### PR DESCRIPTION
## Summary

`AnthropicBedrock`'s SigV4 signer raises `KeyError: 'connection'` when the outgoing request has no `Connection` header.

`get_auth_headers` in `src/anthropic/lib/bedrock/_auth.py` strips the connection header before signing (it may be altered by proxies, so it must not be part of the signature) via:

```python
headers = headers.copy()
del headers["connection"]
```

`httpx.Headers.__delitem__` raises `KeyError` when the key is absent. A request can legitimately lack a `Connection` header:

- **HTTP/2 forbids it** — per RFC 9113 §8.2.2 the `Connection` header is not used in HTTP/2, so a client created with `http2=True` produces requests without it.
- Custom transports / manually-built requests may omit it.

In those cases signing crashes before the request is ever sent.

## Fix

Filter the header out instead of deleting it, so an absent header is a no-op. This mirrors the sibling `aws/_auth.py` implementation, which already strips `connection` this way — now both AWS auth paths handle it identically:

```python
new_headers = {k: v for k, v in dict(headers).items() if k.lower() != "connection"}
```

## Testing

Added two tests in `tests/lib/test_bedrock.py`:

- `test_get_auth_headers_without_connection_header` — signing succeeds when no `connection` header is present (fails with `KeyError` before this fix).
- `test_get_auth_headers_strips_connection_header` — regression guard that `connection` is still excluded from `SignedHeaders`.

Verified RED (`KeyError: 'connection'` at `_auth.py:60`) → GREEN. Full `test_bedrock.py` + `test_aws_auth.py` + `test_aws.py` pass (113 tests); `./scripts/lint` clean (ruff + pyright + mypy).