### PR TITLE
fix(examples): replace dated model alias in tools example

### DIFF
--- a/examples/tools.py
+++ b/examples/tools.py
@@ -21,7 +21,7 @@ tools: list[ToolParam] = [
 ]
 
 message = client.messages.create(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
     max_tokens=1024,
     messages=[user_message],
     tools=tools,
@@ -32,7 +32,7 @@ assert message.stop_reason == "tool_use"
 
 tool = next(c for c in message.content if c.type == "tool_use")
 response = client.messages.create(
-    model="claude-sonnet-4-5-20250929",
+    model="claude-sonnet-4-5",
     max_tokens=1024,
     messages=[
         user_message,


### PR DESCRIPTION
Fixes #1596

Replace the dated model ID in `examples/tools.py` with the stable `claude-sonnet-4-5` alias so the example does not drift into a 404 as snapshots are retired.

Local verification:
- `python3 -m compileall examples/tools.py`