### PR TITLE
fix(vertex): resolve project_id from credentials before building request URL

### DIFF
--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -153,6 +153,15 @@ class AnthropicVertex(BaseVertexClient[httpx.Client, Stream[Any]], SyncAPIClient
 
     @override
     def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        if self.project_id is None:
+            # Building the request URL requires a project_id. When it isn't given
+            # explicitly (or via `ANTHROPIC_VERTEX_PROJECT_ID`) it can still be
+            # resolved from Application Default Credentials, but that only happens
+            # in `_ensure_access_token`, which `_prepare_request` calls *after*
+            # this. Resolve credentials now so the ADC project is available before
+            # we build the URL; otherwise this would fail with "could not be
+            # resolved from credentials" without ever consulting them.
+            self._ensure_access_token()
         return _prepare_options(options, project_id=self.project_id, region=self.region)
 
     @override
@@ -317,6 +326,15 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
 
     @override
     async def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        if self.project_id is None:
+            # Building the request URL requires a project_id. When it isn't given
+            # explicitly (or via `ANTHROPIC_VERTEX_PROJECT_ID`) it can still be
+            # resolved from Application Default Credentials, but that only happens
+            # in `_ensure_access_token`, which `_prepare_request` calls *after*
+            # this. Resolve credentials now so the ADC project is available before
+            # we build the URL; otherwise this would fail with "could not be
+            # resolved from credentials" without ever consulting them.
+            await self._ensure_access_token()
         return _prepare_options(options, project_id=self.project_id, region=self.region)
 
     @override

--- a/tests/lib/test_vertex.py
+++ b/tests/lib/test_vertex.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 from typing_extensions import Protocol
 
 import httpx
@@ -15,6 +16,11 @@ base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
 class MockRequestCall(Protocol):
     request: httpx.Request
+
+
+def _fake_load_auth(*, project_id: str | None) -> tuple[Any, str]:
+    """Stand-in for `vertex._client.load_auth` that resolves the project from ADC."""
+    return SimpleNamespace(expired=False, token="fake-token"), project_id or "adc-project"
 
 
 class TestAnthropicVertex:
@@ -47,6 +53,32 @@ class TestAnthropicVertex:
 
         assert calls[0].request.url == request_url
         assert calls[1].request.url == request_url
+
+    @pytest.mark.respx()
+    def test_project_id_resolved_from_credentials(
+        self, respx_mock: MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # With no explicit project_id (and no env var), the project must be resolved
+        # from Application Default Credentials before the request URL is built.
+        # `_prepare_options` (which builds the URL) runs before `_prepare_request`
+        # loads credentials, so it must trigger credential resolution itself.
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.setattr("anthropic.lib.vertex._client.load_auth", _fake_load_auth)
+        client = AnthropicVertex(region="region")
+
+        request_url = "https://region-aiplatform.googleapis.com/v1/projects/adc-project/locations/region/publishers/anthropic/models/claude-3-sonnet@20240229:rawPredict"
+        respx_mock.post(request_url).mock(return_value=httpx.Response(200, json={"foo": "bar"}))
+
+        client.messages.create(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Say hello there!"}],
+            model="claude-3-sonnet@20240229",
+        )
+
+        assert client.project_id == "adc-project"
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 1
+        assert calls[0].request.url == request_url
 
     def test_copy(self) -> None:
         copied = self.client.copy()
@@ -199,6 +231,33 @@ class TestAsyncAnthropicVertex:
 
         assert calls[0].request.url == request_url
         assert calls[1].request.url == request_url
+
+    @pytest.mark.respx()
+    @pytest.mark.asyncio()
+    async def test_project_id_resolved_from_credentials(
+        self, respx_mock: MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # With no explicit project_id (and no env var), the project must be resolved
+        # from Application Default Credentials before the request URL is built.
+        # `_prepare_options` (which builds the URL) runs before `_prepare_request`
+        # loads credentials, so it must trigger credential resolution itself.
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.setattr("anthropic.lib.vertex._client.load_auth", _fake_load_auth)
+        client = AsyncAnthropicVertex(region="region")
+
+        request_url = "https://region-aiplatform.googleapis.com/v1/projects/adc-project/locations/region/publishers/anthropic/models/claude-3-sonnet@20240229:rawPredict"
+        respx_mock.post(request_url).mock(return_value=httpx.Response(200, json={"foo": "bar"}))
+
+        await client.messages.create(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Say hello there!"}],
+            model="claude-3-sonnet@20240229",
+        )
+
+        assert client.project_id == "adc-project"
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 1
+        assert calls[0].request.url == request_url
 
     def test_copy(self) -> None:
         copied = self.client.copy()


### PR DESCRIPTION
## Summary

`AnthropicVertex` / `AsyncAnthropicVertex` fail on every request with

> `RuntimeError: No project_id was given and it could not be resolved from credentials. ...`

whenever the project is meant to be resolved from **Application Default Credentials** rather than passed explicitly or set via `ANTHROPIC_VERTEX_PROJECT_ID`.

## Root cause

The request URL is built in `_prepare_options`, which needs a `project_id`:

```python
def _prepare_options(self, options):
    return _prepare_options(options, project_id=self.project_id, region=self.region)
    # -> raises "could not be resolved from credentials" when project_id is None
```

Resolution from ADC only happens inside `_ensure_access_token` (`load_auth()` returns `(credentials, project_id)` from `google.auth.default()`), which the base client calls from `_prepare_request`. But the base client runs them in this order:

```python
options = self._prepare_options(options)   # builds URL, needs project_id  ← runs first, raises
request = self._build_request(options, ...)
self._prepare_request(request)             # loads credentials, resolves project_id  ← never reached
```

So the ADC project is never consulted before the URL is built — the error message ("could not be resolved from credentials") is emitted without the credentials ever being loaded. This breaks the common deployment pattern of running on GCE/GKE/Cloud Run with ADC and no explicit project.

## Fix

Resolve credentials in `_prepare_options` when `project_id` is unset, so the ADC project is available before the URL is built. `_ensure_access_token` caches the loaded credentials, so the subsequent `_prepare_request` call reuses them without a second network round-trip. Applied symmetrically to the sync and async clients.

When `project_id` genuinely can't be resolved (e.g. an `access_token` was supplied without a project, or ADC has no default project), the same `RuntimeError` is still raised — now *after* credentials were actually consulted.

## Testing

Added `test_project_id_resolved_from_credentials` (sync + async) in `tests/lib/test_vertex.py`: with no explicit `project_id` and no env var, a mocked `load_auth` supplies the project, and the request is asserted to hit `/projects/adc-project/.../rawPredict`.

Verified RED (`RuntimeError` before the fix) → GREEN. Full `tests/lib/test_vertex.py` passes (26 tests); `./scripts/lint` clean (ruff + pyright + mypy).