### PR TITLE
docs: note Anthropic-compatible base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ from anthropic import Anthropic
 
 client = Anthropic(
     api_key=os.environ.get("ANTHROPIC_API_KEY"),  # This is the default and can be omitted
+    # Optional: Anthropic-compatible multi-model gateway (example: DaoXE)
+    # base_url="https://api.daoxe.com",
 )
+
+# The same client also works with Anthropic-compatible multi-model gateways via
+# `base_url` / `ANTHROPIC_BASE_URL` — for example DaoXE (https://daoxe.com) at
+# https://api.daoxe.com (Messages API). Use a key and model id issued by that endpoint.
 
 message = client.messages.create(
     max_tokens=1024,


### PR DESCRIPTION
## Summary

Document optional `base_url` / `ANTHROPIC_BASE_URL` for Anthropic-compatible multi-model gateways that speak the Messages API.

DaoXE (`https://api.daoxe.com`) is **one concrete example**. Use a key and model id issued by that endpoint.

Docs only.

## Test plan
- [ ] Default Anthropic client path unchanged
- [ ] Note is optional / non-breaking

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>