### PR TITLE
fix(streaming): accumulate container from message_delta in non-beta helper

### DIFF
--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -501,6 +501,7 @@ def accumulate_event(
         if content_block.type == "text" and is_given(output_format):
             content_block.parsed_output = parse_text(content_block.text, output_format)
     elif event.type == "message_delta":
+        current_snapshot.container = event.delta.container
         current_snapshot.stop_reason = event.delta.stop_reason
         current_snapshot.stop_sequence = event.delta.stop_sequence
         if event.delta.stop_details is not None:

--- a/tests/lib/streaming/fixtures/container_response.txt
+++ b/tests/lib/streaming/fixtures/container_response.txt
@@ -1,0 +1,26 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_4QpJur2dWWDjF6C758FbBw5vm12BaVipnK","type":"message","role":"assistant","content":[],"model":"claude-3-opus-latest","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" there"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"!"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"container":{"id":"container_011CPmr789A6Pg7Rjhvi6cvJ","expires_at":"2026-08-05T12:00:00Z"}},"usage":{"output_tokens":6}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/tests/lib/streaming/test_messages.py
+++ b/tests/lib/streaming/test_messages.py
@@ -115,6 +115,27 @@ def assert_refusal_response(message: Message) -> None:
 
 class TestSyncMessages:
     @pytest.mark.respx(base_url=base_url)
+    def test_container_accumulated_from_message_delta(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=get_response("container_response.txt"))
+        )
+
+        with sync_client.messages.stream(
+            max_tokens=1024,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Say hello there!",
+                }
+            ],
+            model="claude-3-opus-latest",
+        ) as stream:
+            message = stream.get_final_message()
+
+        assert message.container is not None
+        assert message.container.id == "container_011CPmr789A6Pg7Rjhvi6cvJ"
+
+    @pytest.mark.respx(base_url=base_url)
     def test_basic_response(self, respx_mock: MockRouter) -> None:
         respx_mock.post("/v1/messages").mock(
             return_value=httpx.Response(200, content=get_response("basic_response.txt"))


### PR DESCRIPTION
## What

The non-beta streaming accumulator (`lib/streaming/_messages.py`) does not copy `event.delta.container` into the message snapshot, while the beta accumulator (`lib/streaming/_beta_messages.py`) does. As a result, a final message built by `client.messages.stream()` always has `container=None`, even when the server delivers the id on `message_delta` — breaking code-execution container reuse for non-beta streaming users (the id is needed as the `container` request parameter on follow-up requests).

This PR mirrors the beta accumulator's line into the non-beta `accumulate_event`, plus a fixture + test asserting the accumulated message carries the container id.

## Test

`tests/lib/streaming/test_messages.py` — new `test_container_accumulated_from_message_delta` using a fixture whose `message_delta` carries a `container` object; full file passes (14/14).

## Related

Found while investigating #1801 (server-side: the pause-for-client-tool response omits `container` entirely). This PR is the independent client-side half: even when the server does send the id, the non-beta helper drops it.