### PR TITLE
Handle MCP blob resources without MIME types safely

### DIFF
--- a/src/anthropic/lib/tools/mcp.py
+++ b/src/anthropic/lib/tools/mcp.py
@@ -101,10 +101,15 @@ def _is_supported_image_type(mime_type: str) -> bool:
     return mime_type in _SUPPORTED_IMAGE_TYPES
 
 
-def _is_supported_resource_mime_type(mime_type: str | None) -> bool:
+def _is_supported_resource(resource: TextResourceContents | BlobResourceContents) -> bool:
+    mime_type = _mcp_field_v1_or_v2(resource, "mime_type")
+    if mime_type is None:
+        # A missing MIME type is safe to interpret as text only when MCP has
+        # already classified the resource as text. A BlobResourceContents may
+        # contain arbitrary bytes, so treating it as UTF-8 is not safe.
+        return isinstance(resource, TextResourceContents)
     return (
-        mime_type is None
-        or mime_type.startswith("text/")
+        mime_type.startswith("text/")
         or mime_type == "application/pdf"
         or _is_supported_image_type(mime_type)
     )
@@ -202,27 +207,34 @@ def _resource_contents_to_block(
         tag_helper(pdf_block, "mcp_resource_to_content")
         return pdf_block  # type: ignore[return-value]
 
-    if mime_type is None or mime_type.startswith("text/"):
+    # Text. Missing MIME is accepted only for an MCP text resource; an
+    # untyped blob has no safe character encoding/content classification.
+    if mime_type is None:
+        if not isinstance(resource, TextResourceContents):
+            raise UnsupportedMCPValueError(f"Blob resource has no MIME type: {resource.uri}")
+        data = resource.text
+    elif mime_type.startswith("text/"):
         if isinstance(resource, TextResourceContents):
             data = resource.text
         else:
             data = base64.b64decode(resource.blob).decode("utf-8")
-        text_block = _TaggedDict(
-            {
-                "type": "document",
-                "source": BetaPlainTextSourceParam(
-                    type="text",
-                    data=data,
-                    media_type="text/plain",
-                ),
-            }
-        )
-        if cache_control is not None:
-            text_block["cache_control"] = cache_control
-        tag_helper(text_block, "mcp_resource_to_content")
-        return text_block  # type: ignore[return-value]
+    else:
+        raise UnsupportedMCPValueError(f'Unsupported MIME type "{mime_type}" for resource: {resource.uri}')
 
-    raise UnsupportedMCPValueError(f'Unsupported MIME type "{mime_type}" for resource: {resource.uri}')
+    text_block = _TaggedDict(
+        {
+            "type": "document",
+            "source": BetaPlainTextSourceParam(
+                type="text",
+                data=data,
+                media_type="text/plain",
+            ),
+        }
+    )
+    if cache_control is not None:
+        text_block["cache_control"] = cache_control
+    tag_helper(text_block, "mcp_resource_to_content")
+    return text_block  # type: ignore[return-value]
 
 
 def mcp_message(
@@ -254,13 +266,11 @@ def mcp_resource_to_content(
     if not result.contents:
         raise UnsupportedMCPValueError("Resource contents array must contain at least one item")
 
-    mime_types = [_mcp_field_v1_or_v2(c, "mime_type") for c in result.contents]
-    supported = next(
-        (c for c, mime_type in zip(result.contents, mime_types) if _is_supported_resource_mime_type(mime_type)),
-        None,
-    )
+    supported = next((content for content in result.contents if _is_supported_resource(content)), None)
     if supported is None:
-        mime_types = [m for m in mime_types if m is not None]
+        mime_types = [
+            _mcp_field_v1_or_v2(content, "mime_type") or "<missing>" for content in result.contents
+        ]
         raise UnsupportedMCPValueError(
             f"No supported MIME type found in resource contents. Available: {', '.join(mime_types)}"
         )

--- a/tests/lib/tools/test_mcp_resource_mime.py
+++ b/tests/lib/tools/test_mcp_resource_mime.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+mcp = pytest.importorskip("mcp")
+
+from mcp.types import (  # noqa: E402
+    EmbeddedResource,
+    ReadResourceResult,
+    BlobResourceContents,
+    TextResourceContents,
+)
+
+from anthropic.lib.tools.mcp import (  # noqa: E402
+    UnsupportedMCPValueError,
+    mcp_content,
+    mcp_resource_to_content,
+)
+
+
+def _blob(data: bytes, mime_type: str | None = None) -> BlobResourceContents:
+    payload = {
+        "uri": "file:///binary.bin",
+        "blob": base64.b64encode(data).decode(),
+    }
+    if mime_type is not None:
+        payload["mimeType"] = mime_type
+    return BlobResourceContents.model_validate(payload)
+
+
+def _text(text: str, mime_type: str | None = None) -> TextResourceContents:
+    payload = {"uri": "file:///text.txt", "text": text}
+    if mime_type is not None:
+        payload["mimeType"] = mime_type
+    return TextResourceContents.model_validate(payload)
+
+
+def _result(*contents: TextResourceContents | BlobResourceContents) -> ReadResourceResult:
+    return ReadResourceResult.model_validate({"contents": [content.model_dump() for content in contents]})
+
+
+def test_unknown_mime_blob_is_not_treated_as_text() -> None:
+    with pytest.raises(UnsupportedMCPValueError, match="No supported MIME type"):
+        mcp_resource_to_content(_result(_blob(b"\xff\xfe\xfd")))
+
+
+def test_unknown_mime_blob_does_not_hide_later_supported_resource() -> None:
+    result = mcp_resource_to_content(
+        _result(
+            _blob(b"\xff\xfe\xfd"),
+            _text("usable text", "text/plain"),
+        )
+    )
+
+    assert result["type"] == "document"
+    assert result["source"]["data"] == "usable text"
+
+
+def test_embedded_unknown_mime_blob_raises_sdk_error() -> None:
+    resource = _blob(b"\xff\xfe\xfd")
+
+    with pytest.raises(UnsupportedMCPValueError, match="Blob resource has no MIME type"):
+        mcp_content(EmbeddedResource(type="resource", resource=resource))
+
+
+def test_explicit_text_blob_remains_supported() -> None:
+    result = mcp_resource_to_content(_result(_blob(b"hello", "text/plain")))
+
+    assert result["type"] == "document"
+    assert result["source"]["data"] == "hello"


### PR DESCRIPTION
## Summary

Prevent MCP binary blob resources with no MIME type from being treated as UTF-8 text.

`mcp_resource_to_content()` currently considers `mime_type=None` supported for every MCP resource. For a `BlobResourceContents`, that causes arbitrary binary bytes to be base64-decoded and then decoded as UTF-8, which can raise `UnicodeDecodeError`. It can also cause an unknown binary blob to be selected ahead of a later supported resource in the same `ReadResourceResult`.

## Fix

- treat missing MIME as text only for `TextResourceContents`;
- skip no-MIME blob resources while selecting the first representable resource;
- raise `UnsupportedMCPValueError` for a directly embedded no-MIME blob instead of leaking a Unicode decoding exception;
- preserve explicitly typed `text/*`, PDF, and supported image behavior;
- include `<missing>` in the unsupported-resource diagnostic when MIME metadata is absent.

## Regression coverage

Adds offline tests covering:

- an isolated no-MIME binary blob;
- a no-MIME blob followed by a usable text resource;
- an embedded no-MIME binary resource;
- unchanged support for an explicitly `text/plain` blob.

The change is confined to the hand-maintained MCP conversion helper and its tests.