### PR TITLE
Read PathLike inside (name, content) file tuples

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -63,15 +63,18 @@ def to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles | None:
 
 
 def _transform_file(file: FileTypes) -> HttpxFileTypes:
+    # Check the tuple form first: is_file_content() also matches tuples, so testing it before
+    # is_tuple_t() would return a (name, PathLike) tuple unchanged, leaving the PathLike for
+    # httpx to choke on (`AttributeError: 'WindowsPath' object has no attribute 'read'`, #1769).
+    if is_tuple_t(file):
+        return (file[0], read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = pathlib.Path(file)
             return (path.name, path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 
@@ -105,15 +108,17 @@ async def async_to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles 
 
 
 async def _async_transform_file(file: FileTypes) -> HttpxFileTypes:
+    # See _transform_file: the tuple form must be checked before is_file_content() (which also
+    # matches tuples), otherwise a (name, PathLike) tuple is returned unread (#1769).
+    if is_tuple_t(file):
+        return (file[0], await async_read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = anyio.Path(file)
             return (path.name, await path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], await async_read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -43,6 +43,22 @@ async def test_async_tuple_input() -> None:
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
 
 
+def test_tuple_with_pathlike_content() -> None:
+    # Regression for #1769: a (name, Path) tuple used as the file content must have its Path
+    # read into bytes, not returned unchanged (which made httpx raise AttributeError on Windows).
+    result = to_httpx_files({"file": ("renamed.md", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("renamed.md", IsBytes())})
+
+
+@pytest.mark.asyncio
+async def test_async_tuple_with_pathlike_content() -> None:
+    # Async regression for #1769.
+    result = await async_to_httpx_files({"file": ("renamed.md", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("renamed.md", IsBytes())})
+
+
 def test_string_not_allowed() -> None:
     with pytest.raises(TypeError, match="Expected file types input to be a FileContent type or to be a tuple"):
         to_httpx_files(


### PR DESCRIPTION
Fixes #1769.

Check tuple inputs before generic `FileContent` inputs in `_transform_file` (and the async version).

`Path` is valid file content, but the current check order returns a `(filename, Path)` tuple without reading the inner path, so httpx later calls `.read()` on it and raises `AttributeError`.

Adds sync and async regression tests for filename + `Path` tuples.
