### PR TITLE
fix: avoid subprocess in platform detection

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -2436,15 +2436,15 @@ Platform = Union[
 def get_platform() -> Platform:
     try:
         system = platform.system().lower()
-        platform_name = platform.platform().lower()
+        release = platform.release().lower()
+        machine = platform.machine().lower()
+        platform_name = "-".join(part for part in (system, release, machine) if part)
     except Exception:
         return "Unknown"
 
-    if "iphone" in platform_name or "ipad" in platform_name:
+    if "iphone" in machine or "ipad" in machine:
         # Tested using Python3IDE on an iPhone 11 and Pythonista on an iPad 7
-        # system is Darwin and platform_name is a string like:
-        # - Darwin-21.6.0-iPhone12,1-64bit
-        # - Darwin-21.6.0-iPad7,11-64bit
+        # system is Darwin and machine is a string like iPhone12,1 or iPad7,11
         return "iOS"
 
     if system == "darwin":
@@ -2453,9 +2453,9 @@ def get_platform() -> Platform:
     if system == "windows":
         return "Windows"
 
-    if "android" in platform_name:
+    if hasattr(sys, "getandroidapilevel") or "android" in release:
         # Tested using Pydroid 3
-        # system is Linux and platform_name is a string like 'Linux-5.10.81-android12-9-00001-geba40aecb3b7-ab8534902-aarch64-with-libc'
+        # system is Linux and release contains 'android'
         return "Android"
 
     if system == "linux":

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2300,6 +2300,26 @@ class TestAsyncAnthropic:
         platform = await asyncify(get_platform)()
         assert isinstance(platform, (str, OtherPlatform))
 
+    @pytest.mark.parametrize(
+        ("system", "release", "machine", "expected"),
+        [
+            ("Darwin", "25.0.0", "arm64", "MacOS"),
+            ("Darwin", "25.0.0", "iPhone12,1", "iOS"),
+            ("Linux", "5.10.81-android12", "aarch64", "Android"),
+        ],
+    )
+    async def test_get_platform_does_not_call_platform_platform(
+        self, monkeypatch: pytest.MonkeyPatch, system: str, release: str, machine: str, expected: str
+    ) -> None:
+        monkeypatch.setattr("anthropic._base_client.platform.system", lambda: system)
+        monkeypatch.setattr("anthropic._base_client.platform.release", lambda: release)
+        monkeypatch.setattr("anthropic._base_client.platform.machine", lambda: machine)
+        platform_mock = mock.Mock(side_effect=AssertionError("platform.platform() must not be called"))
+        monkeypatch.setattr("anthropic._base_client.platform.platform", platform_mock)
+
+        assert await asyncify(get_platform)() == expected
+        platform_mock.assert_not_called()
+
     async def test_proxy_environment_variables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Test that the proxy environment variables are set correctly
         monkeypatch.setenv("HTTPS_PROXY", "https://example.org")


### PR DESCRIPTION
Fixes #1762

## Summary

- replace `platform.platform()` with fork-free `system()`, `release()`, and `machine()` lookups
- preserve macOS, iOS, Android, Linux, and fallback platform classification
- add regression coverage that fails if `platform.platform()` is called

## Testing

- `uv run pytest tests/test_client.py -n0 -q` (185 passed)
- `./scripts/lint` (ruff, pyright, mypy, and import check passed)
