### PR TITLE
fix(environments): warn when heartbeat signals shutdown on first beat

### DIFF
--- a/src/anthropic/lib/environments/_worker.py
+++ b/src/anthropic/lib/environments/_worker.py
@@ -108,6 +108,7 @@ async def _heartbeat_loop(
     ttl = _HEARTBEAT_TTL_DEFAULT
     last = _NO_HEARTBEAT_SENTINEL
     last_success = time.monotonic()
+    heartbeat_count = 0
     while not stop.is_set():
         try:
             # Bound each heartbeat: a network blackhole must not leave us
@@ -139,11 +140,30 @@ async def _heartbeat_loop(
         else:
             last = resp.last_heartbeat
             last_success = time.monotonic()
+            heartbeat_count += 1
             if resp.ttl_seconds > 0:
                 ttl = resp.ttl_seconds
                 interval = max(1.0, min(resp.ttl_seconds / 2, _HEARTBEAT_DEFAULT))
             if resp.state in ("stopping", "stopped") or not resp.lease_extended:
-                log.info("heartbeat signals shutdown state=%s lease_extended=%s", resp.state, resp.lease_extended)
+                if heartbeat_count == 1:
+                    log.warning(
+                        "heartbeat signals shutdown on the very first beat "
+                        "(state=%s lease_extended=%s work_id=%s) — this almost always "
+                        "means your --on-work script exited before the spawned worker "
+                        "connected. Ensure spawn.sh BLOCKS until the sandbox exits: "
+                        "use 'docker run' (foreground), not 'docker run -d'; or "
+                        "'kubectl wait --for=condition=complete job/...' instead of "
+                        "'kubectl apply'. See the self-hosted environments docs.",
+                        resp.state,
+                        resp.lease_extended,
+                        work_id,
+                    )
+                else:
+                    log.info(
+                        "heartbeat signals shutdown state=%s lease_extended=%s",
+                        resp.state,
+                        resp.lease_extended,
+                    )
                 stop.set()
                 return
         # Sleep up to `interval` seconds, but wake immediately if stop is set.
@@ -351,6 +371,16 @@ class EnvironmentWorker:
         Raises:
           ValueError: if any of ``work_id`` / ``environment_id`` / ``session_id``
             / ``environment_key`` is still empty after the fallbacks.
+
+        Note:
+            When invoked from a ``worker poll --on-work`` script, that script MUST
+            block until the spawned worker process exits. Returning immediately after
+            launching a background container (e.g. ``kubectl apply``, ``docker run -d``)
+            causes the poller to mark the work item as complete before this worker
+            connects — the first heartbeat then returns ``state: stopping`` and the
+            session is permanently stuck at ``stop_reason: requires_action``. Use
+            ``docker run`` (foreground) or ``kubectl wait --for=condition=complete``
+            to block until the sandbox exits.
         """
         work_id = _require(work_id, name="work_id", env_var="ANTHROPIC_WORK_ID")
         environment_id = _require(environment_id, name="environment_id", env_var="ANTHROPIC_ENVIRONMENT_ID")


### PR DESCRIPTION
## Problem

When using `ant beta:worker poll --on-work spawn.sh`, if `spawn.sh` exits immediately after launching a background container — e.g. `kubectl apply` or `docker run -d` — the poller releases the work-item lease before the spawned worker connects. The first heartbeat then returns `state: stopping`, `_heartbeat_loop` silently calls `stop.set()` and returns, and the session is permanently stuck at `stop_reason: requires_action` with no output to explain why.

This is the issue described in #1779: the failure is deterministic once you understand the cause, but the SDK gives the user nothing to go on — no warning, no pointer to the blocking requirement.

## Fix

`src/anthropic/lib/environments/_worker.py` — the hand-written carve-out, not Stainless-generated code.

**1. `_heartbeat_loop`: detect and warn on first-beat shutdown**

Add a `heartbeat_count` counter. When `state: stopping` / `lease_extended: false` arrives on the very first successful heartbeat, emit `log.warning` with an explicit message:
- names the root cause (spawn script exited before worker connected)
- gives the concrete fix (`docker run` foreground vs `-d`, `kubectl wait` vs `kubectl apply`)
- links to the self-hosted environments docs

All subsequent shutdowns continue to use `log.info` (normal end-of-session).

**2. `handle_item` docstring: add a `Note:` section**

Documents the blocking requirement inline where users reading the API are most likely to encounter it, complementing any docs-side updates.

## Testing

The change is a logging-only diagnostic path; existing behaviour for normal session teardown (`heartbeat_count > 1`) is unchanged. The new `log.warning` branch fires only when `heartbeat_count == 1` at shutdown, which is the exact condition that previously produced a silent hang.

Fixes #1779