### PR TITLE
fix(streaming): resolve unchecked content block index and type safety issues

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -469,18 +469,18 @@ def accumulate_event(
     if current_snapshot is None:
         if event.type == "message_start":
             return cast(
-                ParsedBetaMessage[ResponseFormatT], ParsedBetaMessage.construct(**cast(Any, event.message.to_dict()))
+                ParsedBetaMessage[ResponseFormatT],
+                construct_type(type_=ParsedBetaMessage, value=event.message.to_dict()),
             )
 
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')
 
     if event.type == "content_block_start":
-        # TODO: check index
-        current_snapshot.content.append(
-            cast(
-                Any,  # Pydantic does not support generic unions at runtime
-                construct_type(type_=ParsedBetaContentBlock, value=event.content_block.to_dict()),
-            ),
+        while len(current_snapshot.content) <= event.index:
+            current_snapshot.content.append(None)  # type: ignore[arg-type]
+        current_snapshot.content[event.index] = cast(
+            Any,  # Pydantic does not support generic unions at runtime
+            construct_type(type_=ParsedBetaContentBlock, value=event.content_block.to_dict()),
         )
         if event.content_block.type == "fallback":
             # the final hop's fallback block names the model that served the response —

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -449,17 +449,19 @@ def accumulate_event(
 
     if current_snapshot is None:
         if event.type == "message_start":
-            return cast(ParsedMessage[ResponseFormatT], ParsedMessage.construct(**cast(Any, event.message.to_dict())))
+            return cast(
+                ParsedMessage[ResponseFormatT],
+                construct_type(type_=ParsedMessage, value=event.message.to_dict()),
+            )
 
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')
 
     if event.type == "content_block_start":
-        # TODO: check index
-        current_snapshot.content.append(
-            cast(
-                Any,  # Pydantic does not support generic unions at runtime
-                construct_type(type_=ParsedContentBlock, value=event.content_block.model_dump()),
-            ),
+        while len(current_snapshot.content) <= event.index:
+            current_snapshot.content.append(None)  # type: ignore[arg-type]
+        current_snapshot.content[event.index] = cast(
+            Any,  # Pydantic does not support generic unions at runtime
+            construct_type(type_=ParsedContentBlock, value=event.content_block.model_dump()),
         )
     elif event.type == "content_block_delta":
         content = current_snapshot.content[event.index]


### PR DESCRIPTION
## Summary
This PR addresses two critical bugs in the streaming message parser (`_messages.py` and `_beta_messages.py`) that can cause runtime crashes or data corruption.

### 1. Missing Content Block Index Validation
The parser previously had a `# TODO: check index` comment and blindly appended new blocks on `content_block_start`. If events arrived out of order or an index was skipped, the subsequent `content_block_delta` would either overwrite the wrong block or crash with an `IndexError`. This PR correctly pads the list up to `event.index` before inserting the block.

### 2. `construct()` Bypassing Type Validation
The snapshot initialization used Pydantic`s `construct(**event.message.to_dict())`. Because `construct()` skips validation and deep coercion, nested fields like `usage` were left as raw Python dictionaries rather than Pydantic objects. When a subsequent usage delta arrived, `current_snapshot.usage.output_tokens = ...` would crash with `AttributeError: 'dict' object has no attribute 'output_tokens'`. This PR fixes it by using `construct_type(type_=...)`, ensuring correct instantiation of nested models.