### PR TITLE
fix(memory): use split("\n") in insert() to match view()/str_replace()

### DIFF
--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -547,7 +547,7 @@ class BetaLocalFilesystemMemoryTool(BetaAbstractMemoryTool):
             raise ToolError(f"The path {command.path} is not a file.")
 
         content = _read_file_content(full_path, command.path)
-        lines = content.splitlines()
+        lines = content.split("\n")
 
         if command.insert_line < 0 or command.insert_line > len(lines):
             raise ToolError(
@@ -848,7 +848,7 @@ class BetaAsyncLocalFilesystemMemoryTool(BetaAsyncAbstractMemoryTool):
             raise ToolError(f"The path {command.path} is not a file.")
 
         content = await _async_read_file_content(full_path, command.path)
-        lines = content.splitlines()
+        lines = content.split("\n")
 
         if command.insert_line < 0 or command.insert_line > len(lines):
             raise ToolError(

--- a/tests/lib/tools/memory_tools/test_filesystem.py
+++ b/tests/lib/tools/memory_tools/test_filesystem.py
@@ -372,6 +372,32 @@ class TestBetaLocalFilesystemMemoryTool:
                 )
             )
 
+    def test_insert_preserves_non_newline_line_boundaries(
+        self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool
+    ) -> None:
+        # U+2028 and form-feed are line boundaries for str.splitlines() but not for "\n".
+        # view()/str_replace() split on "\n", so insert() must too, otherwise these
+        # characters are silently rewritten to "\n" and the text lands at the wrong line.
+        sync_local_filesystem_tool.create(
+            BetaMemoryTool20250818CreateCommand(
+                command="create", file_text="alpha\u2028beta\x0cgamma", path="/memories/insert_unicode_test.txt"
+            )
+        )
+
+        view_result = sync_local_filesystem_tool.view(
+            BetaMemoryTool20250818ViewCommand(command="view", path="/memories/insert_unicode_test.txt")
+        )
+        assert len(view_result.split(":\n", 1)[1].split("\n")) == 1
+
+        sync_local_filesystem_tool.insert(
+            BetaMemoryTool20250818InsertCommand(
+                command="insert", path="/memories/insert_unicode_test.txt", insert_line=1, insert_text="INSERTED"
+            )
+        )
+
+        dir_snapshot = get_directory_snapshot(str(sync_local_filesystem_tool.base_path))
+        assert dir_snapshot == {"memories/insert_unicode_test.txt": "alpha\u2028beta\x0cgamma\nINSERTED\n"}
+
     def test_delete(self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool) -> None:
         sync_local_filesystem_tool.create(
             BetaMemoryTool20250818CreateCommand(
@@ -861,6 +887,32 @@ class TestBetaAsyncLocalFilesystemMemoryTool:
                     command="insert", path="/memories/insert_test.txt", insert_line=10, insert_text="text"
                 )
             )
+
+    async def test_insert_preserves_non_newline_line_boundaries(
+        self, async_local_filesystem_tool: BetaAsyncLocalFilesystemMemoryTool
+    ) -> None:
+        # U+2028 and form-feed are line boundaries for str.splitlines() but not for "\n".
+        # view()/str_replace() split on "\n", so insert() must too, otherwise these
+        # characters are silently rewritten to "\n" and the text lands at the wrong line.
+        await async_local_filesystem_tool.create(
+            BetaMemoryTool20250818CreateCommand(
+                command="create", file_text="alpha\u2028beta\x0cgamma", path="/memories/insert_unicode_test.txt"
+            )
+        )
+
+        view_result = await async_local_filesystem_tool.view(
+            BetaMemoryTool20250818ViewCommand(command="view", path="/memories/insert_unicode_test.txt")
+        )
+        assert len(view_result.split(":\n", 1)[1].split("\n")) == 1
+
+        await async_local_filesystem_tool.insert(
+            BetaMemoryTool20250818InsertCommand(
+                command="insert", path="/memories/insert_unicode_test.txt", insert_line=1, insert_text="INSERTED"
+            )
+        )
+
+        dir_snapshot = get_directory_snapshot(str(async_local_filesystem_tool.base_path))
+        assert dir_snapshot == {"memories/insert_unicode_test.txt": "alpha\u2028beta\x0cgamma\nINSERTED\n"}
 
     async def test_delete(self, async_local_filesystem_tool: BetaAsyncLocalFilesystemMemoryTool) -> None:
         await async_local_filesystem_tool.create(


### PR DESCRIPTION
## Who hits this

Anyone using the built-in filesystem memory tool (`BetaLocalFilesystemMemoryTool` / `BetaAsyncLocalFilesystemMemoryTool`) whose memory files contain any of the characters `str.splitlines()` treats as line boundaries but `"\n"` does not: carriage return, vertical tab, form feed (`\x0c`), file/group/record separators (`\x1c`-`\x1e`), NEL (`\x85`), U+2028, or U+2029. When the model issues an `insert` command against such a file, the insert lands at the wrong line and those characters are silently rewritten to `\n`.

## Root cause

Every memory command reads and splits file content the same way except `insert`. `view()` (line 451) and `str_replace()` (line 526) split on `"\n"`, but both the sync and async `insert()` used `content.splitlines()`. `splitlines()` breaks on ~8 extra Unicode/control boundaries in addition to `\n`. As a result `insert()`:

- counted and located lines differently from what `view()` reports to the model, so an `insert_line` chosen from the numbers `view()` showed landed at the wrong offset (text spliced into the middle of what the model saw as a single line), and
- rejoined the lines with `"\n"`, discarding the boundary characters that were part of the file's content.

## Fix

Change `content.splitlines()` to `content.split("\n")` in both `insert()` methods, making line indexing consistent with `view()` and `str_replace()` and preserving the file's characters. No behavior change for ordinary `\n`-delimited files.

## Before / after

```python
from anthropic.lib.tools._beta_builtin_memory_tool import BetaLocalFilesystemMemoryTool
from anthropic.types.beta import (
    BetaMemoryTool20250818CreateCommand,
    BetaMemoryTool20250818InsertCommand,
)

tool = BetaLocalFilesystemMemoryTool(base_path="/tmp/mem-demo")

# A file whose content contains a form feed (\x0c). view() reports it as ONE line.
tool.create(BetaMemoryTool20250818CreateCommand(
    command="create", file_text="alpha beta\x0cgamma", path="/memories/f.txt"
))

# Insert after that single line.
tool.insert(BetaMemoryTool20250818InsertCommand(
    command="insert", path="/memories/f.txt", insert_line=1, insert_text="INSERTED"
))

print(repr(open("/tmp/mem-demo/memories/f.txt").read()))
# Before: 'alpha beta\nINSERTED\ngamma\n'   -> \x0c lost, INSERTED spliced into the middle
# After:  'alpha beta\x0cgamma\nINSERTED\n' -> \x0c preserved, INSERTED appended after the line
```

## Tests

Adds one regression test (sync and async) in `tests/lib/tools/memory_tools/test_filesystem.py` that creates a file containing U+2028 and a form feed, asserts `view()` numbers it as a single line, runs `insert(insert_line=1, ...)`, and asserts the boundary characters are preserved and the text is appended after the whole line. Fails on the current code, passes with the fix. Full memory-tool suite: 65 passed. `ruff check` / `ruff format` clean.