### PR TITLE
Fail clearly on unsupported dynamic object schemas

### DIFF
--- a/src/anthropic/lib/_parse/_transform.py
+++ b/src/anthropic/lib/_parse/_transform.py
@@ -51,6 +51,27 @@ def get_transformed_string(
     return schema
 
 
+def _dynamic_object_keywords_without_properties(json_schema: dict[str, Any]) -> list[str]:
+    """Return unsupported keywords that are the only way this object can admit keys."""
+    keywords: list[str] = []
+
+    pattern_properties = json_schema.get("patternProperties")
+    if isinstance(pattern_properties, dict) and pattern_properties:
+        keywords.append("patternProperties")
+
+    additional_properties = json_schema.get("additionalProperties")
+    if isinstance(additional_properties, dict):
+        keywords.append("additionalProperties")
+
+    if "propertyNames" in json_schema and additional_properties is not False:
+        keywords.append("propertyNames")
+
+    if "unevaluatedProperties" in json_schema and json_schema["unevaluatedProperties"] is not False:
+        keywords.append("unevaluatedProperties")
+
+    return keywords
+
+
 def transform_schema(
     json_schema: type[pydantic.BaseModel] | dict[str, Any],
 ) -> dict[str, Any]:
@@ -126,8 +147,19 @@ def transform_schema(
         strict_schema["title"] = title
 
     if type_ == "object":
+        properties = json_schema.pop("properties", {})
+        if not properties:
+            unsupported_dynamic_keywords = _dynamic_object_keywords_without_properties(json_schema)
+            if unsupported_dynamic_keywords:
+                keywords = ", ".join(unsupported_dynamic_keywords)
+                raise ValueError(
+                    "Structured output schemas cannot safely transform an object that relies on "
+                    f"{keywords} without explicit properties. Transforming this schema would make "
+                    "the object accept no keys."
+                )
+
         strict_schema["properties"] = {
-            key: transform_schema(prop_schema) for key, prop_schema in json_schema.pop("properties", {}).items()
+            key: transform_schema(prop_schema) for key, prop_schema in properties.items()
         }
         json_schema.pop("additionalProperties", None)
         strict_schema["additionalProperties"] = False

--- a/src/anthropic/lib/_parse/_transform.py
+++ b/src/anthropic/lib/_parse/_transform.py
@@ -60,7 +60,7 @@ def _dynamic_object_keywords_without_properties(json_schema: dict[str, Any]) -> 
         keywords.append("patternProperties")
 
     additional_properties = json_schema.get("additionalProperties")
-    if isinstance(additional_properties, dict):
+    if additional_properties is True or isinstance(additional_properties, dict):
         keywords.append("additionalProperties")
 
     if "propertyNames" in json_schema and additional_properties is not False:

--- a/tests/lib/_parse/test_dynamic_object_transform.py
+++ b/tests/lib/_parse/test_dynamic_object_transform.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from pydantic import BaseModel
 
@@ -14,9 +16,29 @@ def test_additional_properties_map_raises_instead_of_becoming_empty_object():
         transform_schema(schema)
 
 
-def test_pydantic_dict_field_raises_instead_of_becoming_empty_object():
+def test_additional_properties_true_raises_instead_of_becoming_empty_object():
+    schema = {
+        "type": "object",
+        "additionalProperties": True,
+    }
+
+    with pytest.raises(ValueError, match="additionalProperties"):
+        transform_schema(schema)
+
+
+def test_pydantic_typed_dict_field_raises_instead_of_becoming_empty_object():
     class Model(BaseModel):
         values: dict[str, str]
+
+    schema = Model.model_json_schema()["properties"]["values"]
+
+    with pytest.raises(ValueError, match="additionalProperties"):
+        transform_schema(schema)
+
+
+def test_pydantic_arbitrary_dict_field_raises_instead_of_becoming_empty_object():
+    class Model(BaseModel):
+        values: dict[str, Any]
 
     schema = Model.model_json_schema()["properties"]["values"]
 

--- a/tests/lib/_parse/test_dynamic_object_transform.py
+++ b/tests/lib/_parse/test_dynamic_object_transform.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import BaseModel
+
+from anthropic.lib._parse._transform import transform_schema
+
+
+def test_additional_properties_map_raises_instead_of_becoming_empty_object():
+    schema = {
+        "type": "object",
+        "additionalProperties": {"type": "string"},
+    }
+
+    with pytest.raises(ValueError, match="additionalProperties"):
+        transform_schema(schema)
+
+
+def test_pydantic_dict_field_raises_instead_of_becoming_empty_object():
+    class Model(BaseModel):
+        values: dict[str, str]
+
+    schema = Model.model_json_schema()["properties"]["values"]
+
+    with pytest.raises(ValueError, match="additionalProperties"):
+        transform_schema(schema)

--- a/tests/lib/_parse/test_transform.py
+++ b/tests/lib/_parse/test_transform.py
@@ -229,3 +229,55 @@ def test_original_schema_not_mutated():
     transform_schema(original_schema)
 
     assert original_schema == original_schema_backup
+
+
+@pytest.mark.parametrize(
+    ("keyword", "constraint"),
+    [
+        ("patternProperties", {"^S_": {"type": "string"}}),
+        ("propertyNames", {"pattern": "^S_"}),
+        ("unevaluatedProperties", {"type": "string"}),
+    ],
+)
+def test_dynamic_object_schema_without_properties_raises(keyword: str, constraint: object):
+    schema = {"type": "object", keyword: constraint}
+
+    with pytest.raises(ValueError, match=keyword):
+        transform_schema(schema)
+
+
+def test_pattern_properties_with_explicit_properties_keeps_existing_demotion_behavior():
+    schema = {
+        "type": "object",
+        "properties": {"fixed": {"type": "string"}},
+        "required": ["fixed"],
+        "patternProperties": {"^S_": {"type": "string"}},
+    }
+
+    result = transform_schema(schema)
+
+    assert result == {
+        "type": "object",
+        "properties": {"fixed": {"type": "string"}},
+        "additionalProperties": False,
+        "required": ["fixed"],
+        "description": "{patternProperties: {'^S_': {'type': 'string'}}}",
+    }
+
+
+def test_closed_empty_object_is_not_rejected():
+    schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "propertyNames": {"pattern": "^S_"},
+        "unevaluatedProperties": False,
+    }
+
+    result = transform_schema(schema)
+
+    assert result == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+        "description": "{propertyNames: {'pattern': '^S_'}, unevaluatedProperties: False}",
+    }


