### PR TITLE
fix: support list-form JSON schema types

### DIFF
--- a/src/anthropic/lib/_parse/_transform.py
+++ b/src/anthropic/lib/_parse/_transform.py
@@ -96,12 +96,22 @@ def transform_schema(
         strict_schema["$ref"] = ref
         return strict_schema
 
-    type_: Optional[SupportedTypes] = json_schema.pop("type", None)
+    type_value = json_schema.pop("type", None)
+    type_union = type_value if is_list(type_value) else None
+    type_: Optional[SupportedTypes] = None if type_union is not None else cast("Optional[SupportedTypes]", type_value)
     any_of = json_schema.pop("anyOf", None)
     one_of = json_schema.pop("oneOf", None)
     all_of = json_schema.pop("allOf", None)
 
-    if is_list(any_of):
+    if type_union is not None:
+        constraints = {key: value for key, value in json_schema.items() if key not in ("description", "enum", "title")}
+        strict_schema["anyOf"] = [
+            transform_schema({"type": variant, **constraints} if variant != "null" else {"type": "null"})
+            for variant in type_union
+        ]
+        for key in constraints:
+            json_schema.pop(key)
+    elif is_list(any_of):
         strict_schema["anyOf"] = [transform_schema(cast("dict[str, Any]", variant)) for variant in any_of]
     elif is_list(one_of):
         strict_schema["anyOf"] = [transform_schema(cast("dict[str, Any]", variant)) for variant in one_of]

--- a/tests/lib/_parse/test_transform.py
+++ b/tests/lib/_parse/test_transform.py
@@ -61,6 +61,36 @@ def test_anyof_schema():
     )
 
 
+def test_type_array_schema():
+    schema = {"type": ["string", "null"]}
+    result = transform_schema(schema)
+    assert result == snapshot({"anyOf": [{"type": "string"}, {"type": "null"}]})
+
+
+def test_type_array_schema_with_constraints():
+    schema = {
+        "type": ["object", "null"],
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+        "description": "A nullable object",
+    }
+    result = transform_schema(schema)
+    assert result == snapshot(
+        {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                    "additionalProperties": False,
+                    "required": ["name"],
+                },
+                {"type": "null"},
+            ],
+            "description": "A nullable object",
+        }
+    )
+
+
 def test_enum_schema():
     schema = {
         "type": "string",


### PR DESCRIPTION
Fixes #1764

## Summary

- canonicalize list-form JSON Schema types into `anyOf` branches
- keep shared descriptions, titles, and enums on the union while applying sibling constraints to non-null branches
- add regression coverage for simple and constrained nullable schemas

## Test plan

- `uv run pytest tests/lib/_parse -n0` (24 passed)
- `uv run ruff check src/anthropic/lib/_parse/_transform.py tests/lib/_parse/test_transform.py`
- `uv run ruff format --check src/anthropic/lib/_parse/_transform.py tests/lib/_parse/test_transform.py`
- `uv run pyright src/anthropic/lib/_parse/_transform.py`
