### PR TITLE
Keep directory uploads inside their root

### DIFF
--- a/src/anthropic/lib/_files.py
+++ b/src/anthropic/lib/_files.py
@@ -8,35 +8,102 @@ import anyio
 from .._types import FileTypes
 
 
+_DirectoryKey = tuple[int, int]
+
+
+def _resolve_within_root(path: Path, root: Path) -> Path:
+    resolved = path.resolve(strict=True)
+    try:
+        resolved.relative_to(root)
+    except ValueError as err:
+        raise ValueError(
+            "Refusing to follow directory-upload entry outside the requested root: "
+            f"{path} -> {resolved}"
+        ) from err
+    return resolved
+
+
 def files_from_dir(directory: str | os.PathLike[str]) -> list[FileTypes]:
     path = Path(directory)
+    root = path.resolve(strict=True)
 
     files: list[FileTypes] = []
-    _collect_files(path, path.parent, files)
+    _collect_files(path, path.parent, root, files, set())
     return files
 
 
-def _collect_files(directory: Path, relative_to: Path, files: list[FileTypes]) -> None:
-    for path in directory.iterdir():
-        if path.is_dir():
-            _collect_files(path, relative_to, files)
-            continue
+def _collect_files(
+    directory: Path,
+    relative_to: Path,
+    root: Path,
+    files: list[FileTypes],
+    active_directories: set[_DirectoryKey],
+) -> None:
+    resolved_directory = _resolve_within_root(directory, root)
+    directory_stat = resolved_directory.stat()
+    directory_key = (directory_stat.st_dev, directory_stat.st_ino)
+    if directory_key in active_directories:
+        raise ValueError(
+            f"Refusing to follow a directory-upload symlink cycle at {directory}"
+        )
 
-        files.append((path.relative_to(relative_to).as_posix(), path.read_bytes()))
+    active_directories.add(directory_key)
+    try:
+        for path in directory.iterdir():
+            resolved = _resolve_within_root(path, root)
+            if resolved.is_dir():
+                _collect_files(path, relative_to, root, files, active_directories)
+                continue
+
+            files.append((path.relative_to(relative_to).as_posix(), resolved.read_bytes()))
+    finally:
+        active_directories.remove(directory_key)
 
 
 async def async_files_from_dir(directory: str | os.PathLike[str]) -> list[FileTypes]:
     path = anyio.Path(directory)
+    root = await path.resolve(strict=True)
 
     files: list[FileTypes] = []
-    await _async_collect_files(path, path.parent, files)
+    await _async_collect_files(path, path.parent, root, files, set())
     return files
 
 
-async def _async_collect_files(directory: anyio.Path, relative_to: anyio.Path, files: list[FileTypes]) -> None:
-    async for path in directory.iterdir():
-        if await path.is_dir():
-            await _async_collect_files(path, relative_to, files)
-            continue
+async def _async_resolve_within_root(path: anyio.Path, root: anyio.Path) -> anyio.Path:
+    resolved = await path.resolve(strict=True)
+    try:
+        resolved.relative_to(root)
+    except ValueError as err:
+        raise ValueError(
+            "Refusing to follow directory-upload entry outside the requested root: "
+            f"{path} -> {resolved}"
+        ) from err
+    return resolved
 
-        files.append((path.relative_to(relative_to).as_posix(), await path.read_bytes()))
+
+async def _async_collect_files(
+    directory: anyio.Path,
+    relative_to: anyio.Path,
+    root: anyio.Path,
+    files: list[FileTypes],
+    active_directories: set[_DirectoryKey],
+) -> None:
+    resolved_directory = await _async_resolve_within_root(directory, root)
+    directory_stat = await resolved_directory.stat()
+    directory_key = (directory_stat.st_dev, directory_stat.st_ino)
+    if directory_key in active_directories:
+        raise ValueError(
+            f"Refusing to follow a directory-upload symlink cycle at {directory}"
+        )
+
+    active_directories.add(directory_key)
+    try:
+        async for path in directory.iterdir():
+            resolved = await _async_resolve_within_root(path, root)
+            if await resolved.is_dir():
+                await _async_collect_files(path, relative_to, root, files, active_directories)
+                continue
+
+            files.append((path.relative_to(relative_to).as_posix(), await resolved.read_bytes()))
+    finally:
+        active_directories.remove(directory_key)

