### PR TITLE
fix(mcp): pin mcp extra to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ vertex = ["google-auth[requests] >=2, <3"]
 google_cloud = ["google-auth[requests] >=2, <3"]
 aws = ["boto3 >= 1.28.57", "botocore >= 1.31.57"]
 bedrock = ["boto3 >= 1.28.57", "botocore >= 1.31.57"]
-mcp = ["mcp>=1.0; python_version >= '3.10'"]
+mcp = ["mcp>=1.0, <2; python_version >= '3.10'"]
 webhooks = ["standardwebhooks >= 1.0.1, < 2"]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -278,7 +278,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0,<1" },
     { name = "httpx-aiohttp", marker = "extra == 'aiohttp'", specifier = ">=0.1.9,<1" },
     { name = "jiter", specifier = ">=0.4.0,<1" },
-    { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=1.0" },
+    { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'", specifier = ">=1.0,<2" },
     { name = "pydantic", specifier = ">=1.9.0,<3" },
     { name = "sniffio" },
     { name = "standardwebhooks", marker = "extra == 'webhooks'", specifier = ">=1.0.1,<2" },


### PR DESCRIPTION
mcp v2 has breaking API changes that the `mcp` extra's helpers aren't compatible with yet. This constrains the extra to `mcp>=1.0, <2` until support for v2 lands.

The lockfile already resolves mcp 1.26.0, so the only lock change is the requires-dist specifier metadata.