### PR TITLE
feat(environments): add defer_ack to work poller to fix dispatch-mode strand (#1746)

### DIFF
--- a/src/anthropic/lib/environments/_poller.py
+++ b/src/anthropic/lib/environments/_poller.py
@@ -59,15 +59,16 @@ def iter_work(
     reclaim_older_than_ms: int | None = None,
     drain: bool = False,
     auto_stop: bool = True,
+    defer_ack: bool = False,
     extra_headers: Headers | None = None,
 ) -> Iterator[BetaSelfHostedWork]:
     """Iterate work items claimed from a self-hosted environment.
 
-    Each yielded :class:`BetaSelfHostedWork` has already been ack'd. The ``work``
-    resource must be bound to a client authenticated for the environment — the
-    poller itself does not handle credentials. Use
-    ``client.beta.environments.work.poller(...)`` for the user-facing entry
-    point that constructs a scoped sub-client for you.
+    Each yielded :class:`BetaSelfHostedWork` has already been ack'd, unless
+    ``defer_ack=True`` (see below). The ``work`` resource must be bound to a
+    client authenticated for the environment — the poller itself does not handle
+    credentials. Use ``client.beta.environments.work.poller(...)`` for the
+    user-facing entry point that constructs a scoped sub-client for you.
 
     Two consumption shapes are supported:
 
@@ -92,6 +93,17 @@ def iter_work(
         loop body completes. Set False when the work item is handed off to
         another process that owns the stop call — otherwise the lease is
         terminated out from under it.
+      defer_ack: When True, yield the item still *unacknowledged* (``queued``)
+        instead of ack'ing it before the yield, leaving the consuming/handoff
+        owner to call ``work.ack`` when it commits to processing. This closes
+        the drain-and-dispatch strand: with the default ack-before-yield, an
+        item whose handoff process dies before its first heartbeat is left in
+        ``starting`` with a null heartbeat, and ``poll(reclaim_older_than_ms=…)``
+        only reclaims *unacknowledged* work, so the item never resurfaces.
+        Deferring the ack keeps a failed handoff recoverable via
+        ``reclaim_older_than_ms`` / lease TTL. Requires ``auto_stop=False``
+        (the consumer owns the full lifecycle — both ack and stop); pairing it
+        with ``auto_stop=True`` raises ``ValueError``.
       reclaim_older_than_ms: Forwarded to ``work.poll``. Reclaim un-ack'd work
         older than this many ms. Useful in drain mode so a dead runner's
         work re-surfaces on the next webhook delivery.
@@ -104,8 +116,21 @@ def iter_work(
         same-named default for that one request, so use it for caller
         passthrough (e.g. trace ids), not to set auth.
     """
+    if defer_ack and auto_stop:
+        raise ValueError(
+            "defer_ack=True requires auto_stop=False: it is for the "
+            "drain-and-dispatch pattern where the consumer owns the work-item "
+            "lifecycle (ack and stop). With auto_stop=True the poller owns that "
+            "lifecycle and must ack the item it will later stop."
+        )
     worker_id = worker_id or _default_worker_id()
-    log.info("poller starting environment_id=%s drain=%s auto_stop=%s", environment_id, drain, auto_stop)
+    log.info(
+        "poller starting environment_id=%s drain=%s auto_stop=%s defer_ack=%s",
+        environment_id,
+        drain,
+        auto_stop,
+        defer_ack,
+    )
     # Poll and ack each get their own backoff counter so a run of ack failures
     # can't inflate the next poll failure's backoff (and vice versa) — each is
     # reset on its own success, and the ``continue`` paths leave them untouched.
@@ -137,6 +162,15 @@ def iter_work(
             time.sleep(_jitter(1.0, 3.0))
             continue
         log.info("claimed work work_id=%s work_type=%s", item.id, getattr(item.data, "type", None))
+        if defer_ack:
+            # Yield the item still unacknowledged ('queued'); the consumer/handoff
+            # owner performs the ack (and stop) when it commits to processing.
+            # A handoff that dies before acking leaves the item recoverable via
+            # reclaim_older_than_ms / lease TTL instead of stranded in 'starting'.
+            # Guaranteed auto_stop=False here (validated above), so this mirrors
+            # the auto_stop-False path below minus the pre-yield ack.
+            yield item
+            continue
         try:
             work.ack(
                 item.id,
@@ -195,13 +229,27 @@ async def aiter_work(
     reclaim_older_than_ms: int | None = None,
     drain: bool = False,
     auto_stop: bool = True,
+    defer_ack: bool = False,
     extra_headers: Headers | None = None,
 ) -> AsyncIterator[BetaSelfHostedWork]:
     """Async version of :func:`iter_work`. See its docstring for semantics,
-    including how ``extra_headers`` is passed through per request.
+    including ``defer_ack`` and how ``extra_headers`` is passed through per request.
     """
+    if defer_ack and auto_stop:
+        raise ValueError(
+            "defer_ack=True requires auto_stop=False: it is for the "
+            "drain-and-dispatch pattern where the consumer owns the work-item "
+            "lifecycle (ack and stop). With auto_stop=True the poller owns that "
+            "lifecycle and must ack the item it will later stop."
+        )
     worker_id = worker_id or _default_worker_id()
-    log.info("poller starting environment_id=%s drain=%s auto_stop=%s", environment_id, drain, auto_stop)
+    log.info(
+        "poller starting environment_id=%s drain=%s auto_stop=%s defer_ack=%s",
+        environment_id,
+        drain,
+        auto_stop,
+        defer_ack,
+    )
     poll_attempt = 0
     ack_attempt = 0
     while True:
@@ -230,6 +278,15 @@ async def aiter_work(
             await anyio.sleep(_jitter(1.0, 3.0))
             continue
         log.info("claimed work work_id=%s work_type=%s", item.id, getattr(item.data, "type", None))
+        if defer_ack:
+            # Yield the item still unacknowledged ('queued'); the consumer/handoff
+            # owner performs the ack (and stop) when it commits to processing.
+            # A handoff that dies before acking leaves the item recoverable via
+            # reclaim_older_than_ms / lease TTL instead of stranded in 'starting'.
+            # Guaranteed auto_stop=False here (validated above), so this mirrors
+            # the auto_stop-False path below minus the pre-yield ack.
+            yield item
+            continue
         try:
             await work.ack(
                 item.id,

--- a/src/anthropic/resources/beta/environments/work.py
+++ b/src/anthropic/resources/beta/environments/work.py
@@ -1120,11 +1120,12 @@ class AsyncWork(AsyncAPIResource):
         reclaim_older_than_ms: int | None = None,
         drain: bool = False,
         auto_stop: bool = True,
+        defer_ack: bool = False,
         extra_headers: Headers | None = None,
     ) -> AsyncIterator[BetaSelfHostedWork]:
         """Async-iterate work items claimed from a self-hosted environment.
 
-        Each yielded item has been ack'd. The environment key authenticates the
+        Each yielded item has been ack'd (unless ``defer_ack=True``). The environment key authenticates the
         poll, ack, and stop calls via a scoped sub-client (built once per
         call). Async only — available on :class:`~anthropic.AsyncAnthropic`
         (the sync client does not expose ``poller``).
@@ -1152,6 +1153,10 @@ class AsyncWork(AsyncAPIResource):
           auto_stop: When True (default), call ``stop`` after the consumer's
             loop body completes. Set False when handing items off to another
             process that owns the stop call.
+          defer_ack: When True, yield the item still unacknowledged so the
+            handoff owner performs the ack (and stop), keeping a failed handoff
+            recoverable via ``reclaim_older_than_ms`` / lease TTL instead of
+            stranded in ``starting``. Requires ``auto_stop=False``.
           extra_headers: Optional headers passed through per request on the
             poll / ack / stop calls. They are threaded into each call's
             ``extra_headers=`` and never assigned onto the client, so client
@@ -1186,6 +1191,7 @@ class AsyncWork(AsyncAPIResource):
             reclaim_older_than_ms=reclaim_older_than_ms,
             drain=drain,
             auto_stop=auto_stop,
+            defer_ack=defer_ack,
             extra_headers=extra_headers,
         )
 

--- a/tests/lib/environments/test_poller_method.py
+++ b/tests/lib/environments/test_poller_method.py
@@ -273,6 +273,42 @@ def test_iter_work_auto_stop_false_does_not_stop_on_body_raise() -> None:
     assert fake.stop_calls == []
 
 
+def test_iter_work_defer_ack_yields_unacked() -> None:
+    """With ``defer_ack=True`` the poller hands items off still unacknowledged so
+    the downstream owner performs the ack; the poller itself never acks."""
+    a, b = _StubWork(id="work_a"), _StubWork(id="work_b")
+    fake = FakeWork(poll_script=[a, b, None])
+    it = iter_work(cast(Any, fake), environment_id="env_1", drain=True, auto_stop=False, defer_ack=True)
+
+    assert [item.id for item in it] == ["work_a", "work_b"]
+    assert fake.ack_calls == [], "defer_ack must not ack before yielding"
+    assert fake.stop_calls == []
+
+
+def test_iter_work_defer_ack_does_not_ack_on_body_raise() -> None:
+    """The strand this fixes: a handoff that fails after the yield must leave the
+    item unacknowledged so ``reclaim_older_than_ms`` / lease TTL can recover it,
+    rather than ack'd-and-abandoned (stuck in ``starting`` with no heartbeat)."""
+    work = _StubWork(id="work_boom")
+    fake = FakeWork(poll_script=[work])
+    it = iter_work(cast(Any, fake), environment_id="env_1", auto_stop=False, defer_ack=True)
+
+    next(it)
+    with pytest.raises(RuntimeError):
+        cast(Any, it).throw(RuntimeError("handoff failed"))
+    assert fake.ack_calls == [], "a failed handoff must leave the item unacknowledged (reclaimable)"
+    assert fake.stop_calls == []
+
+
+def test_iter_work_defer_ack_requires_auto_stop_false() -> None:
+    """``defer_ack`` only makes sense when the consumer owns the lifecycle;
+    pairing it with the lifecycle-owning ``auto_stop=True`` is a usage error."""
+    fake = FakeWork(poll_script=[_StubWork()])
+    with pytest.raises(ValueError, match="defer_ack=True requires auto_stop=False"):
+        next(iter_work(cast(Any, fake), environment_id="env_1", defer_ack=True))
+    assert fake.poll_calls == [], "must reject before polling"
+
+
 def test_iter_work_forwards_reclaim_older_than_ms() -> None:
     fake = FakeWork(poll_script=[None])
     it = iter_work(cast(Any, fake), environment_id="env_1", drain=True, reclaim_older_than_ms=2000)
@@ -319,6 +355,39 @@ async def test_aiter_work_calls_stop_when_body_raises() -> None:
     with pytest.raises(RuntimeError):
         await cast(Any, ait).athrow(RuntimeError("body failed"))
     assert fake.stop_calls == [("work_boom", fake.stop_calls[0][1])]
+
+
+@pytest.mark.asyncio()
+async def test_aiter_work_defer_ack_yields_unacked() -> None:
+    a, b = _StubWork(id="work_a"), _StubWork(id="work_b")
+    fake = FakeAsyncWork(poll_script=[a, b, None])
+    ait = aiter_work(cast(Any, fake), environment_id="env_1", drain=True, auto_stop=False, defer_ack=True)
+
+    assert [item.id async for item in ait] == ["work_a", "work_b"]
+    assert fake.ack_calls == [], "defer_ack must not ack before yielding"
+    assert fake.stop_calls == []
+
+
+@pytest.mark.asyncio()
+async def test_aiter_work_defer_ack_does_not_ack_on_body_raise() -> None:
+    work = _StubWork(id="work_boom")
+    fake = FakeAsyncWork(poll_script=[work])
+    ait = aiter_work(cast(Any, fake), environment_id="env_1", auto_stop=False, defer_ack=True)
+
+    await ait.__anext__()
+    with pytest.raises(RuntimeError):
+        await cast(Any, ait).athrow(RuntimeError("handoff failed"))
+    assert fake.ack_calls == [], "a failed handoff must leave the item unacknowledged (reclaimable)"
+    assert fake.stop_calls == []
+
+
+@pytest.mark.asyncio()
+async def test_aiter_work_defer_ack_requires_auto_stop_false() -> None:
+    fake = FakeAsyncWork(poll_script=[_StubWork()])
+    ait = aiter_work(cast(Any, fake), environment_id="env_1", defer_ack=True)
+    with pytest.raises(ValueError, match="defer_ack=True requires auto_stop=False"):
+        await ait.__anext__()
+    assert fake.poll_calls == [], "must reject before polling"
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## What was broken

In the poller's **drain-and-dispatch** shape (`auto_stop=False` — the webhook/handoff pattern the docstring describes), `iter_work` / `aiter_work` `ack` a claimed item (transitioning it `queued → starting`) *before* yielding it to the process that will actually run it. If that handoff process dies before its first heartbeat, the item is left in `starting` with a null heartbeat — and `poll(reclaim_older_than_ms=…)` only reclaims **unacknowledged** work, so the item is reachable by neither `reclaim` nor lease-TTL requeue. It's permanently stranded. (This is issue #1746, reported with 29 real items stuck in `starting`.)

## Why not a nack

The issue proposed either a deferred-ack mode *or* a nack/fail API. The `Work` resource exposes only `poll` / `ack` / `stop` / `heartbeat` — there is no `nack`/`fail` endpoint — so a true nack can't be implemented client-side. That leaves deferred ack.

## The fix

Adds an opt-in `defer_ack: bool = False` to `iter_work` / `aiter_work` and the public `poller()` entry point:

- **Default (`False`)** — exact current behavior (ack before yield). Fully backward-compatible; no existing caller changes.
- **`True`** — the poller yields the item still **unacknowledged** (`queued`); the consumer / handoff owner performs the `ack` (and `stop`) when it commits to processing. A handoff that dies before acking now leaves the item recoverable via `reclaim_older_than_ms` / lease TTL instead of stranded.
- **Guard** — `defer_ack=True` requires `auto_stop=False` (the dispatch pattern where the consumer owns the lifecycle); pairing it with `auto_stop=True` raises `ValueError`, since the poller can't `stop` an item whose `ack` it deferred. Validated before the first poll, sync and async.

## How it's tested

Uses the existing `FakeWork` / `FakeAsyncWork` harness in `tests/lib/environments/test_poller_method.py` — no live API. New tests (sync + async):
- `..._defer_ack_yields_unacked` — items are handed off with **no** `ack`/`stop` call by the poller.
- `..._defer_ack_does_not_ack_on_body_raise` — the strand path: a handoff that fails after the yield leaves the item unacknowledged (i.e. reclaimable), asserting `ack_calls == []`.
- `..._defer_ack_requires_auto_stop_false` — the `ValueError` guard fires before any poll.

Full local run for this PR: `uv run pytest tests/lib/` (752 passed; the 2 failures in `tests/lib/test_credentials.py` reproduce identically on clean `main` and are unrelated to this change), `ruff check` / `ruff format --check` clean, `mypy .` clean (1052 files), `pyright` 0/0/0.

## Scope / boundary note

The behavior change is entirely in the hand-written `src/anthropic/lib/environments/_poller.py`. The 8-line change to `poller()` in `resources/beta/environments/work.py` is a passthrough of the new kwarg; `poller()`/`worker()` are maintained custom methods there (they import from `lib/` and have this dedicated test file), but if the codegen config needs a matching entry for the new parameter, happy to adjust.

## What this deliberately does not change

- No change to the default ack-before-yield behavior, the retry/backoff policy, or the `auto_stop=True` runner path.
- Does not add a nack API (no server endpoint for it).

Fixes #1746