### PR TITLE
fix: cap overflowing retry backoff

### DIFF
--- a/src/anthropic/lib/_retry.py
+++ b/src/anthropic/lib/_retry.py
@@ -31,7 +31,11 @@ _RETRYABLE_4XX = frozenset({408, 409, 429})
 
 def backoff(attempt: int, *, cap: float, base: float = 2.0) -> float:
     """Exponential backoff for ``attempt`` (1-indexed), capped at ``cap``."""
-    return min(cap, base**attempt)
+    try:
+        delay = base**attempt
+    except OverflowError:
+        return cap
+    return min(cap, delay)
 
 
 def jitter(low: float, high: float) -> float:

--- a/tests/lib/environments/test_poller.py
+++ b/tests/lib/environments/test_poller.py
@@ -11,6 +11,7 @@ from anthropic.lib.environments._poller import _jitter, _backoff
         ("first failure backs off two seconds", 1, 2.0),
         ("second failure doubles to four seconds", 2, 4.0),
         ("very large attempt is capped at sixty seconds", 100, 60.0),
+        ("overflowing attempt is capped at sixty seconds", 1024, 60.0),
     ],
 )
 def test_backoff(description: str, attempt: int, want: float) -> None:


### PR DESCRIPTION
Fixes #1760

## Summary

- return the configured cap when exponential backoff overflows
- add regression coverage for the 1024th consecutive retry attempt

## Tests

- `uv run pytest tests/lib/environments/test_poller.py -n0` (5 passed)
- `./scripts/lint` (Ruff, Pyright, mypy, and import check passed)
