### PR TITLE
fix(tools): surface non-UTF-8 files as ToolError in read/edit

### DIFF
--- a/src/anthropic/lib/tools/agent_toolset.py
+++ b/src/anthropic/lib/tools/agent_toolset.py
@@ -512,6 +512,11 @@ def beta_read_tool(ctx: AgentToolContext) -> BetaAsyncFunctionTool[Any]:
             text = target.read_text()
         except ToolError:
             raise
+        except UnicodeDecodeError as e:
+            # read_text() decodes as UTF-8; a non-UTF-8 file (binary artifact or
+            # e.g. a latin-1 text file) would otherwise escape as a raw
+            # UnicodeDecodeError, bypassing this tool's ToolError contract.
+            raise ToolError(f"read: {file_path}: not valid UTF-8 text") from e
         except OSError as e:
             raise _fs_error("read", file_path, e) from e
         if not view_range:
@@ -570,6 +575,11 @@ def beta_edit_tool(ctx: AgentToolContext) -> BetaAsyncFunctionTool[Any]:
             text = target.read_text()
         except ToolError:
             raise
+        except UnicodeDecodeError as e:
+            # A non-UTF-8 file can't be edited by string replacement — decoding
+            # with errors="replace" would corrupt it on write-back — so surface a
+            # clean ToolError instead of leaking a raw UnicodeDecodeError.
+            raise ToolError(f"edit: {file_path}: not valid UTF-8 text") from e
         except OSError as e:
             raise _fs_error("edit", file_path, e) from e
         count = text.count(old_string)

--- a/tests/lib/tools/test_agent_toolset.py
+++ b/tests/lib/tools/test_agent_toolset.py
@@ -146,6 +146,24 @@ async def test_edit_rejects_directory(tmp_path: Path) -> None:
 
 
 @needs_pydantic_v2
+async def test_read_rejects_non_utf8_file(tmp_path: Path) -> None:
+    # A non-UTF-8 file (here latin-1 "café") must surface as a clean ToolError,
+    # not leak a raw UnicodeDecodeError past the tool's error contract.
+    (tmp_path / "notes.txt").write_bytes(b"caf\xe9 menu\n")
+    env = AgentToolContext(workdir=str(tmp_path))
+    with pytest.raises(ToolError, match="not valid UTF-8"):
+        await beta_read_tool(env).call({"file_path": "notes.txt"})
+
+
+@needs_pydantic_v2
+async def test_edit_rejects_non_utf8_file(tmp_path: Path) -> None:
+    (tmp_path / "notes.txt").write_bytes(b"caf\xe9 menu\n")
+    env = AgentToolContext(workdir=str(tmp_path))
+    with pytest.raises(ToolError, match="not valid UTF-8"):
+        await beta_edit_tool(env).call({"file_path": "notes.txt", "old_string": "menu", "new_string": "x"})
+
+
+@needs_pydantic_v2
 async def test_edit_normal_within_limit(tmp_path: Path) -> None:
     (tmp_path / "f.txt").write_text("hello world")
     env = AgentToolContext(workdir=str(tmp_path))


### PR DESCRIPTION
## Summary

The agent `read` and `edit` tools (`src/anthropic/lib/tools/agent_toolset.py`) decode files with `Path.read_text()` (UTF-8) inside a `try` that only catches `ToolError` and `OSError`:

```python
text = target.read_text()
except ToolError:
    raise
except OSError as e:
    raise _fs_error("read", file_path, e) from e
```

`UnicodeDecodeError` is a subclass of `ValueError`, **not** `OSError`, so it escapes uncaught. The moment the model calls `read`/`edit` on a file that isn't valid UTF-8 — a binary artifact, or an ordinary latin-1 / UTF-16 text file — the exception bypasses the tools' error-normalization: instead of the intended clean `"read: <path>: ..."` `ToolError`, the messages runner logs a full traceback (`log.exception`) and hands the model a raw `UnicodeDecodeError` repr.

The sibling `grep` and `bash` tools in the same module already decode with `errors="replace"`, so non-UTF-8 files are a known, expected input here — `read`/`edit` just don't handle them.

### Reproduction

```python
env = AgentToolContext(workdir=d)
(Path(d) / "notes.txt").write_bytes(b"caf\xe9 menu\n")   # latin-1 text
await beta_read_tool(env).call({"file_path": "notes.txt"})
# -> UnicodeDecodeError leaks out instead of a ToolError
```

## Fix

Catch `UnicodeDecodeError` in both tools and raise a clean `ToolError`. The `edit` path deliberately does **not** fall back to a lossy `errors="replace"` decode, since the replacement round-trip would corrupt the file on write-back.

## Testing

Added `test_read_rejects_non_utf8_file` and `test_edit_rejects_non_utf8_file` in `tests/lib/tools/test_agent_toolset.py` (a latin-1 file must raise `ToolError` matching "not valid UTF-8"). Verified RED (raw `UnicodeDecodeError`) → GREEN. Full `test_agent_toolset.py` passes (42 tests); `./scripts/lint` clean (ruff + pyright + mypy).