### PR TITLE
fix: avoid platform subprocess during OS detection

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -2436,7 +2436,9 @@ Platform = Union[
 def get_platform() -> Platform:
     try:
         system = platform.system().lower()
-        platform_name = platform.platform().lower()
+        platform_name = "-".join(
+            part.lower() for part in (system, platform.release(), platform.version(), platform.machine()) if part
+        )
     except Exception:
         return "Unknown"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2300,6 +2300,27 @@ class TestAsyncAnthropic:
         platform = await asyncify(get_platform)()
         assert isinstance(platform, (str, OtherPlatform))
 
+    @pytest.mark.parametrize(
+        ("system", "release", "machine", "expected"),
+        [
+            ("Darwin", "25.5.0", "arm64", "MacOS"),
+            ("Darwin", "21.6.0", "iPhone12,1", "iOS"),
+            ("Linux", "5.10.81-android12", "aarch64", "Android"),
+        ],
+    )
+    async def test_get_platform_does_not_call_platform_platform(
+        self, monkeypatch: pytest.MonkeyPatch, system: str, release: str, machine: str, expected: str
+    ) -> None:
+        monkeypatch.setattr("anthropic._base_client.platform.system", lambda: system)
+        monkeypatch.setattr("anthropic._base_client.platform.release", lambda: release)
+        monkeypatch.setattr("anthropic._base_client.platform.version", lambda: "")
+        monkeypatch.setattr("anthropic._base_client.platform.machine", lambda: machine)
+        platform_mock = mock.Mock(side_effect=AssertionError("platform.platform() must not be called"))
+        monkeypatch.setattr("anthropic._base_client.platform.platform", platform_mock)
+
+        assert await asyncify(get_platform)() == expected
+        platform_mock.assert_not_called()
+
     async def test_proxy_environment_variables(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Test that the proxy environment variables are set correctly
         monkeypatch.setenv("HTTPS_PROXY", "https://example.org")


### PR DESCRIPTION
Fixes #1762

## Summary

- replace `platform.platform()` with fork-free system, release, version, and machine queries
- preserve macOS, iOS, and Android platform detection without resolving the lazy processor field
- add regression coverage that fails if `platform.platform()` is called

## Tests

- `uv run pytest -n0 tests/test_client.py` (185 passed)
- `uv run ruff check src/anthropic/_base_client.py tests/test_client.py`
- `uv run ruff format --check src/anthropic/_base_client.py tests/test_client.py`
- `uv run pyright src/anthropic/_base_client.py tests/test_client.py`
- `./scripts/lint`
