### PR TITLE
fix: handle bare unparameterized list in construct_type

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -668,6 +668,9 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_list(value):
             return value
 
+        if not args:
+            return value
+
         inner_type = args[0]  # List[inner_type]
         return [construct_type(value=entry, type_=inner_type) for entry in value]
 


### PR DESCRIPTION
Fixes #1626

When `construct_type` is called with a bare `list` (no type parameter, e.g. `construct_type(value=[...], type_=list)`), `get_args(list)` returns an empty tuple, causing `IndexError` at `args[0]`.

This PR adds a guard to return the value unchanged when there are no type arguments.