### PR TITLE
fix(foundry): don't treat an env-derived resource as conflicting with base_url

### DIFF
--- a/src/anthropic/lib/foundry.py
+++ b/src/anthropic/lib/foundry.py
@@ -155,6 +155,11 @@ class AnthropicFoundry(BaseFoundryClient[httpx.Client, Stream[Any]], Anthropic):
             azure_ad_token_provider: A function that returns an Azure Active Directory token, will be invoked on every request.
         """
         api_key = api_key if api_key is not None else os.environ.get("ANTHROPIC_FOUNDRY_API_KEY")
+        # Only an explicitly-passed `resource` conflicts with `base_url`. A `resource`
+        # picked up from the environment is a fallback for building `base_url`, so it
+        # must not clash with a `base_url` that was supplied — e.g. by `copy()`, which
+        # always forwards `base_url` and never `resource`.
+        resource_explicitly_provided = resource is not None
         resource = resource if resource is not None else os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE")
         base_url = base_url if base_url is not None else os.environ.get("ANTHROPIC_FOUNDRY_BASE_URL")
 
@@ -169,7 +174,7 @@ class AnthropicFoundry(BaseFoundryClient[httpx.Client, Stream[Any]], Anthropic):
                     "Must provide one of the `base_url` or `resource` arguments, or the `ANTHROPIC_FOUNDRY_RESOURCE` environment variable"
                 )
             base_url = f"https://{resource}.services.ai.azure.com/anthropic/"
-        elif resource is not None:
+        elif resource_explicitly_provided:
             raise ValueError("base_url and resource are mutually exclusive")
 
         super().__init__(
@@ -380,6 +385,11 @@ class AsyncAnthropicFoundry(BaseFoundryClient[httpx.AsyncClient, AsyncStream[Any
             azure_ad_token_provider: A function that returns an Azure Active Directory token, will be invoked on every request.
         """
         api_key = api_key if api_key is not None else os.environ.get("ANTHROPIC_FOUNDRY_API_KEY")
+        # Only an explicitly-passed `resource` conflicts with `base_url`. A `resource`
+        # picked up from the environment is a fallback for building `base_url`, so it
+        # must not clash with a `base_url` that was supplied — e.g. by `copy()`, which
+        # always forwards `base_url` and never `resource`.
+        resource_explicitly_provided = resource is not None
         resource = resource if resource is not None else os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE")
         base_url = base_url if base_url is not None else os.environ.get("ANTHROPIC_FOUNDRY_BASE_URL")
 
