### PR TITLE
fix: update broken README anchor links in error messages to point to official docs

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -774,7 +774,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         if expected_time > default_time or (max_nonstreaming_tokens and max_tokens > max_nonstreaming_tokens):
             raise ValueError(
                 "Streaming is required for operations that may take longer than 10 minutes. "
-                + "See https://github.com/anthropics/anthropic-sdk-python#long-requests for more details",
+                + "See https://platform.claude.com/docs/en/api/sdks/python#long-running-requests for more details",
             )
         return Timeout(
             default_time,

--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -36,7 +36,7 @@ def assert_is_file_content(obj: object, *, key: str | None = None) -> None:
     if not is_file_content(obj):
         prefix = f"Expected entry at `{key}`" if key is not None else f"Expected file input `{obj!r}`"
         raise RuntimeError(
-            f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://github.com/anthropics/anthropic-sdk-python/tree/main#file-uploads"
+            f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://platform.claude.com/docs/en/api/sdks/python#file-uploads"
         ) from None
 
 


### PR DESCRIPTION
## Problem

Two error messages in the SDK reference README anchor links that no longer exist:

1. **`_base_client.py:777`** — When a user hits the streaming requirement for long-running requests, the `ValueError` message links to `github.com/anthropics/anthropic-sdk-python#long-requests`
2. **`_files.py:39`** — When a user passes an invalid file type, the `RuntimeError` message links to `github.com/anthropics/anthropic-sdk-python/tree/main#file-uploads`

The current README only contains these sections: `Documentation`, `Installation`, `Getting started`, `Requirements`, `Contributing`, and `License`. Neither `#long-requests` nor `#file-uploads` anchors exist, so users who follow these links from error tracebacks land at the top of the README with no useful context.

## Fix

Updated both links to point to the official SDK documentation at `platform.claude.com/docs/en/api/sdks/python` where the relevant information about streaming requirements and file upload formats actually lives.

## Files Changed

- `src/anthropic/_base_client.py` — Updated broken `#long-requests` anchor
- `src/anthropic/_files.py` — Updated broken `#file-uploads` anchor