### PR TITLE
Preserve tool runner history during compaction

### DIFF
--- a/src/anthropic/lib/tools/_beta_runner.py
+++ b/src/anthropic/lib/tools/_beta_runner.py
@@ -225,7 +225,9 @@ class BaseSyncToolRunner(BaseToolRunner[BetaRunnableTool, ResponseFormatT], Gene
             ]
 
             if non_tool_blocks:
-                messages[-1]["content"] = non_tool_blocks
+                # ``messages`` is only a shallow list copy. Replace the final
+                # message dict instead of mutating the runner's stored object.
+                messages[-1] = {**messages[-1], "content": non_tool_blocks}
             else:
                 messages.pop()
 
@@ -514,7 +516,9 @@ class BaseAsyncToolRunner(
             ]
 
             if non_tool_blocks:
-                messages[-1]["content"] = non_tool_blocks
+                # ``messages`` is only a shallow list copy. Replace the final
+                # message dict instead of mutating the runner's stored object.
+                messages[-1] = {**messages[-1], "content": non_tool_blocks}
             else:
                 messages.pop()
 

--- a/tests/lib/tools/test_compaction_history_integrity.py
+++ b/tests/lib/tools/test_compaction_history_integrity.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from anthropic import Anthropic, AsyncAnthropic
+from anthropic._compat import PYDANTIC_V1
+from anthropic.lib.tools._beta_runner import BetaAsyncToolRunner, BetaToolRunner
+from anthropic.types.beta.beta_message_param import BetaMessageParam
+
+
+pytestmark = pytest.mark.skipif(
+    PYDANTIC_V1,
+    reason="tool runner not supported with pydantic v1",
+)
+
+
+def _history() -> list[BetaMessageParam]:
+    return [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I will call the tool."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_pending",
+                    "name": "do_work",
+                    "input": {"value": 1},
+                },
+            ],
+        }
+    ]
+
+
+def _last_message() -> Any:
+    return SimpleNamespace(
+        usage=SimpleNamespace(
+            input_tokens=10,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+            output_tokens=10,
+        )
+    )
+
+
+def _block_types(message: BetaMessageParam) -> list[object]:
+    content = cast("list[dict[str, object]]", message["content"])
+    return [block["type"] for block in content]
+
+
+def _assert_compaction_request_is_sanitized(messages: object) -> None:
+    sent = cast("list[BetaMessageParam]", messages)
+    assert _block_types(sent[0]) == ["text"]
+
+
+def test_failed_sync_compaction_does_not_mutate_runner_history() -> None:
+    def fail_create(**kwargs: Any) -> None:
+        _assert_compaction_request_is_sanitized(kwargs["messages"])
+        raise RuntimeError("compaction failed")
+
+    client = cast(
+        Anthropic,
+        SimpleNamespace(beta=SimpleNamespace(messages=SimpleNamespace(create=fail_create))),
+    )
+    history = _history()
+
+    with pytest.warns(DeprecationWarning, match="compaction_control.*deprecated"):
+        runner = BetaToolRunner(
+            params=cast(
+                Any,
+                {"model": "test-model", "max_tokens": 128, "messages": history},
+            ),
+            options={},
+            tools=[],
+            client=client,
+            compaction_control={"enabled": True, "context_token_threshold": 1},
+        )
+    runner._last_message = _last_message()
+
+    with pytest.raises(RuntimeError, match="compaction failed"):
+        runner._check_and_compact()
+
+    stored = cast("list[BetaMessageParam]", runner._params["messages"])
+    assert stored[0]["content"] == history[0]["content"]
+    assert _block_types(stored[0]) == ["text", "tool_use"]
+
+
+@pytest.mark.asyncio
+async def test_failed_async_compaction_does_not_mutate_runner_history() -> None:
+    async def fail_create(**kwargs: Any) -> None:
+        _assert_compaction_request_is_sanitized(kwargs["messages"])
+        raise RuntimeError("compaction failed")
+
+    client = cast(
+        AsyncAnthropic,
+        SimpleNamespace(beta=SimpleNamespace(messages=SimpleNamespace(create=fail_create))),
+    )
+    history = _history()
+
+    with pytest.warns(DeprecationWarning, match="compaction_control.*deprecated"):
+        runner = BetaAsyncToolRunner(
+            params=cast(
+                Any,
+                {"model": "test-model", "max_tokens": 128, "messages": history},
+            ),
+            options={},
+            tools=[],
+            client=client,
+            compaction_control={"enabled": True, "context_token_threshold": 1},
+        )
+    runner._last_message = _last_message()
+
+    with pytest.raises(RuntimeError, match="compaction failed"):
+        await runner._check_and_compact()
+
+    stored = cast("list[BetaMessageParam]", runner._params["messages"])
+    assert stored[0]["content"] == history[0]["content"]
+    assert _block_types(stored[0]) == ["text", "tool_use"]


### PR DESCRIPTION
## Summary

Prevent deprecated client-side compaction from mutating the tool runner's live conversation history before the compaction request succeeds.

Both the synchronous and asynchronous tool runners create the compaction history with:

messages = list(self._params["messages"])

That copies the list but not the message dictionaries inside it. When the most recent assistant message contains a pending `tool_use`, compaction removes that block before sending the summary request by assigning to `messages[-1]["content"]`.

Because the final dictionary is shared with `self._params["messages"]`, this also edits the runner's stored conversation in place.

If the compaction API call then fails, the runner is left with corrupted history: the pending tool call has disappeared even though no compaction summary was produced.

## Fix

Keep the temporary compaction history copy-on-write.

When non-tool blocks need to replace the final assistant message's content, replace the final message dictionary in the temporary list instead of mutating the shared dictionary:

messages[-1] = {**messages[-1], "content": non_tool_blocks}

The change is applied symmetrically to the synchronous and asynchronous compaction paths.

Successful compaction behavior is otherwise unchanged.

## Regression coverage

Adds deterministic sync and async failure-path tests that verify:

- the history sent to the compaction request has pending `tool_use` blocks removed as required;
- the compaction request then fails deliberately;
- the runner's stored history still contains the original text and pending `tool_use` blocks after the failure.

The production change is confined to Anthropic's hand-maintained tool-runner implementation.