### PR TITLE
Preserve falsy parsed outputs

### DIFF
--- a/src/anthropic/types/beta/parsed_beta_message.py
+++ b/src/anthropic/types/beta/parsed_beta_message.py
@@ -73,6 +73,6 @@ class ParsedBetaMessage(BetaMessage, Generic[ResponseFormatT]):
     @property
     def parsed_output(self) -> Optional[ResponseFormatT]:
         for content in self.content:
-            if content.type == "text" and content.parsed_output:
+            if content.type == "text" and content.parsed_output is not None:
                 return content.parsed_output
         return None

--- a/src/anthropic/types/parsed_message.py
+++ b/src/anthropic/types/parsed_message.py
@@ -63,6 +63,6 @@ class ParsedMessage(Message, Generic[ResponseFormatT]):
     @property
     def parsed_output(self) -> Optional[ResponseFormatT]:
         for content in self.content:
-            if content.type == "text" and content.parsed_output:
+            if content.type == "text" and content.parsed_output is not None:
                 return content.parsed_output
         return None

--- a/tests/lib/_parse/test_falsy_parsed_output.py
+++ b/tests/lib/_parse/test_falsy_parsed_output.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from anthropic.types.parsed_message import ParsedMessage, ParsedTextBlock
+from anthropic.types.beta.parsed_beta_message import ParsedBetaMessage, ParsedBetaTextBlock
+
+
+@pytest.mark.parametrize("value", [False, 0, "", [], {}])
+def test_parsed_message_returns_falsy_output(value: Any) -> None:
+    message = ParsedMessage.construct(
+        content=[
+            ParsedTextBlock.construct(type="text", text="unparsed", parsed_output=None),
+            ParsedTextBlock.construct(type="text", text="parsed", parsed_output=value),
+        ]
+    )
+
+    assert type(message.parsed_output) is type(value)
+    assert message.parsed_output == value
+
+
+@pytest.mark.parametrize("value", [False, 0, "", [], {}])
+def test_parsed_beta_message_returns_falsy_output(value: Any) -> None:
+    message = ParsedBetaMessage.construct(
+        content=[
+            ParsedBetaTextBlock.construct(type="text", text="unparsed", parsed_output=None),
+            ParsedBetaTextBlock.construct(type="text", text="parsed", parsed_output=value),
+        ]
+    )
+
+    assert type(message.parsed_output) is type(value)
+    assert message.parsed_output == value
+
+
+def test_parsed_output_remains_none_when_absent() -> None:
+    message = ParsedMessage.construct(
+        content=[ParsedTextBlock.construct(type="text", text="unparsed", parsed_output=None)]
+    )
+    beta_message = ParsedBetaMessage.construct(
+        content=[ParsedBetaTextBlock.construct(type="text", text="unparsed", parsed_output=None)]
+    )
+
+    assert message.parsed_output is None
+    assert beta_message.parsed_output is None


### PR DESCRIPTION
## Summary

Preserve valid falsy structured outputs returned by messages.parse() and beta.messages.parse().

Both ParsedMessage.parsed_output and ParsedBetaMessage.parsed_output currently use a truthiness check:

if content.type == "text" and content.parsed_output:

As a result, valid parsed outputs such as False, 0, "", [], and {} are incorrectly exposed as None.

## Fix

Check explicitly for None instead of truthiness:

if content.type == "text" and content.parsed_output is not None:

This preserves all valid structured-output values while continuing to return None when no parsed output is present.

The fix is applied consistently to both:

- ParsedMessage
- ParsedBetaMessage

## Regression coverage

Adds focused tests covering:

- False
- 0
- empty string
- empty list
- empty dict
- genuinely absent parsed_output

The regression also verifies that an earlier text block with parsed_output=None does not prevent a later valid falsy parsed value from being returned.