### PR TITLE
fix(bedrock): run async SigV4 auth off the event loop

### DIFF
--- a/src/anthropic/lib/bedrock/_client.py
+++ b/src/anthropic/lib/bedrock/_client.py
@@ -11,6 +11,7 @@ import httpx
 from ... import _exceptions
 from ._beta import Beta, AsyncBeta
 from ..._types import NOT_GIVEN, Timeout, NotGiven
+from ..._utils import to_thread
 from ..._utils import is_dict, is_given
 from ..._compat import model_copy
 from ..._version import __version__
@@ -221,7 +222,8 @@ class AnthropicBedrock(BaseBedrockClient[httpx.Client, Stream[Any]], SyncAPIClie
             request.headers["Authorization"] = f"Bearer {self.api_key}"
             return
 
-        from ._auth import get_auth_headers
+        from ..._utils._sync import to_thread
+from ._auth import get_auth_headers
 
         data = request.read().decode()
 
@@ -405,7 +407,10 @@ class AsyncAnthropicBedrock(BaseBedrockClient[httpx.AsyncClient, AsyncStream[Any
 
         data = request.read().decode()
 
-        headers = get_auth_headers(
+        # AWS credential resolution / SigV4 signing is synchronous and can block.
+        # Run off the event-loop thread so concurrent async tasks keep running (#1770).
+        headers = await to_thread(
+            get_auth_headers,
             method=request.method,
             url=str(request.url),
             headers=request.headers,

--- a/src/anthropic/lib/bedrock/_mantle.py
+++ b/src/anthropic/lib/bedrock/_mantle.py
@@ -1,3 +1,4 @@
+from ..._utils._sync import to_thread
 from __future__ import annotations
 
 import os
@@ -462,7 +463,9 @@ class AsyncAnthropicBedrockMantle(BaseMantleClient[httpx.AsyncClient, AsyncStrea
 
         data = request.read().decode()
 
-        headers = get_auth_headers(
+        # Keep SigV4 credential work off the event loop (#1770).
+        headers = await to_thread(
+            get_auth_headers,
             method=request.method,
             url=str(request.url),
             headers=request.headers,

--- a/tests/lib/test_bedrock_async_thread.py
+++ b/tests/lib/test_bedrock_async_thread.py
@@ -1,0 +1,43 @@
+"""Regression test for #1770: AsyncAnthropicBedrock must not block the event loop during SigV4 auth."""
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from anthropic import AsyncAnthropicBedrock
+
+
+@pytest.mark.asyncio
+async def test_async_bedrock_auth_does_not_block_event_loop():
+    """Slow credential resolution must not stall concurrent async tasks."""
+    heartbeats: list[float] = []
+
+    async def heartbeat():
+        for _ in range(4):
+            heartbeats.append(time.monotonic())
+            await asyncio.sleep(0.1)
+
+    def slow_get_auth_headers(**kwargs):
+        time.sleep(0.5)
+        return {"Authorization": "AWS4-HMAC-SHA256 ..."}
+
+    client = AsyncAnthropicBedrock(aws_region="us-east-1")
+
+    with patch("anthropic.lib.bedrock._client.get_auth_headers", side_effect=slow_get_auth_headers):
+        # _prepare_request needs a real httpx.Request
+        import httpx
+
+        req = httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/model/test/invoke", content=b"{}")
+
+        async def call_prepare():
+            await client._prepare_request(req)
+
+        await asyncio.gather(heartbeat(), call_prepare())
+
+    # If auth blocked the loop, heartbeats would cluster after the sleep.
+    # With to_thread, heartbeats should be spread across ~0.4s.
+    assert len(heartbeats) == 4
+    span = heartbeats[-1] - heartbeats[0]
+    assert span > 0.2, f"Heartbeats too clustered ({span:.3f}s) — event loop was blocked"


### PR DESCRIPTION
## Summary

`AsyncAnthropicBedrock._prepare_request` called `get_auth_headers()` synchronously, blocking the event loop during AWS credential resolution and SigV4 signing (#1770).

## Fix

Wrap the call in `to_thread()` (from `anthropic._utils._sync`) so credential work runs in a worker thread. Same fix applied to `AsyncAnthropicBedrockMantle`.

## Test

Added `test_bedrock_async_thread.py` — asserts concurrent heartbeats keep firing while auth is slow.

Fixes #1770