### PR TITLE
Preserve iterable ToolError content

### DIFF
--- a/src/anthropic/lib/tools/_beta_functions.py
+++ b/src/anthropic/lib/tools/_beta_functions.py
@@ -49,6 +49,9 @@ class ToolError(Exception):
         if isinstance(content, str):
             message = content
         else:
+            # Materialize once so one-shot iterables (for example generators)
+            # remain available when the runner later serializes ``exc.content``.
+            content = list(content)
             parts: list[str] = []
             for block in content:
                 text = block.get("text")

--- a/tests/lib/tools/test_tool_error_iterables.py
+++ b/tests/lib/tools/test_tool_error_iterables.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from anthropic.lib.tools import ToolError
+from anthropic.lib.tools._tool_dispatch import tool_error_content
+from anthropic.types.beta.beta_tool_result_block_param import Content as BetaContent
+
+
+def _error_blocks() -> Iterator[BetaContent]:
+    yield {"type": "text", "text": "first detail"}
+    yield {"type": "text", "text": "second detail"}
+
+
+def test_tool_error_preserves_generator_content_for_runner() -> None:
+    error = ToolError(_error_blocks())
+
+    assert str(error) == "first detail second detail"
+    assert list(tool_error_content(error)) == [
+        {"type": "text", "text": "first detail"},
+        {"type": "text", "text": "second detail"},
+    ]
+
+
+def test_tool_error_content_remains_reusable_after_message_rendering() -> None:
+    error = ToolError(_error_blocks())
+
+    first_read = list(error.content)
+    second_read = list(error.content)
+
+    assert first_read == second_read
+    assert first_read == [
+        {"type": "text", "text": "first detail"},
+        {"type": "text", "text": "second detail"},
+    ]
+
+
+def test_tool_error_string_content_is_unchanged() -> None:
+    error = ToolError("plain failure")
+
+    assert str(error) == "plain failure"
+    assert error.content == "plain failure"


### PR DESCRIPTION
## Summary

Preserve structured `ToolError` content when callers provide a one-shot iterable such as a generator.

`BetaFunctionToolResultType` explicitly accepts `Iterable[BetaContent]`. `ToolError.__init__()` currently iterates non-string content to build the exception message and then stores the same iterable on `self.content`. For generators, that consumes the iterable before the tool runner later reads `exc.content`, so the emitted `tool_result` loses the structured error content.

## Fix

Materialize non-string `ToolError` content once before rendering the exception message. The same reusable collection is then retained on `self.content` for the runner.

String content remains unchanged.

## Regression coverage

Adds focused tests verifying:
- generator-backed structured error content survives through `tool_error_content()`, the same path used by the runners;
- the stored content remains reusable after exception message construction;
- string `ToolError` behavior is unchanged.

The production change is three lines in Anthropic's hand-maintained tool helper.