### PR TITLE
Keep capped retry backoff from overflowing

### DIFF
--- a/src/anthropic/lib/_retry.py
+++ b/src/anthropic/lib/_retry.py
@@ -30,8 +30,19 @@ _RETRYABLE_4XX = frozenset({408, 409, 429})
 
 
 def backoff(attempt: int, *, cap: float, base: float = 2.0) -> float:
-    """Exponential backoff for ``attempt`` (1-indexed), capped at ``cap``."""
-    return min(cap, base**attempt)
+    """Exponential backoff for ``attempt`` (1-indexed), capped at ``cap``.
+
+    Compute the uncapped value defensively: long-running helpers can accumulate
+    an arbitrarily large attempt count during a sustained outage, and float
+    exponentiation eventually raises ``OverflowError`` before ``min()`` gets a
+    chance to apply the cap. Once that happens the correct capped value is
+    already known.
+    """
+    try:
+        delay = base**attempt
+    except OverflowError:
+        return cap
+    return min(cap, delay)
 
 
 def jitter(low: float, high: float) -> float:

--- a/tests/lib/test_retry.py
+++ b/tests/lib/test_retry.py
@@ -1,0 +1,15 @@
+from anthropic.lib._retry import backoff
+
+
+def test_backoff_preserves_normal_exponential_values() -> None:
+    assert backoff(1, cap=60.0) == 2.0
+    assert backoff(4, cap=60.0) == 16.0
+    assert backoff(6, cap=60.0) == 60.0
+
+
+def test_backoff_large_attempt_stays_at_cap_instead_of_overflowing() -> None:
+    assert backoff(10_000, cap=60.0) == 60.0
+
+
+def test_backoff_overflow_respects_custom_cap() -> None:
+    assert backoff(10_000, cap=3.5) == 3.5


### PR DESCRIPTION
## Summary

Keep the shared runner-helper backoff capped even after an extremely long sequence of consecutive failures.

`backoff()` currently computes `base ** attempt` before applying `min(cap, ...)`. The environment poller keeps an unbounded failure counter during a sustained control-plane outage, so a sufficiently large attempt count eventually makes floating-point exponentiation raise `OverflowError`. At that point the poller crashes instead of continuing to retry at its configured capped delay.

The cap is supposed to make large attempt counts harmless; the exponentiation currently defeats that guarantee before the cap can be applied.

## Fix

Catch numeric overflow from the uncapped exponential calculation and return the already-known cap.

Normal retry values are unchanged:

- early attempts still use exponential backoff;
- values that naturally exceed the cap still clamp through `min()`;
- only exponentiation that would overflow takes the direct cap path.

This keeps the shared helper safe for arbitrarily long outages without changing poller retry policy or jitter behavior.

## Regression coverage

Adds focused tests covering:

- normal exponential values below the cap;
- ordinary capping once the exponential exceeds the cap;
- a very large attempt count that previously raised `OverflowError`;
- preservation of a custom cap on the overflow path.

The production change is confined to the hand-maintained shared retry helper.