### PR TITLE
fix(streaming): enforce strict index validation in event accumulator to prevent state corruption

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -475,7 +475,11 @@ def accumulate_event(
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')
 
     if event.type == "content_block_start":
-        # TODO: check index
+        if event.index != len(current_snapshot.content):
+            raise RuntimeError(
+                f"Unexpected content block index: {event.index}. "
+                f"Expected index {len(current_snapshot.content)} based on current snapshot state."
+            )
         current_snapshot.content.append(
             cast(
                 Any,  # Pydantic does not support generic unions at runtime

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -454,7 +454,11 @@ def accumulate_event(
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')
 
     if event.type == "content_block_start":
-        # TODO: check index
+        if event.index != len(current_snapshot.content):
+            raise RuntimeError(
+                f"Unexpected content block index: {event.index}. "
+                f"Expected index {len(current_snapshot.content)} based on current snapshot state."
+            )
         current_snapshot.content.append(
             cast(
                 Any,  # Pydantic does not support generic unions at runtime

--- a/tests/lib/streaming/fixtures/out_of_order_response.txt
+++ b/tests/lib/streaming/fixtures/out_of_order_response.txt
@@ -1,0 +1,8 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_4QpJur2dWWDjF6C758FbBw5vm12BaVipnK","type":"message","role":"assistant","content":[],"model":"claude-3-opus-latest","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/tests/lib/streaming/test_beta_messages.py
+++ b/tests/lib/streaming/test_beta_messages.py
@@ -402,6 +402,21 @@ class TestSyncMessages:
         ) as stream:
             assert_fallback_credit_response(stream.get_final_message())
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_out_of_order_content_block_start(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=get_response("out_of_order_response.txt"))
+        )
+
+        with pytest.raises(RuntimeError, match="Unexpected content block index: 1"):
+            with sync_client.beta.messages.stream(
+                max_tokens=1024,
+                messages=[{"role": "user", "content": "Say hello there!"}],
+                model="claude-3-opus-latest",
+            ) as stream:
+                for _ in stream:
+                    pass
+
 
 class TestAsyncMessages:
     @pytest.mark.asyncio
@@ -569,6 +584,22 @@ class TestAsyncMessages:
             model="claude-sonnet-4-5",
         ) as stream:
             assert_fallback_credit_response(await stream.get_final_message())
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx(base_url=base_url)
+    async def test_out_of_order_content_block_start(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=to_async_iter(get_response("out_of_order_response.txt")))
+        )
+
+        with pytest.raises(RuntimeError, match="Unexpected content block index: 1"):
+            async with async_client.beta.messages.stream(
+                max_tokens=1024,
+                messages=[{"role": "user", "content": "Say hello there!"}],
+                model="claude-3-opus-latest",
+            ) as stream:
+                async for _ in stream:
+                    pass
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])

--- a/tests/lib/streaming/test_messages.py
+++ b/tests/lib/streaming/test_messages.py
@@ -206,6 +206,21 @@ class TestSyncMessages:
         ) as stream:
             assert_refusal_response(stream.get_final_message())
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_out_of_order_content_block_start(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=get_response("out_of_order_response.txt"))
+        )
+
+        with pytest.raises(RuntimeError, match="Unexpected content block index: 1"):
+            with sync_client.messages.stream(
+                max_tokens=1024,
+                messages=[{"role": "user", "content": "Say hello there!"}],
+                model="claude-3-opus-latest",
+            ) as stream:
+                for _ in stream:
+                    pass
+
 
 class TestAsyncMessages:
     @pytest.mark.asyncio
@@ -304,6 +319,22 @@ class TestAsyncMessages:
             model="claude-opus-4-7",
         ) as stream:
             assert_refusal_response(await stream.get_final_message())
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx(base_url=base_url)
+    async def test_out_of_order_content_block_start(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=to_async_iter(get_response("out_of_order_response.txt")))
+        )
+
+        with pytest.raises(RuntimeError, match="Unexpected content block index: 1"):
+            async with async_client.messages.stream(
+                max_tokens=1024,
+                messages=[{"role": "user", "content": "Say hello there!"}],
+                model="claude-3-opus-latest",
+            ) as stream:
+                async for _ in stream:
+                    pass
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
## Summary
This PR resolves an unhandled edge case in the streaming parser where out-of-sequence or dropped `content_block_start` events could silently corrupt the internal accumulator state, leading to cryptic `IndexError` exceptions during downstream `content_block_delta` processing.

## Root Cause Analysis
The accumulator previously appended `content_block_start` payloads blindly without asserting the sequence invariant (as noted by the legacy `# TODO: check index` comment). If an SSE event is dropped or misordered by the network layer, `current_snapshot.content` desynchronizes from the expected block sequence. 

When a subsequent `content_block_delta` arrives, the parser relies on `content = current_snapshot.content[event.index]`. If the internal state length is misaligned with the incoming `event.index`, it triggers an obscure `IndexError` inside the delta router, making it extremely difficult for developers to debug the underlying network/API failure.

## Changes Made
- Introduced a strict sequence invariant check during `content_block_start` evaluation for both standard (`_messages.py`) and beta (`_beta_messages.py`) streams.
- The parser now employs a fail-fast mechanism by explicitly raising a `RuntimeError` describing the index mismatch, guaranteeing stream integrity.

## Validation
- Adheres to existing `ruff` static analysis and formatting guidelines.
- The state machine mathematically ensures `event.index == len(current_snapshot.content)` before allowing `.append()` mutations.