--- a/tests/lib/test_files_from_dir_symlinks.py
+++ b/tests/lib/test_files_from_dir_symlinks.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+
+from anthropic.lib._files import async_files_from_dir, files_from_dir
+
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="symlink creation is not reliably available on Windows CI"
+)
+
+
+def _make_tree(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    root = tmp_path / "bundle"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    return root, outside
+
+
+def test_files_from_dir_rejects_file_symlink_outside_root(
+    tmp_path: pathlib.Path,
+) -> None:
+    root, outside = _make_tree(tmp_path)
+    secret = outside / "secret.txt"
+    secret.write_text("outside-secret")
+    (root / "leak.txt").symlink_to(secret)
+
+    with pytest.raises(ValueError, match="outside the requested root"):
+        files_from_dir(root)
+
+
+def test_files_from_dir_allows_symlinks_that_stay_inside_root(
+    tmp_path: pathlib.Path,
+) -> None:
+    root, _ = _make_tree(tmp_path)
+    target = root / "actual.txt"
+    target.write_text("inside")
+    (root / "alias.txt").symlink_to(target.name)
+
+    files = dict(files_from_dir(root))
+
+    assert files[f"{root.name}/actual.txt"] == b"inside"
+    assert files[f"{root.name}/alias.txt"] == b"inside"
+
+
+def test_files_from_dir_rejects_directory_symlink_cycle(
+    tmp_path: pathlib.Path,
+) -> None:
+    root, _ = _make_tree(tmp_path)
+    subdir = root / "subdir"
+    subdir.mkdir()
+    (subdir / "back").symlink_to(root, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink cycle"):
+        files_from_dir(root)
+
+
+@pytest.mark.asyncio()
+async def test_async_files_from_dir_rejects_directory_symlink_outside_root(
+    tmp_path: pathlib.Path,
+) -> None:
+    root, outside = _make_tree(tmp_path)
+    (outside / "data.txt").write_text("outside")
+    (root / "external").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="outside the requested root"):
+        await async_files_from_dir(root)
+
+
+@pytest.mark.asyncio()
+async def test_async_files_from_dir_rejects_directory_symlink_cycle(
+    tmp_path: pathlib.Path,
+) -> None:
+    root, _ = _make_tree(tmp_path)
+    subdir = root / "subdir"
+    subdir.mkdir()
+    (subdir / "back").symlink_to(root, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink cycle"):
+        await async_files_from_dir(root)


### PR DESCRIPTION
## Summary

Prevent `files_from_dir()` and `async_files_from_dir()` from following directory-tree entries outside the directory the caller asked to upload.

The current recursive walkers use `Path.is_dir()` / `anyio.Path.is_dir()`, which follow symlinks. As a result, a symlink inside the requested directory can:

- point to a file outside the requested tree and have that file uploaded;
- point to an external directory and recursively upload its contents;
- point back to an ancestor directory and drive unbounded recursive traversal.

## Fix

Resolve the requested root once and require every traversed entry to resolve underneath it.

For directory recursion, track the `(st_dev, st_ino)` identities currently on the recursion stack. Re-entering an active directory is treated as a symlink cycle and rejected explicitly.

Safe symlinks whose targets remain inside the requested root continue to work. External links and cycles are rejected. The same protection is applied to the sync and async helpers.

## Regression coverage

Adds tests covering:

- a file symlink escaping the requested root;
- an internal file symlink that remains supported;
- an ancestor directory-symlink cycle;
- async external-directory traversal rejection;
- async cycle detection.

The production change is confined to the hand-maintained directory upload helper.