### PR DESCRIPTION
## Summary

Prevent `transform_schema()` from silently turning dynamic-key object schemas into objects that accept no keys.

When an object has no explicit `properties` and relies on `patternProperties`, `propertyNames`, `unevaluatedProperties`, or an explicit `additionalProperties` schema to admit keys, the current transformer can demote or discard that information and then force `properties: {}` plus `additionalProperties: false`. The transformed schema can therefore only produce `{}` even though the source schema admits populated dictionaries.

Fixes #1817.

## Fix

Detect explicit dynamic-object forms before closing an otherwise property-less object and raise a targeted `ValueError` instead of returning a silently unsatisfiable schema.

The guard is deliberately narrow:

- populated `patternProperties` without explicit properties is rejected;
- explicit schema-valued `additionalProperties` without properties is rejected;
- `propertyNames` is rejected only while the source object still admits additional keys;
- non-false `unevaluatedProperties` without explicit properties is rejected;
- schemas with explicit properties retain the existing demotion-to-description behavior;
- already-closed empty objects are not rejected.

## Regression coverage

Adds focused tests for the dynamic-key forms, an ordinary Pydantic `dict[str, str]` field, and controls for explicit-property and already-closed objects.

The patch is confined to Anthropic's hand-maintained `src/anthropic/lib/_parse/` transformer and regression tests.