### PR TITLE
fix(streaming): get_final_message() drops container, breaking code execution continuation

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -501,6 +501,7 @@ def accumulate_event(
         if content_block.type == "text" and is_given(output_format):
             content_block.parsed_output = parse_text(content_block.text, output_format)
     elif event.type == "message_delta":
+        current_snapshot.container = event.delta.container
         current_snapshot.stop_reason = event.delta.stop_reason
         current_snapshot.stop_sequence = event.delta.stop_sequence
         if event.delta.stop_details is not None:

--- a/tests/lib/streaming/fixtures/container_response.txt
+++ b/tests/lib/streaming/fixtures/container_response.txt
@@ -1,0 +1,17 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01Gh8kQEinLbnrkVJ9BqrmyQ","type":"message","role":"assistant","content":[],"model":"claude-opus-4-8","container":null,"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Running your code now."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"container":{"id":"container_011CPTa1PkYDZagcpQ8VZCcy","expires_at":"2026-07-23T16:16:14.426901Z"},"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":6}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/tests/lib/streaming/test_messages.py
+++ b/tests/lib/streaming/test_messages.py
@@ -105,6 +105,11 @@ def assert_tool_use_response(events: list[ParsedMessageStreamEvent[None]], messa
     ]
 
 
+def assert_container_response(message: Message) -> None:
+    assert message.container is not None
+    assert message.container.id == "container_011CPTa1PkYDZagcpQ8VZCcy"
+
+
 def assert_refusal_response(message: Message) -> None:
     assert message.stop_reason == "refusal"
     assert message.stop_details is not None
@@ -206,6 +211,19 @@ class TestSyncMessages:
         ) as stream:
             assert_refusal_response(stream.get_final_message())
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_container_propagated(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=get_response("container_response.txt"))
+        )
+
+        with sync_client.messages.stream(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Say hello there!"}],
+            model="claude-opus-4-8",
+        ) as stream:
+            assert_container_response(stream.get_final_message())
+
 
 class TestAsyncMessages:
     @pytest.mark.asyncio
@@ -304,6 +322,20 @@ class TestAsyncMessages:
             model="claude-opus-4-7",
         ) as stream:
             assert_refusal_response(await stream.get_final_message())
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx(base_url=base_url)
+    async def test_container_propagated(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=to_async_iter(get_response("container_response.txt")))
+        )
+
+        async with async_client.messages.stream(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Say hello there!"}],
+            model="claude-opus-4-8",
+        ) as stream:
+            assert_container_response(await stream.get_final_message())
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
When streaming with `client.messages.stream()`, the final message's `container` field is always `None`, even though the API sends it in the `message_delta` event. The streaming code copies `stop_reason`, `stop_sequence`, `stop_details`, and usage from that event, but not `container`. The equivalent code for `client.beta.messages.stream()` does copy it.

Without the container id, a caller can't continue a conversation that has unfinished code execution — the next request fails with `400: container_id is required when there are pending tool uses generated by code execution with tools.`

This adds the missing copy, plus sync and async tests that fail without it.

Fixes #1424.
