### PR TITLE
fix(parse): reject unrepresentable dynamic object schemas

### DIFF
--- a/src/anthropic/lib/_parse/_transform.py
+++ b/src/anthropic/lib/_parse/_transform.py
@@ -126,8 +126,20 @@ def transform_schema(
         strict_schema["title"] = title
 
     if type_ == "object":
+        properties = cast("dict[str, dict[str, Any]] | None", json_schema.pop("properties", None))
+        dynamic_key_keywords = [
+            keyword
+            for keyword in ("patternProperties", "propertyNames", "unevaluatedProperties")
+            if keyword in json_schema
+        ]
+        if not properties and dynamic_key_keywords:
+            keywords = ", ".join(dynamic_key_keywords)
+            raise ValueError(
+                f"Object schemas using {keywords} without explicit properties cannot be represented by the API"
+            )
+
         strict_schema["properties"] = {
-            key: transform_schema(prop_schema) for key, prop_schema in json_schema.pop("properties", {}).items()
+            key: transform_schema(prop_schema) for key, prop_schema in (properties or {}).items()
         }
         json_schema.pop("additionalProperties", None)
         strict_schema["additionalProperties"] = False

--- a/src/anthropic/lib/_parse/_transform.py
+++ b/src/anthropic/lib/_parse/_transform.py
@@ -126,13 +126,14 @@ def transform_schema(
         strict_schema["title"] = title
 
     if type_ == "object":
+        properties_present = "properties" in json_schema
         properties = cast("dict[str, dict[str, Any]] | None", json_schema.pop("properties", None))
         dynamic_key_keywords = [
             keyword
             for keyword in ("patternProperties", "propertyNames", "unevaluatedProperties")
             if keyword in json_schema
         ]
-        if not properties and dynamic_key_keywords:
+        if not properties_present and dynamic_key_keywords:
             keywords = ", ".join(dynamic_key_keywords)
             raise ValueError(
                 f"Object schemas using {keywords} without explicit properties cannot be represented by the API"

--- a/tests/lib/_parse/test_transform.py
+++ b/tests/lib/_parse/test_transform.py
@@ -124,6 +124,40 @@ def test_object_schema():
     )
 
 
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
+        ("patternProperties", {"^S_": {"type": "string"}}),
+        ("propertyNames", {"type": "string"}),
+        ("unevaluatedProperties", {"type": "string"}),
+    ],
+)
+def test_object_schema_with_dynamic_keys_is_not_silently_emptied(keyword, value):
+    schema = {"type": "object", keyword: value}
+
+    with pytest.raises(ValueError, match=keyword):
+        transform_schema(schema)
+
+
+def test_object_schema_with_explicit_properties_keeps_dynamic_key_constraints_as_description():
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "patternProperties": {"^S_": {"type": "string"}},
+    }
+
+    result = transform_schema(schema)
+
+    assert result == snapshot(
+        {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "additionalProperties": False,
+            "description": "{patternProperties: {'^S_': {'type': 'string'}}}",
+        }
+    )
+
+
 def test_array_schema():
     schema = {
         "type": "array",

--- a/tests/lib/_parse/test_transform.py
+++ b/tests/lib/_parse/test_transform.py
@@ -158,6 +158,25 @@ def test_object_schema_with_explicit_properties_keeps_dynamic_key_constraints_as
     )
 
 
+def test_object_schema_with_empty_explicit_properties_keeps_dynamic_key_constraints_as_description():
+    schema = {
+        "type": "object",
+        "properties": {},
+        "patternProperties": {"^S_": {"type": "string"}},
+    }
+
+    result = transform_schema(schema)
+
+    assert result == snapshot(
+        {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+            "description": "{patternProperties: {'^S_': {'type': 'string'}}}",
+        }
+    )
+
+
 def test_array_schema():
     schema = {
         "type": "array",


### PR DESCRIPTION
## Summary

Fixes #1817.

When an object schema uses `patternProperties`, `propertyNames`, or `unevaluatedProperties` without explicit `properties`, the structured-output schema transformer previously discarded the dynamic-key rule and emitted an object with no properties and `additionalProperties: false`. That silently made every non-empty value invalid.

This change raises a clear `ValueError` for those unrepresentable shapes instead of sending an unsatisfiable schema. Objects that explicitly provide `properties`, including an empty mapping, keep their existing behavior; unsupported dynamic-key constraints remain in the description as before.

## Tests

- `UV_PYTHON='>=3.9,<3.10' ./scripts/test tests/lib/_parse/test_transform.py`
  - Pydantic v2: 19 passed
  - Pydantic v1: 19 passed
  - MCP v2: skipped because MCP 2 requires Python 3.10+
- `UV_PYTHON='>=3.10,<3.11' ./scripts/test tests/lib/_parse/test_transform.py`
  - Pydantic v2: 19 passed
  - Pydantic v1: 19 passed
  - MCP v2: 39 passed
- `uv run pyright src/anthropic/lib/_parse/_transform.py`: 0 errors
- `uv run ruff check src/anthropic/lib/_parse/_transform.py tests/lib/_parse/test_transform.py`: passed
- `uv run ruff format --check src/anthropic/lib/_parse/_transform.py tests/lib/_parse/test_transform.py`: passed

AI assistance was used to investigate the issue, prepare the patch, and run the checks.