### PR TITLE
feat(vertex): add labels support to AnthropicVertex clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ message = client.messages.create(
             "content": "Hello, Claude",
         }
     ],
-
     model="claude-opus-4-6",
 )
 

--- a/examples/vertex.py
+++ b/examples/vertex.py
@@ -39,5 +39,29 @@ async def async_client() -> None:
     print(message.to_json())
 
 
+def sync_client_with_labels() -> None:
+    print("------ Sync Vertex with billing labels ------")
+
+    client = AnthropicVertex(
+        labels={
+            "team": "ml-platform",
+            "environment": "production",
+        },
+    )
+
+    message = client.messages.create(
+        model="claude-sonnet-4@20250514",
+        max_tokens=100,
+        messages=[
+            {
+                "role": "user",
+                "content": "Hello!",
+            }
+        ],
+    )
+    print(message.to_json())
+
+
 sync_client()
 asyncio.run(async_client())
+sync_client_with_labels()

--- a/src/anthropic/lib/vertex/_client.py
+++ b/src/anthropic/lib/vertex/_client.py
@@ -108,6 +108,7 @@ class AnthropicVertex(BaseVertexClient[httpx.Client, Stream[Any]], SyncAPIClient
         # Configure a custom httpx client. See the [httpx documentation](https://www.python-httpx.org/api/#client) for more details.
         http_client: httpx.Client | None = None,
         middleware: Sequence[MiddlewareInput] | None = None,
+        labels: dict[str, str] | None = None,
         _strict_response_validation: bool = False,
     ) -> None:
         if not is_given(region):
@@ -147,13 +148,14 @@ class AnthropicVertex(BaseVertexClient[httpx.Client, Stream[Any]], SyncAPIClient
         self.region = region
         self.access_token = access_token
         self.credentials = credentials
+        self._labels = labels
 
         self.messages = Messages(self)
         self.beta = Beta(self)
 
     @override
     def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
-        return _prepare_options(options, project_id=self.project_id, region=self.region)
+        return _prepare_options(options, project_id=self.project_id, region=self.region, labels=self._labels)
 
     @override
     def _prepare_request(self, request: httpx.Request) -> None:
@@ -272,6 +274,7 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
         # Configure a custom httpx client. See the [httpx documentation](https://www.python-httpx.org/api/#client) for more details.
         http_client: httpx.AsyncClient | None = None,
         middleware: Sequence[MiddlewareInput] | None = None,
+        labels: dict[str, str] | None = None,
         _strict_response_validation: bool = False,
     ) -> None:
         if not is_given(region):
@@ -311,13 +314,14 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
         self.region = region
         self.access_token = access_token
         self.credentials = credentials
+        self._labels = labels
 
         self.messages = AsyncMessages(self)
         self.beta = AsyncBeta(self)
 
     @override
     async def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
-        return _prepare_options(options, project_id=self.project_id, region=self.region)
+        return _prepare_options(options, project_id=self.project_id, region=self.region, labels=self._labels)
 
     @override
     async def _prepare_request(self, request: httpx.Request) -> None:
