### PR TITLE
Treat empty AWS environment values as unset

### DIFF
--- a/src/anthropic/lib/aws/_credentials.py
+++ b/src/anthropic/lib/aws/_credentials.py
@@ -20,10 +20,15 @@ def validate_credentials(
 
 
 def _read_env(*env_vars: str) -> str | None:
-    """Return the first non-None value from the given env vars, or None."""
+    """Return the first non-empty value from the given env vars, or None.
+
+    Empty-string environment variables are common in CI and container
+    manifests where optional secrets are declared but not populated. Treat
+    them as unset so they do not override later fallbacks or switch auth modes.
+    """
     for var in env_vars:
         value = os.environ.get(var)
-        if value is not None:
+        if value:
             return value
     return None
 

--- a/tests/lib/test_aws_credentials_env.py
+++ b/tests/lib/test_aws_credentials_env.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from anthropic.lib.aws._credentials import (
+    _read_env,
+    resolve_api_key,
+    resolve_auth_mode,
+    resolve_base_url,
+    resolve_workspace_id,
+)
+
+
+def test_read_env_skips_empty_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_TEST_FIRST", "")
+    monkeypatch.setenv("ANTHROPIC_TEST_SECOND", "configured")
+
+    assert _read_env("ANTHROPIC_TEST_FIRST", "ANTHROPIC_TEST_SECOND") == "configured"
+
+
+def test_empty_aws_api_key_env_does_not_disable_sigv4(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_TEST_AWS_API_KEY", "")
+
+    use_sigv4 = resolve_auth_mode(
+        api_key=None,
+        aws_access_key=None,
+        aws_secret_key=None,
+        aws_profile=None,
+        api_key_env_vars=("ANTHROPIC_TEST_AWS_API_KEY",),
+    )
+
+    assert use_sigv4 is True
+    assert resolve_api_key(
+        api_key=None,
+        use_sigv4=use_sigv4,
+        api_key_env_vars=("ANTHROPIC_TEST_AWS_API_KEY",),
+    ) is None
+
+
+def test_empty_workspace_env_is_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_TEST_AWS_WORKSPACE", "")
+
+    assert resolve_workspace_id(None, workspace_id_env_vars=("ANTHROPIC_TEST_AWS_WORKSPACE",)) is None
+
+
+def test_empty_base_url_env_falls_back_to_region(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_TEST_AWS_BASE_URL", "")
+
+    assert (
+        resolve_base_url(
+            None,
+            region="eu-west-1",
+            base_url_env_vars=("ANTHROPIC_TEST_AWS_BASE_URL",),
+        )
+        == "https://aws-external-anthropic.eu-west-1.api.aws"
+    )


### PR DESCRIPTION
## Summary

Treat empty AWS-related environment variables as absent in the AWS client credential resolver.

The shared `_read_env()` helper currently returns the first value that is not `None`. That means an exported-but-empty variable is considered configured. This is common in CI and container manifests where optional secrets are declared with empty defaults.

The most significant case is `ANTHROPIC_AWS_API_KEY=""`: its mere presence switches auth selection from the default AWS SigV4 credential chain into API-key mode, after which the resolved API key is the empty string. A harmless empty placeholder can therefore disable otherwise valid IAM/role credentials.

The same helper is also used for workspace IDs and AWS base URLs, so an empty higher-priority variable can mask a later usable fallback.

## Fix

Have `_read_env()` return the first non-empty environment value instead of the first non-`None` value.

Explicit constructor arguments are unchanged. The normalization applies only to environment fallback resolution, matching the SDK's existing treatment of optional environment credentials in other auth paths.

This restores expected fallback behavior:

- an empty AWS API-key env var no longer disables SigV4;
- an empty workspace env var resolves as absent;
- an empty base-URL env var falls through to the region-derived endpoint;
- when multiple env names are supplied, an empty earlier value no longer masks a later configured value.

## Regression coverage

Adds focused tests for all four cases above using isolated test environment-variable names.

The production change is confined to the hand-maintained AWS credential-resolution helper.