### PR TITLE
fix(jsonl): do not treat a lone CR as a line ending

### DIFF
--- a/src/anthropic/_decoders/jsonl.py
+++ b/src/anthropic/_decoders/jsonl.py
@@ -41,18 +41,30 @@ class JSONLDecoder(Generic[_T]):
         self.http_response.close()
 
     def __decode__(self) -> Iterator[_T]:
+        # JSON Lines uses `\n` as the line separator; `\r\n` is also valid.
+        # Do not finalize on a lone `\r` — batch results are read with a small
+        # `iter_bytes` chunk size, so CRLF often arrives split across chunks.
         buf = b""
         for chunk in self._raw_iterator:
-            for line in chunk.splitlines(keepends=True):
-                buf += line
-                if buf.endswith((b"\r", b"\n", b"\r\n")):
-                    yield construct_type_unchecked(
-                        value=json.loads(buf),
-                        type_=self._line_type,
-                    )
-                    buf = b""
+            buf += chunk
+            while True:
+                newline = buf.find(b"\n")
+                if newline < 0:
+                    break
+
+                line = buf[:newline]
+                buf = buf[newline + 1 :]
+                if line.endswith(b"\r"):
+                    line = line[:-1]
+
+                yield construct_type_unchecked(
+                    value=json.loads(line),
+                    type_=self._line_type,
+                )
 
         # flush
