### PR TITLE
fix(agent_toolset): reject non-regular files in the `write` tool instead of hanging on a FIFO

### DIFF
--- a/src/anthropic/lib/tools/agent_toolset.py
+++ b/src/anthropic/lib/tools/agent_toolset.py
@@ -625,6 +625,15 @@ def beta_write_tool(ctx: AgentToolContext) -> BetaAsyncFunctionTool[Any]:
         except ValueError as e:
             raise ToolError(f"write: {e}") from e
         try:
+            # stat() before any open(): reject FIFOs/devices/directories without
+            # opening them (open() on an unconnected FIFO blocks). A missing
+            # target is a normal new-file write, so it is allowed here.
+            try:
+                st: Optional[os.stat_result] = target.stat()
+            except FileNotFoundError:
+                st = None
+            if st is not None and not S_ISREG(st.st_mode):
+                raise ToolError(f"write: {file_path}: not a regular file")
             target.parent.mkdir(parents=True, exist_ok=True)
             target.write_text(content, encoding="utf-8")
         except OSError as e:

--- a/tests/lib/tools/test_agent_toolset.py
+++ b/tests/lib/tools/test_agent_toolset.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 import base64
+import threading
 from typing import Any, cast
 from pathlib import Path
 from typing_extensions import Required, get_args, get_origin, get_type_hints
@@ -375,6 +376,43 @@ def test_text_io_is_utf8_under_ascii_locale(tmp_path: Path) -> None:
     assert proc.returncode == 0, proc.stderr.decode("utf-8", errors="replace")
     assert proc.stdout.decode("utf-8") == "café — naïve\n"
     assert (tmp_path / "notes.txt").read_text(encoding="utf-8") == "thé — naïve\n"
+
+
+@needs_pydantic_v2
+@pytest.mark.skipif(sys.platform == "win32", reason="FIFOs are POSIX-only")
+async def test_write_rejects_fifo_instead_of_blocking(tmp_path: Path) -> None:
+    """`write` must reject a FIFO the same way `read`/`edit` do.
+
+    Unlike a plain directory (which fails fast with ``IsADirectoryError``),
+    opening an unconnected FIFO for writing *blocks the calling thread
+    forever* waiting for a reader. `read`/`edit` avoid this with an
+    ``S_ISREG`` stat() guard before ever calling ``open()``; `write` had no
+    such guard, so pointing it at a FIFO hangs instead of raising. Run the
+    call off-thread with a bounded join so an unfixed SDK fails this test
+    quickly instead of hanging the whole run.
+    """
+    fifo_path = tmp_path / "pipe"
+    os.mkfifo(fifo_path)
+    env = AgentToolContext(workdir=str(tmp_path))
+
+    box: dict[str, object] = {}
+
+    def runner() -> None:
+        try:
+            anyio.run(beta_write_tool(env).call, {"file_path": "pipe", "content": "hello"})
+        except BaseException as e:  # noqa: BLE001 - captured across the thread boundary
+            box["exc"] = e
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join(timeout=5.0)
+
+    if thread.is_alive():
+        pytest.fail("write() hung opening a FIFO instead of rejecting it as a non-regular file")
+
+    exc = box.get("exc")
+    assert isinstance(exc, ToolError), f"expected ToolError, got {exc!r}"
+    assert "not a regular file" in str(exc)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What

`beta_write_tool` in `src/anthropic/lib/tools/agent_toolset.py` has no guard against the target path being a
FIFO (or other non-regular file). `beta_read_tool` and `beta_edit_tool` both `stat()` the target and reject
anything that isn't `S_ISREG` before ever calling `open()`, specifically because opening an unconnected FIFO for
I/O blocks the calling thread indefinitely. `beta_edit_tool`'s guard is a direct copy of `beta_read_tool`'s
("Same guard as the read tool, edit reads the whole file too."), but `beta_write_tool` never received it.

Since `write()`'s file I/O runs directly in the coroutine (not offloaded to a worker thread), calling `write`
on a path that resolves to a FIFO hangs the call forever and freezes the whole async event loop with it, not
just the one tool invocation. A directory at the same path does *not* trigger this: `write_text()` on a
directory raises `IsADirectoryError` immediately, which the existing `except OSError` already converts to a
clean `ToolError`. A FIFO is the case that actually blocks instead of raising, and it's reachable any time an
agent using this reference toolset is asked to write to a path that happens to be a named pipe, for example
one it created itself moments earlier with the `bash` tool (`mkfifo`), or one already present in a shared /
self-hosted environment.

### Fix

`stat()` the target before opening it, same as `read`/`edit`, and reject non-regular files with a `ToolError`.
Unlike `read`/`edit`, `write`'s target commonly does not exist yet (a normal new-file write), so a missing file
is explicitly not an error here: only an *existing* non-regular file is rejected.

```python
try:
    st: os.stat_result | None = target.stat()
except FileNotFoundError:
    st = None
if st is not None and not S_ISREG(st.st_mode):
    raise ToolError(f"write: {file_path}: not a regular file")
```

12 lines changed in `agent_toolset.py`, all inside `beta_write_tool`. No signature or return-type changes.

### Test

Added `test_write_rejects_fifo_instead_of_blocking` to `tests/lib/tools/test_agent_toolset.py`, mirroring the
existing `test_read_rejects_directory` / `test_edit_rejects_directory` pattern but using a real `os.mkfifo` FIFO
(POSIX-only, skipped on Windows) since a directory doesn't reproduce this specific failure mode (it already
fails fast via `IsADirectoryError`, only a FIFO blocks). The call runs on a background thread with a bounded
`join()` so an unfixed SDK fails the test in ~5s instead of hanging the run:

- Before this fix: the test fails with `"write() hung opening a FIFO instead of rejecting it as a non-regular
  file"` after a 5s bounded wait.
- After this fix: the test passes in <0.1s, asserting a `ToolError` containing `"not a regular file"`.

Full mapped test file (`tests/lib/tools/test_agent_toolset.py`): 41 passed with the fix (the new test fails on
the unmodified baseline as above; the other 40 pass on both). `ruff check` and `ruff format --check` are clean
on both changed files.

### Scope

This only touches `beta_write_tool`. It does not change `beta_read_tool` or `beta_edit_tool`, and it does not
move the file I/O off the event loop thread (a separate, larger change if the maintainers want it); this PR is
scoped to closing the specific gap where `write` is the only one of the three file-mutating tools without the
non-regular-file guard the reference toolset's own docstring says the file tools provide ("the file tools ...
are safe to use without a sandbox").

Happy to extend the test to also cover a character device (e.g. skip on CI sandboxes without `/dev/null`
writable) if useful, but the FIFO case alone is a deterministic, cross-CI-safe repro of the hang.
