### PR TITLE
fix(files): skip recursive directory symlinks

### DIFF
--- a/src/anthropic/lib/_files.py
+++ b/src/anthropic/lib/_files.py
@@ -18,6 +18,8 @@ def files_from_dir(directory: str | os.PathLike[str]) -> list[FileTypes]:
 
 def _collect_files(directory: Path, relative_to: Path, files: list[FileTypes]) -> None:
     for path in directory.iterdir():
+        if path.is_symlink() and path.is_dir():
+            continue
         if path.is_dir():
             _collect_files(path, relative_to, files)
             continue
@@ -35,6 +37,8 @@ async def async_files_from_dir(directory: str | os.PathLike[str]) -> list[FileTy
 
 async def _async_collect_files(directory: anyio.Path, relative_to: anyio.Path, files: list[FileTypes]) -> None:
     async for path in directory.iterdir():
+        if await path.is_symlink() and await path.is_dir():
+            continue
         if await path.is_dir():
             await _async_collect_files(path, relative_to, files)
             continue

--- a/tests/lib/test_files.py
+++ b/tests/lib/test_files.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import pytest
+
+from anthropic.lib import files_from_dir, async_files_from_dir
+
+
+def _create_directory_tree_with_symlink(root: Path, target: Path) -> None:
+    (root / "included.txt").write_text("included")
+    (root / "linked-directory").symlink_to(target, target_is_directory=True)
+
+
+def test_files_from_dir_does_not_follow_directory_symlinks(tmp_path: Path) -> None:
+    root = tmp_path / "upload"
+    root.mkdir()
+    _create_directory_tree_with_symlink(root, root)
+
+    assert files_from_dir(root) == [("upload/included.txt", b"included")]
+
+
+@pytest.mark.asyncio
+async def test_async_files_from_dir_does_not_follow_directory_symlinks(tmp_path: Path) -> None:
+    root = tmp_path / "upload"
+    root.mkdir()
+    _create_directory_tree_with_symlink(root, root)
+
+    assert await async_files_from_dir(root) == [("upload/included.txt", b"included")]


### PR DESCRIPTION
## What

- skip directory symlinks in both `files_from_dir()` and `async_files_from_dir()`
- add sync and async regression tests using a self-referential directory link
- preserve the existing behavior for regular files and file symlinks

## Why

Both directory helpers currently call `is_dir()` before recursing, which follows symlinks. A self-referential link therefore crashes with `OSError: Too many levels of symbolic links`; a link to another directory also expands the upload beyond the directory tree the caller selected.

This is a deliberately narrow follow-up to the maintainer feedback on #1066: it is based on current `main`, retains the current path formatting, and does not add unrelated streaming APIs or change file-symlink behavior.

## Impact

Real directories continue to be traversed. Directory symlinks are omitted, preventing recursive cycles and out-of-tree directory expansion in both public helpers.

## Checks

- `uv run pytest tests/lib/test_files.py -n0` (2 passed)
- `uv run ruff check src/anthropic/lib/_files.py tests/lib/test_files.py`
- `uv run ruff format --check src/anthropic/lib/_files.py tests/lib/test_files.py`
- `uv run mypy src/anthropic/lib/_files.py`
- `uv sync --all-extras && ./scripts/lint` (Ruff, dependency caps, Pyright, mypy over 1127 files, and import smoke test passed)