### PR TITLE
fix(streaming): accumulate compaction delta content

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -529,7 +529,7 @@ def accumulate_event(
                 content.signature = event.delta.signature
         elif event.delta.type == "compaction_delta":
             if content.type == "compaction":
-                content.content = event.delta.content
+                content.content = (content.content or "") + (event.delta.content or "")
                 content.encrypted_content = event.delta.encrypted_content
         else:
             # we only want exhaustive checking for linters, not at runtime

--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -529,7 +529,8 @@ def accumulate_event(
                 content.signature = event.delta.signature
         elif event.delta.type == "compaction_delta":
             if content.type == "compaction":
-                content.content = (content.content or "") + (event.delta.content or "")
+                if event.delta.content is not None:
+                    content.content = (content.content or "") + event.delta.content
                 content.encrypted_content = event.delta.encrypted_content
         else:
             # we only want exhaustive checking for linters, not at runtime

--- a/tests/lib/streaming/fixtures/compaction_multi_delta_response.txt
+++ b/tests/lib/streaming/fixtures/compaction_multi_delta_response.txt
@@ -1,0 +1,29 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01CompactionMultiDelta0001","type":"message","role":"assistant","content":[],"model":"claude-opus-4-7","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":30,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"compaction","content":null,"encrypted_content":null}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"compaction_delta","content":"Earlier conversation ","encrypted_content":"EpwBCioIDxgCEAEYASJALd_opaque_chunk_one"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"compaction_delta","content":"summarized in full.","encrypted_content":"EpwBCioIDxgCEAEYASJALd_opaque_chunk_two"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hello there!"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":8}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/tests/lib/streaming/test_beta_messages.py
+++ b/tests/lib/streaming/test_beta_messages.py
@@ -190,6 +190,40 @@ EXPECTED_COMPACTION_EVENT_TYPES = [
     "message_delta",
 ]
 
+# A compaction summary long enough to be split across more than one `compaction_delta`
+# event, the way `text_delta`/`thinking_delta` are chunked for any other long content.
+EXPECTED_COMPACTION_MULTI_DELTA_MESSAGE = {
+    "id": "msg_01CompactionMultiDelta0001",
+    "model": "claude-opus-4-7",
+    "role": "assistant",
+    "stop_reason": "end_turn",
+    "type": "message",
+    "content": [
+        {
+            "type": "compaction",
+            "content": "Earlier conversation summarized in full.",
+            "encrypted_content": "EpwBCioIDxgCEAEYASJALd_opaque_chunk_two",
+        },
+        {"type": "text", "text": "Hello there!"},
+    ],
+    "usage": {"input_tokens": 30, "output_tokens": 8},
+}
+
+EXPECTED_COMPACTION_MULTI_DELTA_EVENT_TYPES = [
+    "message_start",
+    "content_block_start",
+    "content_block_delta",
+    "compaction",
+    "content_block_delta",
+    "compaction",
+    "content_block_stop",
+    "content_block_start",
+    "content_block_delta",
+    "text",
+    "content_block_stop",
+    "message_delta",
+]
+
 
 def assert_message_matches(message: BetaMessage, expected: Dict[str, Any]) -> None:
     actual_message_json = message.model_dump_json(
@@ -224,6 +258,29 @@ def assert_compaction_response(events: list[ParsedBetaMessageStreamEvent], messa
     compaction_events = [e for e in events if isinstance(e, BetaCompactionEvent)]
     assert len(compaction_events) == 1
     assert compaction_events[0].encrypted_content == "EpwBCioIDxgCEAEYASJALd_opaque_compaction_payload"
+
+
+def assert_compaction_multi_delta_response(events: list[ParsedBetaMessageStreamEvent], message: BetaMessage) -> None:
+    assert_message_matches(message, EXPECTED_COMPACTION_MULTI_DELTA_MESSAGE)
+    assert [e.type for e in events] == EXPECTED_COMPACTION_MULTI_DELTA_EVENT_TYPES
+
+    # every `compaction_delta` chunk must be concatenated onto the block's `content`, not
+    # replace it outright -- each successive event's snapshot should keep growing, mirroring
+    # how `text`/`thinking` events expose a running snapshot rather than just the latest delta
+    compaction_events = [e for e in events if isinstance(e, BetaCompactionEvent)]
+    assert len(compaction_events) == 2
+    assert compaction_events[0].content == "Earlier conversation "
+    assert compaction_events[1].content == "Earlier conversation summarized in full."
+
+    # `encrypted_content` is an opaque, self-contained checkpoint from the server rather than
+    # text to be concatenated, so the most recent delta's value should win outright
+    assert compaction_events[0].encrypted_content == "EpwBCioIDxgCEAEYASJALd_opaque_chunk_one"
+    assert compaction_events[1].encrypted_content == "EpwBCioIDxgCEAEYASJALd_opaque_chunk_two"
+
+    final_block = message.content[0]
+    assert final_block.type == "compaction"
+    assert final_block.content == "Earlier conversation summarized in full."
+    assert final_block.encrypted_content == "EpwBCioIDxgCEAEYASJALd_opaque_chunk_two"
 
 
 def assert_refusal_response(message: BetaMessage) -> None:
@@ -365,6 +422,21 @@ class TestSyncMessages:
             assert isinstance(cast(Any, stream), BetaMessageStream)
 
             assert_compaction_response([event for event in stream], stream.get_final_message())
+
+    @pytest.mark.respx(base_url=base_url)
+    def test_compaction_multi_delta(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=get_response("compaction_multi_delta_response.txt"))
+        )
+
+        with sync_client.beta.messages.stream(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Say hello there!"}],
+            model="claude-opus-4-7",
+        ) as stream:
+            assert isinstance(cast(Any, stream), BetaMessageStream)
+
+            assert_compaction_multi_delta_response([event for event in stream], stream.get_final_message())
 
     @pytest.mark.respx(base_url=base_url)
     def test_fallback_relabels_model(self, respx_mock: MockRouter) -> None:
@@ -518,6 +590,22 @@ class TestAsyncMessages:
             assert isinstance(cast(Any, stream), BetaAsyncMessageStream)
 
             assert_compaction_response([event async for event in stream], await stream.get_final_message())
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx(base_url=base_url)
+    async def test_compaction_multi_delta(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=to_async_iter(get_response("compaction_multi_delta_response.txt")))
+        )
+
+        async with async_client.beta.messages.stream(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Say hello there!"}],
+            model="claude-opus-4-7",
+        ) as stream:
+            assert isinstance(cast(Any, stream), BetaAsyncMessageStream)
+
+            assert_compaction_multi_delta_response([event async for event in stream], await stream.get_final_message())
 
     @pytest.mark.asyncio
     @pytest.mark.respx(base_url=base_url)


### PR DESCRIPTION
## Summary

`compaction_delta` content was being overwritten rather than accumulated in the beta streaming accumulator. When a compaction summary is delivered across multiple `compaction_delta` events, earlier chunks are silently discarded from the accumulated message and event snapshots.

This PR fixes that by accumulating `content` across successive deltas, consistent with the existing `text_delta` and `thinking_delta` handling and the behavior of the TypeScript SDK.

`encrypted_content` intentionally retains overwrite semantics because it is an opaque, self-contained server checkpoint rather than text that should be concatenated.

## Regression coverage

Added a two-chunk SSE fixture and regression coverage for both synchronous and asynchronous beta message streaming.

The tests verify:

- the first compaction snapshot contains the first chunk;
- the second snapshot contains the concatenated content;
- the final message contains the complete summary;
- `encrypted_content` advances to the latest server-provided value.

## Validation

- `uv run pytest tests/lib/streaming/test_beta_messages.py -q` → 24 passed
- `uv run pytest tests/lib/streaming -q` → 42 passed
- `uv run ruff check .` → all checks passed
- `uv run ruff format --check .` reports four unrelated pre-existing files requiring formatting; none are touched by this PR.

Related prior art: #1665 identified the same compaction accumulation issue. This PR intentionally isolates that still-unmerged fix and does not include the unrelated GA JSON parsing change from that PR.