### PR TITLE
fix: allow null caller in tool use params

### DIFF
--- a/src/anthropic/types/beta/beta_tool_use_block_param.py
+++ b/src/anthropic/types/beta/beta_tool_use_block_param.py
@@ -27,5 +27,5 @@ class BetaToolUseBlockParam(TypedDict, total=False):
     cache_control: Optional[BetaCacheControlEphemeralParam]
     """Create a cache control breakpoint at this content block."""
 
-    caller: Caller
+    caller: Optional[Caller]
     """Tool invocation directly from the model."""

--- a/src/anthropic/types/tool_use_block_param.py
+++ b/src/anthropic/types/tool_use_block_param.py
@@ -27,5 +27,5 @@ class ToolUseBlockParam(TypedDict, total=False):
     cache_control: Optional[CacheControlEphemeralParam]
     """Create a cache control breakpoint at this content block."""
 
-    caller: Caller
+    caller: Optional[Caller]
     """Tool invocation directly from the model."""

--- a/tests/test_tool_use_types.py
+++ b/tests/test_tool_use_types.py
@@ -1,0 +1,16 @@
+from anthropic.types import ToolUseBlockParam
+from anthropic.types.beta import BetaToolUseBlockParam
+
+
+def test_tool_use_block_params_allow_null_caller() -> None:
+    tool_use: ToolUseBlockParam = {"id": "id", "input": {}, "name": "tool", "type": "tool_use", "caller": None}
+    beta_tool_use: BetaToolUseBlockParam = {
+        "id": "id",
+        "input": {},
+        "name": "tool",
+        "type": "tool_use",
+        "caller": None,
+    }
+
+    assert tool_use["caller"] is None
+    assert beta_tool_use["caller"] is None


### PR DESCRIPTION
Fixes #1454

`ToolUseBlock` can contain `caller=None`, but the corresponding request parameter types rejected that value. This makes `caller` optional in both the stable and beta parameter types and adds a typechecked regression test for converting nullable tool-use blocks.

Tests:
- `uv run ruff check src/anthropic/types/tool_use_block_param.py src/anthropic/types/beta/beta_tool_use_block_param.py tests/test_tool_use_types.py`
- `uv run pytest tests/test_tool_use_types.py`
- `uv run pyright tests/test_tool_use_types.py src/anthropic/types/tool_use_block_param.py src/anthropic/types/beta/beta_tool_use_block_param.py`
