### PR TITLE
fix(session-runner): bound the reconnect reconcile so a long or wrapping history cannot wedge the runner

### DIFF
--- a/src/anthropic/lib/tools/_beta_session_runner.py
+++ b/src/anthropic/lib/tools/_beta_session_runner.py
@@ -22,14 +22,17 @@ import math
 import time
 import logging
 import contextlib
-from typing import TYPE_CHECKING, Union, Literal, cast
+from typing import TYPE_CHECKING, Any, Dict, Union, Literal, Optional, cast
+from datetime import datetime, timedelta
 from dataclasses import dataclass
 from collections.abc import Sequence, AsyncIterator
 
 import anyio
+import anyio.abc
 
 from .._retry import TRANSIENT_ERRORS, is_fatal_status_error
 from ..._types import Headers
+from ..._streaming import AsyncStream
 from ._tool_dispatch import tool_registry, run_runnable_tool, tool_error_content
 from .._scoped_client import _copy_client_with_bearer_auth
 from ._beta_functions import (
@@ -42,6 +45,7 @@ from ._beta_functions import (
 from .._stainless_helpers import helper_header
 from ...types.beta.sessions import (
     BetaManagedAgentsAgentToolUseEvent,
+    BetaManagedAgentsStreamSessionEvents,
     BetaManagedAgentsAgentCustomToolUseEvent,
     BetaManagedAgentsUserToolConfirmationEvent,
 )
@@ -106,6 +110,16 @@ MANAGED_AGENTS_BETA = "managed-agents-2026-04-01"
 
 STREAM_BACKOFF_START = 0.5
 STREAM_BACKOFF_CAP = 10.0
+# After the first complete history read, a reconnect only re-reads events at or
+# after the newest ``processed_at`` already seen, minus this allowance for
+# events stamped slightly out of order around the disconnect. Everything older
+# was already accounted for in memory (``_seen``/``_answered``/``_confirmations``).
+RECONCILE_WINDOW_SKEW = timedelta(seconds=30)
+# On a reconnect the windowed history read normally finishes well inside this
+# budget and is applied before any live event, exactly as on first attach. A
+# read that takes longer keeps running, but the live stream is consumed
+# alongside it instead of waiting behind it indefinitely.
+RECONCILE_ATTACH_BUDGET = 10.0
 # Outer per-tool-call timeout. This MUST stay strictly greater than the bash
 # tool's own ``agent_toolset.BASH_DEFAULT_TIMEOUT`` (120s). The bash tool wraps
 # its read in its own ``anyio.fail_after(BASH_DEFAULT_TIMEOUT)`` and, on
@@ -479,6 +493,12 @@ class SessionToolRunner:
         # actually landed, so a failed post is retried on the next reconcile.
         self._seen: set[str] = set()
         self._answered: set[str] = set()
+        # Newest ``processed_at`` observed on any event, and whether one full
+        # history read has completed. Together they let every reconcile after
+        # the first read only the window a disconnect could have hidden.
+        self._newest_processed_at: Optional[datetime] = None
+        self._history_complete = False
+        self._reconciling: Optional[anyio.Event] = None
         # Confirmation gating (``always_ask`` tools): ``_confirmations`` records
         # every ``user.tool_confirmation`` verdict by ``tool_use_id``;
         # ``_awaiting_confirmation`` holds the tool-call events whose
@@ -512,6 +532,7 @@ class SessionToolRunner:
             # consumer as ``Cancelled``.
             with anyio.CancelScope():
                 async with anyio.create_task_group() as tg:
+                    self._task_group: anyio.abc.TaskGroup = tg
                     # The stop watcher closes ``_send_work`` when ``_stop`` is
                     # set so the dispatch loop's ``receive()`` raises
                     # EndOfStream and the loop exits cleanly without us having
@@ -561,8 +582,27 @@ class SessionToolRunner:
         pending: list[DispatchedToolUseEvent] = []
         last_was_end_turn = False
         list_failed = False
+        # First pass: the whole history. Later passes: only the window since
+        # the newest event already seen — the rest is already reflected in
+        # ``_seen``/``_answered``/``_confirmations``, and re-reading it made
+        # every reconnect cost the full history.
+        window: Dict[str, Any] = {}
+        if self._history_complete and self._newest_processed_at is not None:
+            window["created_at_gte"] = self._newest_processed_at - RECONCILE_WINDOW_SKEW
+        ids_this_pass: set[str] = set()
         try:
-            async for ev in self._events.list(self.session_id, limit=1000, extra_headers=self.extra_headers):
+            async for ev in self._events.list(self.session_id, limit=1000, extra_headers=self.extra_headers, **window):
+                # A listing whose pages wrap around would otherwise never end,
+                # and this pass runs where nothing else can proceed until it
+                # does. An id repeating within one pass means every reachable
+                # page has been read: stop and work with the complete set.
+                ev_id = getattr(ev, "id", None)
+                if isinstance(ev_id, str):
+                    if ev_id in ids_this_pass:
+                        log.warning("reconcile listing repeated event %s; treating history as complete", ev_id)
+                        break
+                    ids_this_pass.add(ev_id)
+                self._note_processed_at(ev)
                 if ev.type == "agent.tool_use" or ev.type == "agent.custom_tool_use":
                     # Mark the event seen so the live stream doesn't re-enqueue it, but
                     # decide whether it still needs executing from ``_answered``, not
@@ -603,6 +643,7 @@ class SessionToolRunner:
             for ev in pending:
                 self._seen.discard(ev.id)
             return
+        self._history_complete = True
         unanswered = [ev for ev in pending if ev.id not in self._answered]
         # Disarm before routing: enqueuing below can block on a full work
         # buffer while the clock may still be armed from before the reconnect.
@@ -637,28 +678,22 @@ class SessionToolRunner:
                 # and the attach is delivered live instead of lost. ``_seen``
                 # dedups any overlap between the history and the live stream.
                 async with await self._events.stream(self.session_id, extra_headers=self.extra_headers) as stream:
-                    await self._reconcile()
-                    async for ev in stream:
-                        backoff = STREAM_BACKOFF_START
-                        # Arm/disarm the idle clock: an ``end_turn`` idle starts
-                        # the grace countdown, any other event cancels it. The
-                        # clock itself defers the countdown while gated calls
-                        # are held or in flight (see ``_IdleClock.hold``).
-                        self._idle_clock.note_event(ev)
-                        if ev.type == "agent.tool_use" or ev.type == "agent.custom_tool_use":
-                            if ev.id not in self._seen:
-                                self._seen.add(ev.id)
-                                await self._route_tool_event(ev)
-                        elif ev.type == "user.tool_result":
-                            self._answered.add(ev.tool_use_id)
-                        elif ev.type == "user.custom_tool_result":
-                            self._answered.add(ev.custom_tool_use_id)
-                        elif ev.type == "user.tool_confirmation":
-                            await self._note_confirmation(ev)
-                        elif ev.type in ("session.status_terminated", "session.deleted"):
-                            log.info("session terminated")
-                            self._stop.set()
-                            return
+                    backoff = STREAM_BACKOFF_START
+                    if self._history_complete:
+                        # A reconnect: what a disconnect can have hidden is a
+                        # small window and ``_answered`` is already complete.
+                        # Apply it before live events when it is quick, but
+                        # never hold the live stream behind a slow read.
+                        reconciled = self._start_background_reconcile()
+                        with anyio.move_on_after(RECONCILE_ATTACH_BUDGET):
+                            await reconciled.wait()
+                    else:
+                        # First attach: nothing may dispatch until the whole
+                        # history says which calls are already answered.
+                        await self._reconcile()
+                    await self._consume_stream(stream)
+                    if self._stop.is_set():
+                        return
             except TRANSIENT_ERRORS as e:
                 if self._stop.is_set():
                     return
@@ -672,6 +707,59 @@ class SessionToolRunner:
             with anyio.move_on_after(backoff):
                 await self._stop.wait()
             backoff = min(backoff * 2, STREAM_BACKOFF_CAP)
+
+    async def _consume_stream(self, stream: AsyncStream[BetaManagedAgentsStreamSessionEvents]) -> None:
+        """Route live events until the stream ends or the session terminates."""
+        async for ev in stream:
+            self._note_processed_at(ev)
+            # Arm/disarm the idle clock: an ``end_turn`` idle starts
+            # the grace countdown, any other event cancels it. The
+            # clock itself defers the countdown while gated calls
+            # are held or in flight (see ``_IdleClock.hold``).
+            self._idle_clock.note_event(ev)
+            if ev.type == "agent.tool_use" or ev.type == "agent.custom_tool_use":
+                if ev.id not in self._seen:
+                    self._seen.add(ev.id)
+                    await self._route_tool_event(ev)
+            elif ev.type == "user.tool_result":
+                self._answered.add(ev.tool_use_id)
+            elif ev.type == "user.custom_tool_result":
+                self._answered.add(ev.custom_tool_use_id)
+            elif ev.type == "user.tool_confirmation":
+                await self._note_confirmation(ev)
+            elif ev.type in ("session.status_terminated", "session.deleted"):
+                log.info("session terminated")
+                self._stop.set()
+                return
+
+    def _start_background_reconcile(self) -> anyio.Event:
+        """Run one windowed reconcile on the runner's task group and return an
+        event set when it finishes. A burst of reconnects shares the pass
+        already reading rather than starting another."""
+        if self._reconciling is not None:
+            return self._reconciling
+        done = anyio.Event()
+        self._reconciling = done
+
+        async def run() -> None:
+            try:
+                await self._reconcile()
+            except (anyio.BrokenResourceError, anyio.ClosedResourceError):
+                # The runner is shutting down; the work stream is gone.
+                pass
+            finally:
+                self._reconciling = None
+                done.set()
+
+        self._task_group.start_soon(run)
+        return done
+
+    def _note_processed_at(self, ev: object) -> None:
+        """Track the newest ``processed_at`` seen, the lower bound of the next
+        reconcile window."""
+        ts = getattr(ev, "processed_at", None)
+        if isinstance(ts, datetime) and (self._newest_processed_at is None or ts > self._newest_processed_at):
+            self._newest_processed_at = ts
 
     # -- confirmation gating (always_ask tools) ------------------------------
 

--- a/tests/lib/tools/test_session_runner.py
+++ b/tests/lib/tools/test_session_runner.py
@@ -194,6 +194,13 @@ class FakeAsyncEvents:
         self.stream_calls: int = 0
         self.stream_headers: list[Any] = []
         self.list_headers: list[Any] = []
+        # ``list_filters`` records the keyword filters of each ``list()`` call
+        # (the reconcile window); ``list_cycles`` makes the listing repeat its
+        # events forever, as a pagination that wraps around would; each entry
+        # of ``list_gates`` holds the corresponding ``list()`` call until set.
+        self.list_filters: list[dict[str, Any]] = []
+        self.list_cycles = False
+        self.list_gates: list[asyncio.Event | None] = []
 
     async def stream(self, _session_id: str, *, extra_headers: Any = None) -> _FakeStream:
         self.stream_calls += 1
@@ -205,14 +212,22 @@ class FakeAsyncEvents:
             raise nxt
         return nxt
 
-    def list(self, _session_id: str, *, limit: int = 1000, extra_headers: Any = None) -> Any:  # noqa: ARG002
+    def list(self, _session_id: str, *, limit: int = 1000, extra_headers: Any = None, **filters: Any) -> Any:  # noqa: ARG002
         list_raises = self._list_raises
         self.list_headers.append(extra_headers)
+        self.list_filters.append(filters)
         list_events = self._list_events_per_call.pop(0) if self._list_events_per_call else self._list_events
+        cycle = self.list_cycles
+        gate = self.list_gates.pop(0) if self.list_gates else None
 
         async def _gen() -> Any:
-            for ev in list_events:
-                yield ev
+            if gate is not None:
+                await gate.wait()
+            while True:
+                for ev in list_events:
+                    yield ev
+                if not cycle:
+                    break
             if list_raises is not None:
                 raise list_raises
 
@@ -1595,3 +1610,89 @@ def test_to_session_content_tool_reference_stringified() -> None:
     block = {"type": "tool_reference", "tool_name": "weather"}
     out = _to_session_content([block])
     assert out == [{"type": "text", "text": session_runner_mod.json.dumps(block)}]
+
+
+# ---------- bounded / incremental reconcile ---------------------------------
+
+
+async def _echo(input: dict[str, Any]) -> str:
+    return f"echo:{input}"
+
+
+@pytest.mark.asyncio()
+async def test_reconcile_survives_a_listing_that_wraps_around() -> None:
+    """A history listing whose pagination never ends (the same events come
+    round again) must not wedge the runner: the pass stops at the first
+    repeated id, treats the distinct set as the whole history, and dispatches
+    what is unanswered in it."""
+    tool = _FakeTool("echo", _echo)
+    events = FakeAsyncEvents(
+        stream_events=[_terminated()],
+        list_events=[_tool_use("tu_1", "echo", {"v": 1}), _tool_use("tu_2", "echo", {"v": 2}), _tool_result("tu_2")],
+    )
+    events.list_cycles = True
+
+    async def collect() -> list[DispatchedToolCall]:
+        return [item async for item in _run_with_fakes(events=events, tools=[tool])]
+
+    # A regression here is a hang, not a wrong answer.
+    items = await asyncio.wait_for(collect(), 5)
+
+    assert [it.tool_use_id for it in items] == ["tu_1"], "unanswered call from the wrapped history dispatched once"
+
+
+@pytest.mark.asyncio()
+async def test_reconnect_reconciles_only_the_recent_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After one complete history read, a reconnect lists only events at or
+    after the newest ``processed_at`` already seen (less a skew allowance)
+    rather than the whole history again."""
+    from datetime import datetime, timezone
+
+    monkeypatch.setattr(session_runner_mod, "STREAM_BACKOFF_START", 0.01)
+    tool = _FakeTool("echo", _echo)
+    seen_at = datetime(2030, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    live = _StubEvent(
+        "agent.tool_use", id="tu_1", name="echo", input={}, evaluated_permission=None, processed_at=seen_at
+    )
+    events = FakeAsyncEvents(
+        streams=[
+            _FakeStream([live], raise_after=1, raise_with=httpx.ReadError("dropped")),
+            _FakeStream([_terminated()]),
+        ],
+        list_events_per_call=[[], []],
+    )
+
+    items = [item async for item in _run_with_fakes(events=events, tools=[tool])]
+
+    assert [it.tool_use_id for it in items] == ["tu_1"]
+    assert events.list_filters[0] == {}, "first attach reads the whole history"
+    assert events.list_filters[1] == {"created_at_gte": seen_at - session_runner_mod.RECONCILE_WINDOW_SKEW}, (
+        "a reconnect reads only the window a disconnect can have hidden"
+    )
+
+
+@pytest.mark.asyncio()
+async def test_slow_reconcile_after_reconnect_does_not_hold_live_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On a reconnect, a windowed history read that outlives the attach budget
+    keeps running in the background while live tool calls are dispatched."""
+    monkeypatch.setattr(session_runner_mod, "STREAM_BACKOFF_START", 0.01)
+    monkeypatch.setattr(session_runner_mod, "RECONCILE_ATTACH_BUDGET", 0.05)
+    tool = _FakeTool("echo", _echo)
+    stuck = asyncio.Event()  # never set: the listing after the reconnect hangs
+    events = FakeAsyncEvents(
+        streams=[
+            # First connection drops straight away so the runner reconnects.
+            _FakeStream([_idle_end_turn()], raise_after=1, raise_with=httpx.ReadError("dropped")),
+            _FakeStream([_tool_use("tu_live", "echo", {"v": 1})]),
+        ],
+        list_events_per_call=[[], []],
+    )
+    events.list_gates = [None, stuck]
+
+    async def first_dispatched() -> str:
+        async for item in _run_with_fakes(events=events, tools=[tool]):
+            return item.tool_use_id  # arrived although the second reconcile never finished
+        raise AssertionError("runner ended without dispatching the live call")
+
+    # A regression here is a hang, not a wrong answer.
+    assert await asyncio.wait_for(first_dispatched(), 5) == "tu_live"


### PR DESCRIPTION
`SessionToolRunner` reconciles by listing session history inside its stream context after every (re)connect. Two properties of that made a long-running session fragile:

- the read was the *whole* history on every reconnect, so each reconnect cost O(history) before any new tool call could be dispatched; and
- the read had no notion of "done" beyond the paginator ending, so a listing whose pages wrap around (or simply a very long one) held the live stream — and every tool call on it — behind it indefinitely, with nothing logged.

This keeps first attach exactly as it was (nothing dispatches until the whole history says which calls are already answered) and changes reconnects:

- after one complete read, a reconnect lists only `created_at_gte = newest processed_at seen − 30s`; everything older is already reflected in `_seen` / `_answered` / `_confirmations`;
- an event id repeating within one pass ends the pass (every reachable page has been read) with a warning, and the distinct set is used;
- the windowed read is applied before live events when it finishes within `RECONCILE_ATTACH_BUDGET` (10 s) — preserving today's ordering for held/confirmed calls — and otherwise continues in the background while the live stream is consumed.

Tests: the existing suite is unchanged and green (including the reconnect/held-call ordering cases); new cases cover a wrapping listing terminating and dispatching once, the reconnect window filter, and a hung windowed read not blocking a live dispatch. `ruff`, `pyright`, `mypy` clean on the touched files.
