### PR TITLE
fix(retry): cap backoff exponent to avoid OverflowError on large attempts

### DIFF
--- a/src/anthropic/lib/_retry.py
+++ b/src/anthropic/lib/_retry.py
@@ -31,7 +31,9 @@ _RETRYABLE_4XX = frozenset({408, 409, 429})
 
 def backoff(attempt: int, *, cap: float, base: float = 2.0) -> float:
     """Exponential backoff for ``attempt`` (1-indexed), capped at ``cap``."""
-    return min(cap, base**attempt)
+    # Cap the exponent (as ``_base_client`` does) so a very large ``attempt`` cannot
+    # overflow ``base ** attempt`` and raise before ``min`` clamps the result to ``cap``.
+    return min(cap, base ** min(attempt, 1000))
 
 
 def jitter(low: float, high: float) -> float:

--- a/tests/lib/environments/test_poller.py
+++ b/tests/lib/environments/test_poller.py
@@ -11,6 +11,10 @@ from anthropic.lib.environments._poller import _jitter, _backoff
         ("first failure backs off two seconds", 1, 2.0),
         ("second failure doubles to four seconds", 2, 4.0),
         ("very large attempt is capped at sixty seconds", 100, 60.0),
+        # ``2 ** attempt`` overflows a C double at attempt >= 1024; the exponent cap
+        # must keep returning ``cap`` instead of raising OverflowError.
+        ("attempt at the double-overflow boundary stays capped", 1024, 60.0),
+        ("huge attempt count stays capped", 5000, 60.0),
     ],
 )
 def test_backoff(description: str, attempt: int, want: float) -> None:


### PR DESCRIPTION
Fixes #1760.

### Problem

`anthropic.lib._retry.backoff(attempt, *, cap, base=2.0)` returns `min(cap, base ** attempt)`. Because `base` is the float `2.0`, `2.0 ** attempt` overflows a C double at `attempt >= 1024` and raises `OverflowError` **before** `min()` can clamp it, so the documented cap is never returned:

```python
from anthropic.lib._retry import backoff
backoff(1023, cap=60.0)   # 60.0
backoff(1024, cap=60.0)   # OverflowError: (34, 'Result too large')
```

The only caller is the environments poller (`lib/environments/_poller.py`, `_backoff = backoff(attempt, cap=60.0)`). Its counter resets to 0 on success, so this needs ~1024 consecutive transient failures — but at that point the run-forever poll loop dies with an uncaught `OverflowError` instead of continuing to retry at the cap.

### Fix

Cap the exponent at 1000, mirroring the guard the core client already applies in `_base_client.py`:

```python
# Also cap retry count to 1000 to avoid any potential overflows with `pow`
nb_retries = min(max_retries - remaining_retries, 1000)
```

`backoff()` just missed the same guard. The returned value is unchanged for every attempt — once `base ** attempt` reaches `cap` the result is always `cap`, which happens far below `attempt = 1000` — so this only removes the crash.

### Tests

Extended the existing `test_backoff` (`tests/lib/environments/test_poller.py`) with the overflow-boundary cases (`attempt=1024` and `attempt=5000`, both expecting the `60.0` cap). They raise `OverflowError` before this change and pass after; the existing cases are unchanged.

Verified locally with `ruff check`/`ruff format` clean.
