### PR TITLE
Avoid consuming one-shot helper iterables

### DIFF
--- a/src/anthropic/lib/_stainless_helpers.py
+++ b/src/anthropic/lib/_stainless_helpers.py
@@ -9,6 +9,7 @@ we only carry the constants and the per-object tagging machinery.
 from __future__ import annotations
 
 from typing import Any, Dict, Mapping, TypeVar, cast
+from collections.abc import Sequence
 from typing_extensions import Literal
 
 __all__ = [
@@ -112,6 +113,18 @@ def carry_helper_tag(source: object, params: _MappingT) -> _MappingT:
     return cast(_MappingT, tagged)
 
 
+def _replayable_sequence(value: Any) -> Sequence[Any] | None:
+    """Return a safely re-iterable helper collection, if available.
+
+    Request parameters accept arbitrary ``Iterable`` values, including generators.
+    Helper telemetry must not consume a one-shot iterable before request
+    serialization gets a chance to read it.
+    """
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return value
+    return None
+
+
 def collect_helpers(
     tools: Any = None,
     messages: Any = None,
@@ -123,12 +136,14 @@ def collect_helpers(
         if tag is not None and tag not in helpers:
             helpers.append(tag)
 
-    if tools:
-        for tool in tools:
+    tool_items = _replayable_sequence(tools)
+    if tool_items:
+        for tool in tool_items:
             _add(get_helper_tag(tool))
 
-    if messages:
-        for message in messages:
+    message_items = _replayable_sequence(messages)
+    if message_items:
+        for message in message_items:
             _add(get_helper_tag(message))
 
             if isinstance(message, dict):

--- a/tests/lib/test_stainless_helper_iterables.py
+++ b/tests/lib/test_stainless_helper_iterables.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import httpx
+import respx
+import pytest
+
+from anthropic import Anthropic
+from anthropic.types.beta import BetaToolParam
+from anthropic.lib._stainless_helpers import STAINLESS_HELPER_HEADER, tag_helper, stainless_helper_header
+
+from ..conftest import base_url
+
+
+class _TaggedDict(dict):  # type: ignore[type-arg]
+    pass
+
+
+def _message_json() -> dict[str, object]:
+    return {
+        "id": "msg_abc123",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5",
+        "content": [{"type": "text", "text": "hi"}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+
+
+def test_helper_collection_does_not_consume_generator() -> None:
+    tool = cast("BetaToolParam", _TaggedDict({"name": "t", "input_schema": {"type": "object"}}))
+    tag_helper(tool, "mcp_tool")
+    tools = (item for item in [tool])
+
+    assert stainless_helper_header(tools=tools) == {}
+    assert list(tools) == [tool]
+
+
+def test_helper_collection_still_reads_replayable_sequences() -> None:
+    tool = cast("BetaToolParam", _TaggedDict({"name": "t", "input_schema": {"type": "object"}}))
+    tag_helper(tool, "mcp_tool")
+
+    assert stainless_helper_header(tools=[tool]) == {STAINLESS_HELPER_HEADER: "mcp_tool"}
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_message_generator_reaches_request_body(client: Anthropic, respx_mock: respx.MockRouter) -> None:
+    respx_mock.post("/v1/messages").mock(return_value=httpx.Response(200, json=_message_json()))
+
+    messages = ({"role": "user", "content": text} for text in ["hello"])
+    client.beta.messages.create(
+        model="claude-sonnet-4-5",
+        max_tokens=16,
+        messages=messages,
+    )
+
+    body = json.loads(respx_mock.calls.last.request.content)
+    assert body["messages"] == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_tool_generator_reaches_request_body(client: Anthropic, respx_mock: respx.MockRouter) -> None:
+    respx_mock.post("/v1/messages").mock(return_value=httpx.Response(200, json=_message_json()))
+
+    tool = cast(
+        "BetaToolParam",
+        _TaggedDict({"name": "t", "description": "d", "input_schema": {"type": "object"}}),
+    )
+    tag_helper(tool, "mcp_tool")
+    tools = (item for item in [tool])
+
+    client.beta.messages.create(
+        model="claude-sonnet-4-5",
+        max_tokens=16,
+        messages=[{"role": "user", "content": "hello"}],
+        tools=tools,
+    )
+
+    body = json.loads(respx_mock.calls.last.request.content)
+    assert body["tools"] == [{"name": "t", "description": "d", "input_schema": {"type": "object"}}]


### PR DESCRIPTION
## Summary

Prevent SDK helper telemetry from consuming one-shot `Iterable` request parameters before they are serialized.

The Messages APIs accept `Iterable` values for `messages` and `tools`. `stainless_helper_header()` currently iterates both collections to discover helper tags before request-body transformation runs. When a caller supplies a generator, telemetry exhausts it first, so the actual request can lose its messages or tools entirely.

## Fix

Restrict helper-tag collection to safely replayable `Sequence` inputs. Lists, tuples, and other replayable sequences continue to contribute helper telemetry. Arbitrary iterables such as generators are left untouched so request serialization remains the first consumer.

## Regression coverage

Adds tests verifying that generator-backed `messages` and `tools` survive into the actual JSON request body, while normal list-backed helper telemetry continues to work.

The production change is confined to Anthropic's hand-maintained `_stainless_helpers.py` path.