### PR TITLE
fix: support bare dict in construct_type

### DIFF
--- a/src/anthropic/_models.py
+++ b/src/anthropic/_models.py
@@ -567,7 +567,8 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        dict_args = get_args(type_)
+        items_type = dict_args[1] if len(dict_args) == 2 else object
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -776,6 +776,10 @@ def test_discriminated_unions_with_aliases_invalid_data() -> None:
         assert m.data == 100  # type: ignore[comparison-overlap]
 
 
+def test_construct_type_with_bare_dict() -> None:
+    assert construct_type(value={"foo": "bar"}, type_=dict) == {"foo": "bar"}
+
+
 def test_discriminated_unions_overlapping_discriminators_invalid_data() -> None:
     class A(BaseModel):
         type: Literal["a"]


### PR DESCRIPTION
Fixes #1619

Guard the `origin == dict` path in `construct_type()` so bare `dict` annotations fall back to `object` items instead of unpacking an empty `get_args()` tuple.

Local verification:
- `PYTHONPATH=/tmp/anthropic-sdk-python/src python3.9 -m pytest tests/test_models.py -k bare_dict -q -o addopts=`