### PR TITLE
fix: support PathLike content in file tuples

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -63,15 +63,15 @@ def to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles | None:
 
 
 def _transform_file(file: FileTypes) -> HttpxFileTypes:
+    if is_tuple_t(file):
+        return (file[0], read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = pathlib.Path(file)
             return (path.name, path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 
@@ -105,15 +105,15 @@ async def async_to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles 
 
 
 async def _async_transform_file(file: FileTypes) -> HttpxFileTypes:
+    if is_tuple_t(file):
+        return (file[0], await async_read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = anyio.Path(file)
             return (path.name, await path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], await async_read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -22,6 +22,11 @@ def test_tuple_input() -> None:
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
 
 
+def test_pathlib_in_file_tuple() -> None:
+    result = to_httpx_files({"file": ("custom-name.md", readme_path)})
+    assert result == IsDict({"file": IsTuple("custom-name.md", IsBytes())})
+
+
 @pytest.mark.asyncio
 async def test_async_pathlib_includes_file_name() -> None:
     result = await async_to_httpx_files({"file": readme_path})
@@ -41,6 +46,12 @@ async def test_async_tuple_input() -> None:
     result = await async_to_httpx_files([("file", readme_path)])
     print(result)
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
+
+
+@pytest.mark.asyncio
+async def test_async_pathlib_in_file_tuple() -> None:
+    result = await async_to_httpx_files({"file": ("custom-name.md", readme_path)})
+    assert result == IsDict({"file": IsTuple("custom-name.md", IsBytes())})
 
 
 def test_string_not_allowed() -> None:


### PR DESCRIPTION
Fixes #1769

## Summary

- convert `PathLike` file content inside tuple-form uploads before passing files to httpx
- preserve the caller-provided tuple filename and any optional content type or headers
- add synchronous and asynchronous regression coverage

## Testing

- `uv run pytest tests/test_files.py -n0` (16 passed)
- `uv run ruff check src/anthropic/_files.py tests/test_files.py`
- `uv run ruff format --check src/anthropic/_files.py tests/test_files.py`
- `uv run pyright` (0 errors)
- `uv run mypy .` (success across 1084 source files)
- `uv run python -c 'import anthropic'`
