### PR TITLE
fix(streaming): don't JSON-parse text when output_format=None

### DIFF
--- a/src/anthropic/lib/_parse/_response.py
+++ b/src/anthropic/lib/_parse/_response.py
@@ -14,7 +14,7 @@ ResponseFormatT = TypeVar("ResponseFormatT", default=None)
 
 
 def parse_text(text: str, output_format: ResponseFormatT | NotGiven) -> ResponseFormatT | None:
-    if is_given(output_format):
+    if is_given(output_format) and output_format is not None:
         adapted_type: TypeAdapter[ResponseFormatT] = TypeAdapter(output_format)
         return adapted_type.validate_json(text)
     return None

--- a/tests/lib/streaming/test_messages.py
+++ b/tests/lib/streaming/test_messages.py
@@ -224,6 +224,31 @@ class TestSyncMessages:
             assert_basic_response([event for event in stream], stream.get_final_message())
 
     @pytest.mark.respx(base_url=base_url)
+    def test_output_format_none_streams_plain_text(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=get_response("basic_response.txt"))
+        )
+
+        # `output_format=None` is accepted by the stream() signature and means
+        # "no structured output" — it must not be fed to the JSON parser.
+        with sync_client.messages.stream(
+            max_tokens=1024,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Say hello there!",
+                }
+            ],
+            model="claude-3-opus-latest",
+            output_format=None,
+        ) as stream:
+            message = stream.get_final_message()
+
+        assert message.content[0].type == "text"
+        assert message.content[0].text == "Hello there!"
+        assert message.content[0].parsed_output is None
+
+    @pytest.mark.respx(base_url=base_url)
     def test_context_manager(self, respx_mock: MockRouter) -> None:
         respx_mock.post("/v1/messages").mock(
             return_value=httpx.Response(200, content=get_response("basic_response.txt"))
@@ -404,6 +429,27 @@ class TestAsyncMessages:
                 assert isinstance(cast(Any, stream), AsyncStream)
 
             assert_basic_response([event async for event in stream], await stream.get_final_message())
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx(base_url=base_url)
+    async def test_output_format_none_streams_plain_text(self, respx_mock: MockRouter) -> None:
+        respx_mock.post("/v1/messages").mock(
+            return_value=httpx.Response(200, content=to_async_iter(get_response("basic_response.txt")))
+        )
+
+        # `output_format=None` is accepted by the stream() signature and means
+        # "no structured output" — it must not be fed to the JSON parser.
+        async with async_client.messages.stream(
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Say hello there!"}],
+            model="claude-3-opus-latest",
+            output_format=None,
+        ) as stream:
+            message = await stream.get_final_message()
+
+        assert message.content[0].type == "text"
+        assert message.content[0].text == "Hello there!"
+        assert message.content[0].parsed_output is None
 
     @pytest.mark.asyncio
     @pytest.mark.respx(base_url=base_url)


### PR DESCRIPTION
## What

`messages.stream()` (and its async + beta siblings) **crash on any plain-text response when called with `output_format=None`** — a value the method's own signature explicitly accepts:

```python
output_format: None | JSONOutputFormatParam | type[ResponseFormatT] | Omit = omit
```

### Reproduction

```python
with client.messages.stream(
    max_tokens=1024,
    messages=[{"role": "user", "content": "Say hello there!"}],
    model="claude-3-opus-latest",
    output_format=None,
) as stream:
    message = stream.get_final_message()
```

This raises on the first text block:

```
pydantic_core.ValidationError: 1 validation error for none
  Invalid JSON: expected value at line 1 column 1 [type=json_invalid, input_value='Hello there!', input_type=str]
```

### Root cause

`None` is documented (by the signature) as "no structured output", and the request-building code already treats it that way (`is_given(output_format) and output_format is not None`). But the streaming manager passes `None` straight through to the accumulator, where `parse_text` checks only `is_given(output_format)` — and `is_given(None)` is `True` — so it runs `TypeAdapter(None).validate_json(text)` on every text block.

The non-streaming `messages.parse()` path survived only because it normalizes `None -> not_given` before calling `parse_text`.

### Fix

Guard `None` in `parse_text` itself (in `src/anthropic/lib/`, which the generator never touches), so every path — sync/async streams, beta streams, and non-streaming parse — is consistent:

```python
-    if is_given(output_format):
+    if is_given(output_format) and output_format is not None:
```

## Verification

- **Before:** `messages.stream(output_format=None)` crashes with the `ValidationError` above; the same call without `output_format` streams fine.
- **After:** `output_format=None` streams 10 events and returns the text; the no-format behavior is unchanged; a real `output_format=PydanticType` still parses.
- **Regression tests added** (sync + async) covering `output_format=None` on the standard text fixture — they **fail on the unpatched code** and pass with the fix.
- Full `tests/lib/` streaming + parse suites: **133 passed** with the fix vs 131 baseline — exactly the 2 new tests, zero regressions.
