### PR TITLE
Validate provider access tokens before auth

### DIFF
--- a/src/anthropic/lib/credentials/_auth.py
+++ b/src/anthropic/lib/credentials/_auth.py
@@ -9,6 +9,7 @@ import httpx2
 
 from ._cache import TokenCache
 from ..._utils import asyncify
+from ..._exceptions import CredentialsError
 from ._constants import OAUTH_API_BETA_HEADER
 
 __all__ = ["AccessTokenAuth"]
@@ -86,6 +87,12 @@ class AccessTokenAuth(httpx2.Auth):
         return bool(request.headers.get("X-Api-Key") or request.headers.get("Authorization"))
 
     def _apply(self, request: httpx2.Request, token: str) -> None:
+        if not isinstance(token, str) or not token or token != token.strip():
+            raise CredentialsError(
+                "Credentials provider returned an invalid access token; expected a non-empty string "
+                "without surrounding whitespace."
+            )
+
         request.headers["Authorization"] = f"Bearer {token}"
         existing_beta = request.headers.get("anthropic-beta", "")
         # Tokenize the comma-separated header so dedupe matches whole flag

--- a/tests/lib/test_access_token_auth_validation.py
+++ b/tests/lib/test_access_token_auth_validation.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import httpx2
+import pytest
+
+from anthropic import CredentialsError
+from anthropic.lib.credentials._auth import AccessTokenAuth
+from anthropic.lib.credentials._cache import TokenCache
+
+
+class _TokenCacheStub:
+    def __init__(self, token: Any) -> None:
+        self.token = token
+        self.calls = 0
+
+    def get_token(self) -> str:
+        self.calls += 1
+        return cast(str, self.token)
+
+
+def _auth(token: Any) -> tuple[AccessTokenAuth, _TokenCacheStub]:
+    cache = _TokenCacheStub(token)
+    return AccessTokenAuth(cast(TokenCache, cache)), cache
+
+
+@pytest.mark.parametrize("token", ["", " ", " token", "token ", "\ttoken", None])
+def test_sync_auth_rejects_invalid_provider_tokens(token: Any) -> None:
+    auth, cache = _auth(token)
+    request = httpx2.Request("GET", "https://api.anthropic.com/v1/models")
+
+    with pytest.raises(CredentialsError, match="invalid access token"):
+        list(auth.sync_auth_flow(request))
+
+    assert cache.calls == 1
+    assert "Authorization" not in request.headers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token", ["", " ", " token", "token ", "\ttoken", None])
+async def test_async_auth_rejects_invalid_provider_tokens(token: Any) -> None:
+    auth, cache = _auth(token)
+    request = httpx2.Request("GET", "https://api.anthropic.com/v1/models")
+
+    with pytest.raises(CredentialsError, match="invalid access token"):
+        [item async for item in auth.async_auth_flow(request)]
+
+    assert cache.calls == 1
+    assert "Authorization" not in request.headers
+
+
+def test_valid_provider_token_is_applied() -> None:
+    auth, cache = _auth("access-token")
+    request = httpx2.Request("GET", "https://api.anthropic.com/v1/models")
+
+    yielded = list(auth.sync_auth_flow(request))
+
+    assert yielded == [request]
+    assert cache.calls == 1
+    assert request.headers["Authorization"] == "Bearer access-token"
+    assert "oauth-2025-04-20" in request.headers["anthropic-beta"]
+
+
+def test_static_authorization_still_bypasses_provider_validation() -> None:
+    auth, cache = _auth("")
+    request = httpx2.Request(
+        "GET",
+        "https://api.anthropic.com/v1/models",
+        headers={"Authorization": "Bearer explicit-token"},
+    )
+
+    yielded = list(auth.sync_auth_flow(request))
+
+    assert yielded == [request]
+    assert cache.calls == 0
+    assert request.headers["Authorization"] == "Bearer explicit-token"


### PR DESCRIPTION
## Summary

Reject malformed access-token values from dynamic credential providers before constructing an HTTP `Authorization` header.

`AccessTokenAuth` currently trusts the string returned by `TokenCache.get_token()` and immediately constructs:

`Authorization: Bearer <token>`

A custom credential provider can return an empty token or a token with surrounding whitespace. In the empty case the SDK produces `Authorization: Bearer `, which can be rejected later by the HTTP stack as an invalid header value. The resulting protocol/API connection error obscures the actual problem: the credential provider returned an invalid token.

## Fix

Validate the token immediately before applying it to the request.

The auth adapter now requires:

- a string token;
- a non-empty token;
- no surrounding whitespace.

Invalid provider output raises a clear `AnthropicError` before any Authorization header is added.

Caller-supplied static credentials retain their existing precedence.

## Regression coverage

Adds sync and async tests covering invalid provider tokens, valid tokens, OAuth beta-header injection, and static Authorization bypass.