### PR TITLE
fix(client): remove unsafe `__del__` method from AsyncHttpxClientWrapper

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -1706,15 +1706,8 @@ else:
 
 
 class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
-    def __del__(self) -> None:
-        if self.is_closed:
-            return
+    pass
 
-        try:
-            # TODO(someday): support non asyncio runtimes here
-            asyncio.get_running_loop().create_task(self.aclose())
-        except Exception:
-            pass
 
 
 class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):


### PR DESCRIPTION
## Summary
The `__del__` method in `AsyncHttpxClientWrapper` was attempting to close the client by calling `asyncio.get_running_loop().create_task(self.aclose())`.

Since garbage collection can run on any thread at any time, this approach is fundamentally unsafe in Python asyncio:
1. If it triggers in a background thread without an event loop, it throws a `RuntimeError` (which is swallowed) and leaks the connection without warning.
2. If it does manage to find an event loop from another thread, calling `create_task` is thread-unsafe and can corrupt the entire async loop.

This PR removes the unsafe `__del__` method. The connection lifecycle should be managed explicitly by the consumer (via `async with` or explicit `.close()`).