### PR TITLE
Freeze AWS credentials before SigV4 signing

### DIFF
--- a/src/anthropic/lib/aws/_auth.py
+++ b/src/anthropic/lib/aws/_auth.py
@@ -64,7 +64,12 @@ def get_auth_headers(
     if not credentials:
         raise RuntimeError("Could not resolve AWS credentials from session")
 
-    signer = SigV4Auth(credentials, service_name, session.region_name)
+    # Refreshable botocore credentials are proxy objects whose individual
+    # properties may trigger a refresh. Freeze one coherent snapshot before
+    # signing so access key, secret key, and session token cannot come from
+    # different credential generations.
+    frozen_credentials = credentials.get_frozen_credentials()
+    signer = SigV4Auth(frozen_credentials, service_name, session.region_name)
     signer.add_auth(request)
 
     prepped = request.prepare()

--- a/tests/lib/test_aws_frozen_credentials.py
+++ b/tests/lib/test_aws_frozen_credentials.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any
+
+import botocore.auth
+import httpx
+import pytest
+
+from anthropic.lib.aws import _auth
+
+
+class _RefreshableCredentials:
+    def __init__(self) -> None:
+        self.frozen = object()
+        self.freeze_calls = 0
+
+    def get_frozen_credentials(self) -> object:
+        self.freeze_calls += 1
+        return self.frozen
+
+
+class _Session:
+    def __init__(self, credentials: object) -> None:
+        self._credentials = credentials
+        self.region_name = "us-east-1"
+
+    def get_credentials(self) -> object:
+        return self._credentials
+
+
+def test_sigv4_signing_uses_one_frozen_credential_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    credentials = _RefreshableCredentials()
+    session = _Session(credentials)
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(_auth, "_get_session", lambda **_kwargs: session)
+
+    class _Signer:
+        def __init__(self, signing_credentials: object, service_name: str, region_name: str) -> None:
+            captured["credentials"] = signing_credentials
+            captured["service_name"] = service_name
+            captured["region_name"] = region_name
+
+        def add_auth(self, request: Any) -> None:
+            request.headers["Authorization"] = "signed"
+
+    monkeypatch.setattr(botocore.auth, "SigV4Auth", _Signer)
+
+    headers = _auth.get_auth_headers(
+        method="post",
+        url="https://example.amazonaws.com/v1/messages",
+        headers=httpx.Headers({"content-type": "application/json"}),
+        aws_access_key=None,
+        aws_secret_key=None,
+        aws_session_token=None,
+        region="us-east-1",
+        profile=None,
+        data="{}",
+        service_name="bedrock",
+    )
+
+    assert credentials.freeze_calls == 1
+    assert captured["credentials"] is credentials.frozen
+    assert captured["service_name"] == "bedrock"
+    assert captured["region_name"] == "us-east-1"
+    assert headers["Authorization"] == "signed"


### PR DESCRIPTION
## Summary

Freeze the AWS credential set before constructing a SigV4 signer so each request is signed from one coherent credential generation.

`get_auth_headers()` currently passes the object returned by `boto3.Session.get_credentials()` directly to `SigV4Auth`. That object may be refreshable. Its access key, secret key, and session token are exposed through credential properties, so using the live refreshable object during signing can allow a refresh to occur while the signer is reading the credential set.

A request should be signed with one immutable access-key / secret-key / session-token tuple. Botocore's own signing path obtains a frozen credential snapshot before constructing the auth implementation.

## Fix

Call `credentials.get_frozen_credentials()` after resolving the session credentials and pass that snapshot to `SigV4Auth`.

Static credentials are unaffected. Missing-credential behavior, region selection, request construction, and signed-header handling are unchanged.

## Regression coverage

Adds a deterministic unit test verifying:

- `get_frozen_credentials()` is called exactly once;
- `SigV4Auth` receives the frozen snapshot rather than the live credential proxy;
- service and region arguments are preserved;
- the signed Authorization header is returned normally.

The production change is confined to the hand-maintained AWS SigV4 auth helper.