### PR TITLE
fix(files): read PathLike content inside (filename, content) tuples (#1769)

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -63,15 +63,19 @@ def to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles | None:
 
 
 def _transform_file(file: FileTypes) -> HttpxFileTypes:
+    # A 2/3-tuple `(filename, content[, content_type])` must be handled before the
+    # generic file-content check: `is_file_content` also matches tuples, so checking it
+    # first would return the tuple verbatim and never read a PathLike `content` — the
+    # cause of #1769 (`AttributeError: 'WindowsPath' object has no attribute 'read'`).
+    if is_tuple_t(file):
+        return (file[0], read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = pathlib.Path(file)
             return (path.name, path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 
@@ -105,15 +109,16 @@ async def async_to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles 
 
 
 async def _async_transform_file(file: FileTypes) -> HttpxFileTypes:
+    # See _transform_file: the tuple form must be handled before is_file_content (#1769).
+    if is_tuple_t(file):
+        return (file[0], await async_read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = anyio.Path(file)
             return (path.name, await path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], await async_read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -43,6 +43,22 @@ async def test_async_tuple_input() -> None:
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
 
 
+def test_tuple_with_pathlib_reads_content() -> None:
+    # Regression for #1769: `(filename, Path)` must read the Path's bytes, not pass the
+    # Path object through raw (which later fails with `'WindowsPath' object has no
+    # attribute 'read'`). The bare-Path and file-handle tuple forms already worked.
+    result = to_httpx_files({"file": ("custom_name.md", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("custom_name.md", IsBytes())})
+
+
+@pytest.mark.asyncio
+async def test_async_tuple_with_pathlib_reads_content() -> None:
+    result = await async_to_httpx_files({"file": ("custom_name.md", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("custom_name.md", IsBytes())})
+
+
 def test_string_not_allowed() -> None:
     with pytest.raises(TypeError, match="Expected file types input to be a FileContent type or to be a tuple"):
         to_httpx_files(


### PR DESCRIPTION
### Problem
`client.beta.files.upload(file=("name.pdf", Path(...)))` raises
`AttributeError: 'WindowsPath' object has no attribute 'read'`, even though the tuple form
`Tuple[Optional[str], FileContent]` (with `FileContent` including `os.PathLike`) type-checks.
A bare `Path` works; only a `Path` *inside the tuple* fails. Reported in #1769.

### Cause
In `_transform_file` / `_async_transform_file`, `is_file_content()` returns `True` for any
tuple and is checked **before** `is_tuple_t()`. So a `(filename, Path)` tuple enters the
file-content branch, fails the `isinstance(file, os.PathLike)` check, and is returned
verbatim — the `PathLike` content is never read. The `is_tuple_t` branch that routes
`file[1]` through `read_file_content` is unreachable for tuples.

### Fix
Handle the tuple form first in both the sync and async transformers. Minimal reorder; no
behavior change for any already-working input.

### Tests
Adds `test_tuple_with_pathlib_reads_content` + async counterpart. Both fail on `main`
(reproduce #1769) and pass with the fix. Full `tests/test_files.py` stays green (16 passed).
