### PR TITLE
Restrict cleartext credential URLs to loopback hostnames

### DIFF
--- a/src/anthropic/lib/credentials/_constants.py
+++ b/src/anthropic/lib/credentials/_constants.py
@@ -4,6 +4,7 @@ import os
 import sys
 import pathlib
 from typing import Optional
+from urllib.parse import urlsplit
 
 from ..._exceptions import AnthropicError, CredentialsError
 
@@ -114,17 +115,19 @@ def _active_profile() -> str:  # pyright: ignore[reportUnusedFunction] — used 
 
 
 def _require_https(url: str, *, field: str) -> None:  # pyright: ignore[reportUnusedFunction] — used by _workload/_providers
-    """Reject non-``https://`` token-endpoint URLs.
+    """Reject non-HTTPS token-endpoint URLs except actual loopback hosts.
 
     Localhost is allowed for testing so ``base_url="http://localhost:8080"``
     works against a local ``oauth_server`` instance; everything else must be
     TLS-encrypted because the body of these POSTs carries the assertion JWT
     or a long-lived refresh token.
     """
-    lowered = url.lower().rstrip("/")
-    if lowered.startswith("https://"):
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() == "https":
         return
-    if lowered.startswith(("http://localhost", "http://127.0.0.1", "http://[::1]")):
+
+    hostname = (parsed.hostname or "").rstrip(".").lower()
+    if parsed.scheme.lower() == "http" and hostname in {"localhost", "127.0.0.1", "::1"}:
         return
     raise CredentialsError(
         f"{field} must use https (got {url!r}); the token-exchange endpoint "

--- a/tests/lib/test_credentials_https_validation.py
+++ b/tests/lib/test_credentials_https_validation.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from anthropic import AnthropicError
+from anthropic.lib.credentials._constants import _require_https
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.anthropic.com",
+        "HTTPS://example.com/custom",
+        "http://localhost:8080",
+        "http://localhost.:8080",
+        "http://127.0.0.1:8080",
+        "http://[::1]:8080",
+    ],
+)
+def test_require_https_allows_https_and_actual_loopback_hosts(url: str) -> None:
+    _require_https(url, field="base_url")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost.evil.example",
+        "http://localhost-example.com",
+        "http://127.0.0.1.evil.example",
+        "http://localhost@evil.example",
+        "http://192.168.1.10",
+        "http://example.com",
+    ],
+)
+def test_require_https_rejects_cleartext_lookalike_and_non_loopback_hosts(url: str) -> None:
+    with pytest.raises(AnthropicError, match="must use https"):
+        _require_https(url, field="base_url")


### PR DESCRIPTION
## Summary

Restrict the credential subsystem's cleartext-HTTP exception to explicit loopback hostnames instead of textual URL prefixes.

`_require_https()` protects OAuth/federation token-exchange endpoints, whose request bodies can contain an assertion JWT or a long-lived refresh token. It currently allows local test endpoints with prefix checks such as `url.startswith("http://localhost")` and `url.startswith("http://127.0.0.1")`.

Those checks also accept non-local lookalike hosts including `http://localhost.evil.example` and `http://127.0.0.1.evil.example`. A credential configuration using one of those hosts can therefore pass the HTTPS guard and send secret token-exchange material over cleartext HTTP to a remote endpoint.

## Fix

Parse the URL and validate its scheme and hostname separately.

- HTTPS remains accepted normally.
- Cleartext HTTP is accepted only when the parsed hostname is exactly `localhost`, `127.0.0.1`, or `::1`.
- A trailing DNS dot on `localhost.` remains supported for local testing.
- Lookalike domains, userinfo tricks, private-network addresses, and ordinary remote HTTP endpoints are rejected.

This preserves the existing localhost testing exception without allowing prefix-based hostname confusion.

## Regression coverage

Adds focused tests covering valid HTTPS and loopback endpoints plus deceptive/non-loopback cleartext URLs, including:

- `localhost.evil.example`
- `localhost-example.com`
- `127.0.0.1.evil.example`
- `localhost@evil.example`
- a private-network address
- a normal remote HTTP host

The production change is confined to the hand-maintained credential URL validation helper.