+        if buf.endswith(b"\r"):
+            buf = buf[:-1]
         if buf:
             yield construct_type_unchecked(
                 value=json.loads(buf),
@@ -97,18 +109,30 @@ class AsyncJSONLDecoder(Generic[_T]):
         await self.http_response.aclose()
 
     async def __decode__(self) -> AsyncIterator[_T]:
+        # JSON Lines uses `\n` as the line separator; `\r\n` is also valid.
+        # Do not finalize on a lone `\r` — batch results are read with a small
+        # `iter_bytes` chunk size, so CRLF often arrives split across chunks.
         buf = b""
         async for chunk in self._raw_iterator:
-            for line in chunk.splitlines(keepends=True):
-                buf += line
-                if buf.endswith((b"\r", b"\n", b"\r\n")):
-                    yield construct_type_unchecked(
-                        value=json.loads(buf),
-                        type_=self._line_type,
-                    )
-                    buf = b""
+            buf += chunk
+            while True:
+                newline = buf.find(b"\n")
+                if newline < 0:
+                    break
+
+                line = buf[:newline]
+                buf = buf[newline + 1 :]
+                if line.endswith(b"\r"):
+                    line = line[:-1]
+
+                yield construct_type_unchecked(
+                    value=json.loads(line),
+                    type_=self._line_type,
+                )
 
         # flush
+        if buf.endswith(b"\r"):
+            buf = buf[:-1]
         if buf:
             yield construct_type_unchecked(
                 value=json.loads(buf),

--- a/tests/decoders/test_jsonl.py
+++ b/tests/decoders/test_jsonl.py
@@ -60,6 +60,53 @@ async def test_multi_byte_character_multiple_chunks(
     assert await iter_next(iterator) == {"content": "известни"}
 
 
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_crlf_line_endings(sync: bool) -> None:
+    def body() -> Iterator[bytes]:
+        yield b'{"foo":true}\r\n'
+        yield b'{"bar":false}\r\n'
+
+    iterator = make_jsonl_iterator(content=body(), sync=sync, line_type=object)
+
+    assert await iter_next(iterator) == {"foo": True}
+    assert await iter_next(iterator) == {"bar": False}
+
+    await assert_empty_iter(iterator)
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_crlf_split_across_chunks(sync: bool) -> None:
+    """Batch results are read with `iter_bytes(chunk_size=64)`, so a CRLF
+    terminator can land across two chunks. A lone CR must not finalize the line.
+    """
+
+    def body() -> Iterator[bytes]:
+        yield b'{"foo":true}\r'
+        yield b'\n{"bar":false}\r\n'
+
+    iterator = make_jsonl_iterator(content=body(), sync=sync, line_type=object)
+
+    assert await iter_next(iterator) == {"foo": True}
+    assert await iter_next(iterator) == {"bar": False}
+
+    await assert_empty_iter(iterator)
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_crlf_split_in_mid_line_then_terminator(sync: bool) -> None:
+    def body() -> Iterator[bytes]:
+        yield b'{"foo":'
+        yield b'true}\r'
+        yield b'\n{"bar":false}\n'
+
+    iterator = make_jsonl_iterator(content=body(), sync=sync, line_type=object)
+
+    assert await iter_next(iterator) == {"foo": True}
+    assert await iter_next(iterator) == {"bar": False}
+
+    await assert_empty_iter(iterator)
+
+
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:
     for chunk in iter:
         yield chunk


### PR DESCRIPTION
## Summary

- `JSONLDecoder` / `AsyncJSONLDecoder` previously treated a lone `\r` as a complete line ending.
- When a CRLF terminator is split across `iter_bytes` chunks (batch results use `chunk_size=64`), that left a leftover `\n` which was parsed as an empty JSONL row and raised `JSONDecodeError`.
- Terminate lines only on `\n` (stripping a preceding `\r` for CRLF), matching JSON Lines and the TypeScript SDK’s `LineDecoder` behavior.

## Problem

`messages.batches.results` / `beta.messages.batches.results` stream JSONL via:

```python
self.http_response.iter_bytes(chunk_size=64)
```

The previous decoder finalized a line whenever the buffer ended with `\r`, `\n`, or `\r\n`. If a chunk ended at `\r` and the next began with `\n`, the decoder:

1. Parsed the line ending at `\r` (OK for that object)
2. Then tried to parse the leftover `\n` as another line → `json.JSONDecodeError: Expecting value`

Intact `\r\n` in a single chunk already worked; only the split case failed.

## Minimal reproduction

```python
import httpx
from anthropic._decoders.jsonl import JSONLDecoder

list(
    JSONLDecoder(
        raw_iterator=iter([b'{"foo":true}\r', b'\n{"bar":false}\r\n']),
        line_type=object,
        http_response=httpx.Response(200),
    )
)
# Before: JSONDecodeError
# After: [{"foo": True}, {"bar": False}]
```

## Current behavior

Split CRLF across chunks raises `JSONDecodeError` while decoding batch results.

## Corrected behavior

CRLF is treated as one terminator even when `\r` and `\n` arrive in separate chunks. Sync and async decoders behave the same.

## Root cause

`bytes.splitlines(keepends=True)` + `buf.endswith((b"\r", b"\n", b"\r\n"))` treated a dangling CR as end-of-line. JSON Lines uses `\n` as the line separator (with `\r\n` also valid); a lone CR must stay buffered until `\n` arrives (or EOF flush).

## Implementation

- Buffer incoming chunks and split only on `\n`.
- Strip a trailing `\r` from each line (CRLF).
- On flush, strip a trailing `\r` before parsing any remaining bytes.
- Applied identically in `JSONLDecoder` and `AsyncJSONLDecoder`.

This is intentionally small: no public API changes, no dependency changes, and no generated resource changes. `_decoders/jsonl.py` is a Stainless-persisted module; the change may need re-application across regenerations, same as prior jsonl fixes in this repo.

## Why this approach is minimal

- Does not introduce a shared line-decoder abstraction.
- Does not skip blank lines or broaden accepted inputs.
- Mirrors the contract already used by the TypeScript SDK’s `LineDecoder` (defer trailing CR) without pulling httpx internals into this path.

## Sync and async coverage

Both `JSONLDecoder` and `AsyncJSONLDecoder` were updated and tested.

## Regression tests

Added in `tests/decoders/test_jsonl.py` (sync + async for each):

- Intact CRLF line endings
- CRLF split across chunk boundaries
- CRLF split after a mid-line chunk boundary

## Validation

Pre-fix (expected failures):

```bash
UV_PYTHON='>=3.9.0' uv run --isolated --all-extras pytest tests/decoders/test_jsonl.py -n0 -v
# 4 failed (CRLF split cases), 8 passed
```

Post-fix:

```bash
UV_PYTHON='>=3.9.0' uv run --isolated --all-extras pytest tests/decoders/test_jsonl.py -n0 -v
# 12 passed

UV_PYTHON='>=3.9.0' uv run --isolated --all-extras --no-extra=mcp --group=pydantic-v1 pytest tests/decoders/test_jsonl.py -n0 -v
# 12 passed

UV_PYTHON='>=3.14.0' uv run --isolated --all-extras pytest tests/decoders/test_jsonl.py -n0 -v
# 12 passed

UV_PYTHON='>=3.9.0' ./scripts/test tests/decoders/ tests/test_streaming.py tests/test_response.py tests/test_legacy_response.py
# 75 passed (pydantic v2), 75 passed (pydantic v1)

UV_PYTHON='>=3.9.0' ./scripts/test
# 4002 passed, 687 skipped, 1 xfailed (pydantic v2)
# 3885 passed, 805 skipped (pydantic v1)

./scripts/lint
# ruff: All checks passed
# pyright: 0 errors
# mypy: Success: no issues found in 1102 source files

uv build
# Successfully built dist/anthropic-0.119.0.tar.gz and .whl

git diff --check
# clean
```

No live Anthropic API calls were made.

## Generated-code considerations

Edited `src/anthropic/_decoders/jsonl.py` (persisted across Stainless generations; may conflict on regen). Tests under `tests/decoders/` are hand-maintained.

## Compatibility

- Backward compatible for `\n`-terminated JSONL (unchanged).
- Improves CRLF handling under chunked reads.
- Pure `\r`-only line endings (non-JSONL) are no longer treated as terminators mid-stream; JSON Lines requires `\n` / `\r\n`.

## Limitations

- Full `./scripts/test` was run for Python 3.9 (min) with both Pydantic major versions; focused JSONL tests were also run on Python 3.14.
- GitHub code search was rate-limited on the final recheck; earlier searches found no open/closed issues or PRs for this root cause.