@@ -417,7 +421,13 @@ class AsyncAnthropicVertex(BaseVertexClient[httpx.AsyncClient, AsyncStream[Any]]
         return self.copy(middleware=[*self._middleware, *middleware])
 
 
-def _prepare_options(input_options: FinalRequestOptions, *, project_id: str | None, region: str) -> FinalRequestOptions:
+def _prepare_options(
+    input_options: FinalRequestOptions,
+    *,
+    project_id: str | None,
+    region: str,
+    labels: dict[str, str] | None = None,
+) -> FinalRequestOptions:
     options = model_copy(input_options, deep=True)
 
     if is_dict(options.json_data):
@@ -437,6 +447,9 @@ def _prepare_options(input_options: FinalRequestOptions, *, project_id: str | No
         specifier = "streamRawPredict" if stream else "rawPredict"
 
         options.url = f"/projects/{project_id}/locations/{region}/publishers/anthropic/models/{model}:{specifier}"
+
+        if labels:
+            options.json_data["labels"] = labels
 
     if options.url in {"/v1/messages/count_tokens", "/v1/messages/count_tokens?beta=true"} and options.method == "post":
         if project_id is None:

--- a/src/anthropic/types/beta/messages/batch_create_params.py
+++ b/src/anthropic/types/beta/messages/batch_create_params.py
@@ -32,8 +32,6 @@ class BatchCreateParams(TypedDict, total=False):
     """
 
 
-
-
 class Request(TypedDict, total=False):
     custom_id: Required[str]
     """Developer-provided ID created for each request in a Message Batch.

--- a/src/anthropic/types/messages/batch_create_params.py
+++ b/src/anthropic/types/messages/batch_create_params.py
@@ -28,7 +28,6 @@ class BatchCreateParams(TypedDict, total=False):
     """
 
 
-
 class Request(TypedDict, total=False):
     custom_id: Required[str]
     """Developer-provided ID created for each request in a Message Batch.

--- a/tests/lib/test_refusal_fallback.py
+++ b/tests/lib/test_refusal_fallback.py
@@ -119,7 +119,12 @@ class TestRefusalFallback:
         # a `fallback` seam block is prepended at the model boundary — the same
         # block shape the streaming splice emits
         assert [block.to_dict() for block in result.content] == [
-            {"type": "fallback", "from": {"model": "primary-model"}, "to": {"model": "fallback-model"}, "trigger": {"type": "refusal", "category": None}}
+            {
+                "type": "fallback",
+                "from": {"model": "primary-model"},
+                "to": {"model": "fallback-model"},
+                "trigger": {"type": "refusal", "category": None},
+            }
         ]
         bodies = request_bodies(respx_mock)
         assert [body["model"] for body in bodies] == ["primary-model", "fallback-model"]
@@ -235,8 +240,18 @@ class TestRefusalFallback:
         assert state.index == 1
         # one seam per model boundary, in hop order, ahead of the served content
         assert [block.to_dict() for block in result.content] == [
-            {"type": "fallback", "from": {"model": "primary-model"}, "to": {"model": "mid-model"}, "trigger": {"type": "refusal", "category": None}},
-            {"type": "fallback", "from": {"model": "mid-model"}, "to": {"model": "last-model"}, "trigger": {"type": "refusal", "category": None}},
+            {
+                "type": "fallback",
+                "from": {"model": "primary-model"},
+                "to": {"model": "mid-model"},
+                "trigger": {"type": "refusal", "category": None},
+            },
+            {
+                "type": "fallback",
+                "from": {"model": "mid-model"},
+                "to": {"model": "last-model"},
+                "trigger": {"type": "refusal", "category": None},
+            },
             {"type": "text", "text": "ok"},
         ]
         bodies = request_bodies(respx_mock)
@@ -261,7 +276,12 @@ class TestRefusalFallback:
 
         assert result.model == "last-model"
         assert [block.to_dict() for block in result.content] == [
-            {"type": "fallback", "from": {"model": "mid-model"}, "to": {"model": "last-model"}, "trigger": {"type": "refusal", "category": None}},
+            {
+                "type": "fallback",
+                "from": {"model": "mid-model"},
+                "to": {"model": "last-model"},
+                "trigger": {"type": "refusal", "category": None},
+            },
             {"type": "text", "text": "ok"},
         ]
         bodies = request_bodies(respx_mock)
@@ -484,7 +504,12 @@ class TestAsyncRefusalFallback:
 
         assert result.model == "fallback-model"
         assert [block.to_dict() for block in result.content] == [
-            {"type": "fallback", "from": {"model": "primary-model"}, "to": {"model": "fallback-model"}, "trigger": {"type": "refusal", "category": None}}
+            {
+                "type": "fallback",
+                "from": {"model": "primary-model"},
+                "to": {"model": "fallback-model"},
+                "trigger": {"type": "refusal", "category": None},
+            }
         ]
         bodies = request_bodies(respx_mock)
         assert [body["model"] for body in bodies] == ["primary-model", "fallback-model"]

--- a/tests/lib/test_refusal_fallback_streaming.py
+++ b/tests/lib/test_refusal_fallback_streaming.py
@@ -592,7 +592,8 @@ class TestEdgeCases:
         client = make_lenient_client(middleware=[BetaRefusalFallbackMiddleware(FALLBACKS)])
 
         with pytest.raises(
-            AnthropicError, match=r"Sending the `fallbacks:` request param is not supported when using the `BetaRefusalFallbackMiddleware`\. You should either remove the middleware and send `fallbacks:` with the `server-side-fallback-2026-06-01` beta header to let the API handle refusal fallbacks, or omit the `fallbacks:` param if you'd like `BetaRefusalFallbackMiddleware` to handle fallbacks on the client side\."
+            AnthropicError,
+            match=r"Sending the `fallbacks:` request param is not supported when using the `BetaRefusalFallbackMiddleware`\. You should either remove the middleware and send `fallbacks:` with the `server-side-fallback-2026-06-01` beta header to let the API handle refusal fallbacks, or omit the `fallbacks:` param if you'd like `BetaRefusalFallbackMiddleware` to handle fallbacks on the client side\.",
         ):
             client.beta.messages.create(
                 model="claude-fable-5",

--- a/tests/lib/test_vertex.py
+++ b/tests/lib/test_vertex.py
@@ -171,6 +171,37 @@ class TestAnthropicVertex:
         )
         assert str(client.base_url).rstrip("/") == "https://test.googleapis.com/v1"
 
+    @pytest.mark.respx()
+    def test_labels_injected_into_request_body(self, respx_mock: MockRouter) -> None:
+        """Labels passed to the client are injected into the rawPredict request body."""
+        import json
+
+        client = AnthropicVertex(
+            region="region",
+            project_id="project",
+            access_token="my-access-token",
+            labels={"team": "ml-platform", "environment": "production"},
+        )
+
+        request_url = "https://region-aiplatform.googleapis.com/v1/projects/project/locations/region/publishers/anthropic/models/claude-3-sonnet@20240229:rawPredict"
+        respx_mock.post(request_url).mock(return_value=httpx.Response(200, json={"foo": "bar"}))
+
+        client.messages.create(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Hello"}],
+            model="claude-3-sonnet@20240229",
+        )
+
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 1
+        body = json.loads(calls[0].request.content)
+        assert body["labels"] == {"team": "ml-platform", "environment": "production"}
+
+    def test_no_labels_by_default(self) -> None:
+        """Labels are not included in the request body when not set."""
+        client = AnthropicVertex(region="region", project_id="project", access_token="my-access-token")
+        assert client._labels is None
+
 
 def test_refresh_without_google_auth_raises_actionable_error(monkeypatch: pytest.MonkeyPatch) -> None:
     # `None` in sys.modules makes the import fail even when google-auth is installed.

--- a/uv.lock
+++ b/uv.lock
@@ -194,7 +194,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.117.0"
+version = "0.118.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Adds a `labels` parameter to both `AnthropicVertex` and `AsyncAnthropicVertex` constructors, enabling cost attribution labels to be attached to Claude API requests on Vertex AI.

## Problem

When calling Claude models through Vertex AI, there is no way to attach billing labels to individual requests. The `generateContent` API (used by Gemini models) supports a native `labels` field that surfaces in Vertex AI billing exports and cost dashboards. The `rawPredict` path used for Claude has no equivalent mechanism in the SDK, making per-team, per-environment, or per-application cost attribution impossible at the Vertex billing layer.

## Changes

- Added `labels: dict[str, str] | None = None` to `AnthropicVertex.__init__` and `AsyncAnthropicVertex.__init__`
- Stored as `self._labels` on the client instance
- `_prepare_options` injects `labels` into the rawPredict JSON body when set
- Fully backwards-compatible — `labels` defaults to `None` so existing code is unaffected

## Usage

```python
client = AsyncAnthropicVertex(
    region="us-east5",
    project_id="my-gcp-project",
    labels={
        "team": "ml-platform",
        "environment": "production",
        "application": "my-service",
    },
)

response = await client.messages.create(
    model="claude-opus-4-5",
    max_tokens=1024,
    messages=[{"role": "user", "content": "Hello"}],
)
```

## Note on Vertex AI billing surfacing

The `labels` field is injected into the rawPredict request body. Surfacing these labels in Vertex AI cost exports requires corresponding support from Google Cloud — this SDK change is the caller-side implementation. A feature request with Google to support label extraction from rawPredict bodies for Anthropic publisher models would complete the end-to-end solution.