@@ -394,7 +404,7 @@ class AsyncAnthropicFoundry(BaseFoundryClient[httpx.AsyncClient, AsyncStream[Any
                     "Must provide one of the `base_url` or `resource` arguments, or the `ANTHROPIC_FOUNDRY_RESOURCE` environment variable"
                 )
             base_url = f"https://{resource}.services.ai.azure.com/anthropic/"
-        elif resource is not None:
+        elif resource_explicitly_provided:
             raise ValueError("base_url and resource are mutually exclusive")
 
         super().__init__(

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -112,6 +112,37 @@ class TestAnthropicFoundry:
         copied = client.with_options(default_headers={"x-stainless-helper": "child"})
         assert copied.default_headers.get("x-stainless-helper") == "parent, child"
 
+    def test_copy_with_resource_from_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """copy()/with_options() must work when `resource` comes from the environment.
+
+        copy() always forwards `base_url` and never `resource`, so re-reading
+        ANTHROPIC_FOUNDRY_RESOURCE in __init__ used to collide with the forwarded
+        base_url and raise "base_url and resource are mutually exclusive".
+        """
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "env-key")
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_RESOURCE", "env-resource")
+
+        client = AnthropicFoundry()
+        copied = client.copy()
+        assert str(copied.base_url) == str(client.base_url)
+
+        derived = client.with_options(max_retries=7)
+        assert derived.max_retries == 7
+        assert str(derived.base_url) == str(client.base_url)
+
+    def test_explicit_base_url_and_resource_conflict(self) -> None:
+        """Explicitly passing both `base_url` and `resource` is still rejected at runtime.
+
+        The typed overloads already forbid this statically; the runtime guard
+        protects dynamic callers, so the call is deliberately type-ignored here.
+        """
+        with pytest.raises(ValueError, match="base_url and resource are mutually exclusive"):
+            AnthropicFoundry(  # type: ignore[call-overload]  # pyright: ignore[reportCallIssue]
+                api_key="test-key",
+                base_url="https://example.com/",
+                resource="example-resource",
+            )
+
 
 class TestAsyncAnthropicFoundry:
     @pytest.mark.asyncio
@@ -180,6 +211,18 @@ class TestAsyncAnthropicFoundry:
 
         copied = client.with_options(default_headers={"x-stainless-helper": "child"})
         assert copied.default_headers.get("x-stainless-helper") == "parent, child"
+
+    def test_copy_with_resource_from_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """copy() must work when `resource` is inferred from the environment."""
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "env-key")
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_RESOURCE", "env-resource")
+
+        client = AsyncAnthropicFoundry()
+        copied = client.copy()
+        assert str(copied.base_url) == str(client.base_url)
+
+        derived = client.with_options(max_retries=7)
+        assert derived.max_retries == 7
 
 
 class TestFoundryDoesNotLeakAnthropicAPIKey:


### PR DESCRIPTION
## Summary

`AnthropicFoundry.copy()` / `with_options()` (and their async equivalents) raise

> `ValueError: base_url and resource are mutually exclusive`

whenever `ANTHROPIC_FOUNDRY_RESOURCE` is set in the environment.

## Root cause

`copy()` reconstructs the client and **always** forwards `base_url` (derived from the live client) while **never** forwarding `resource`:

```python
return self.__class__(
    ...
    base_url=str(base_url or self.base_url),   # always non-None
    ...                                         # resource is never passed
)
```

`__init__` then falls back to the env var for `resource`:

```python
resource = resource if resource is not None else os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE")
base_url = base_url if base_url is not None else os.environ.get("ANTHROPIC_FOUNDRY_BASE_URL")

if base_url is None:
    ...
elif resource is not None:
    raise ValueError("base_url and resource are mutually exclusive")
```

So when `ANTHROPIC_FOUNDRY_RESOURCE` is set, the forwarded `base_url` and the env-derived `resource` are both non-None and the guard fires — even though the caller never supplied a conflicting configuration. Any deployment that configures Foundry purely through env vars (`ANTHROPIC_FOUNDRY_RESOURCE` + `ANTHROPIC_FOUNDRY_API_KEY`) and then calls the public `copy()` / `with_options()` API hits this.

### Reproduction

```python
os.environ["ANTHROPIC_FOUNDRY_RESOURCE"] = "example-resource"
os.environ["ANTHROPIC_FOUNDRY_API_KEY"] = "sk-foundry-abc"
client = AnthropicFoundry()   # OK
client.copy()                 # ValueError: base_url and resource are mutually exclusive
```

## Fix

An env-derived `resource` is only a fallback for building `base_url`, so it must not conflict with a `base_url` that was actually supplied. Track whether `resource` was passed explicitly and only raise on a genuine caller-supplied conflict; otherwise a supplied `base_url` wins over the resource env var (matching normal explicit-arg-over-env precedence). Applied symmetrically to the sync and async clients.

Explicitly passing both `base_url` and `resource` is still rejected (and remains a static type error via the existing overloads).

## Testing

Added to `tests/lib/test_azure.py`:
- `test_copy_with_resource_from_environment` (sync + async) — `copy()` / `with_options()` succeed with `ANTHROPIC_FOUNDRY_RESOURCE` set (fails before this change).
- `test_explicit_base_url_and_resource_conflict` — the runtime guard still rejects an explicit `base_url` + `resource` pair.

Verified RED → GREEN. Full `tests/lib/test_azure.py` passes (21 tests); `./scripts/lint` clean (ruff + pyright + mypy).