### PR TITLE
Preserve structured-only MCP error payloads

### DIFF
--- a/src/anthropic/lib/tools/mcp.py
+++ b/src/anthropic/lib/tools/mcp.py
@@ -297,10 +297,15 @@ def mcp_resource_to_file(
 
 def _convert_tool_result(result: CallToolResult) -> BetaFunctionToolResultType:
     """Convert MCP ``CallToolResult`` to a value suitable for returning from ``call()``."""
-    if _mcp_field_v1_or_v2(result, "is_error"):
-        raise ToolError([mcp_content(item) for item in result.content])
-
     structured_content = _mcp_field_v1_or_v2(result, "structured_content")
+
+    if _mcp_field_v1_or_v2(result, "is_error"):
+        if result.content:
+            raise ToolError([mcp_content(item) for item in result.content])
+        if structured_content is not None:
+            raise ToolError(json.dumps(structured_content))
+        raise ToolError([])
+
     if not result.content and structured_content is not None:
         return json.dumps(structured_content)
 

--- a/tests/lib/tools/test_mcp_structured_error.py
+++ b/tests/lib/tools/test_mcp_structured_error.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import anyio
+import pytest
+
+mcp = pytest.importorskip("mcp")
+
+from mcp.types import Tool, TextContent, CallToolResult  # noqa: E402
+
+from anthropic.lib.tools import ToolError  # noqa: E402
+from anthropic.lib.tools.mcp import async_mcp_tool  # noqa: E402
+
+
+class _Client:
+    def __init__(self, result: CallToolResult) -> None:
+        self.result = result
+
+    async def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> CallToolResult:  # noqa: ARG002
+        return self.result
+
+
+def test_structured_only_mcp_error_preserves_payload() -> None:
+    async def run() -> None:
+        payload = {"code": "invalid_input", "details": {"field": "query"}}
+        result = CallToolResult(content=[], structuredContent=payload, isError=True)
+        tool = async_mcp_tool(Tool(name="lookup", inputSchema={"type": "object"}), _Client(result))
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool.call({})
+
+        assert exc_info.value.content == json.dumps(payload)
+        assert str(exc_info.value) == json.dumps(payload)
+
+    anyio.run(run)
+
+
+def test_mcp_error_prefers_explicit_content_over_structured_fallback() -> None:
+    async def run() -> None:
+        result = CallToolResult(
+            content=[TextContent(type="text", text="explicit failure")],
+            structuredContent={"code": "fallback"},
+            isError=True,
+        )
+        tool = async_mcp_tool(Tool(name="lookup", inputSchema={"type": "object"}), _Client(result))
+
+        with pytest.raises(ToolError) as exc_info:
+            await tool.call({})
+
+        content = list(exc_info.value.content)
+        assert content[0]["type"] == "text"
+        assert content[0]["text"] == "explicit failure"
+
+    anyio.run(run)
+
+
+def test_structured_only_mcp_success_remains_json_string() -> None:
+    async def run() -> None:
+        payload = {"status": "ok"}
+        result = CallToolResult(content=[], structuredContent=payload, isError=False)
+        tool = async_mcp_tool(Tool(name="lookup", inputSchema={"type": "object"}), _Client(result))
+
+        assert await tool.call({}) == json.dumps(payload)
+
+    anyio.run(run)


### PR DESCRIPTION
## Summary

Preserve MCP error details when a `CallToolResult` contains `structuredContent` but no regular `content` blocks.

`_convert_tool_result()` currently handles `isError` before the existing `structuredContent` fallback. As a result, an MCP result such as `content=[]`, `structuredContent={...}`, `isError=True` raises `ToolError([])` and discards the only useful error payload. The tool runner then surfaces a generic `Tool error` instead of the structured details returned by the MCP server.

## Fix

Read `structuredContent` before branching on `isError` and use it as the error fallback only when normal content is empty.

Precedence remains:

- explicit MCP `content` blocks win when present;
- otherwise structured error content is JSON-encoded and preserved in `ToolError`;
- an error with neither form keeps the existing empty-error behavior;
- successful structured-only results keep the existing JSON-string fallback.

## Regression coverage

Adds focused tests covering:

- structured-only MCP errors preserve their payload;
- explicit error content still takes precedence over `structuredContent`;
- structured-only successful results remain unchanged.

The production change is confined to the hand-maintained MCP tool-result conversion helper.