### PR TITLE
Preserve explicit empty query string values

### DIFF
--- a/src/anthropic/_qs.py
+++ b/src/anthropic/_qs.py
@@ -112,10 +112,13 @@ class Querystring:
                     f"Unknown array_format value: {array_format}, choose from {', '.join(get_args(ArrayFormat))}"
                 )
 
-        serialised = self._primitive_value_to_str(value)
-        if not serialised:
+        # ``None`` means "not supplied" in the SDK's query model and retains
+        # the existing omission behavior. An explicit empty string is different:
+        # preserve it as ``key=`` so callers can distinguish a blank value from
+        # an absent parameter.
+        if value is None:
             return []
-        return [(key, serialised)]
+        return [(key, self._primitive_value_to_str(value))]
 
     def _primitive_value_to_str(self, value: PrimitiveData) -> str:
         # copied from httpx

--- a/tests/test_qs_empty_values.py
+++ b/tests/test_qs_empty_values.py
@@ -1,0 +1,24 @@
+from urllib.parse import unquote
+
+from anthropic._qs import Querystring, stringify
+
+
+def test_preserves_explicit_empty_string() -> None:
+    assert stringify({"blank": ""}) == "blank="
+
+
+def test_preserves_nested_empty_string() -> None:
+    assert unquote(stringify({"filter": {"name": ""}})) == "filter[name]="
+
+
+def test_repeat_array_preserves_empty_string_but_omits_none() -> None:
+    assert unquote(stringify({"item": ["first", "", None, "last"]})) == "item=first&item=&item=last"
+
+
+def test_bracket_array_preserves_empty_string_but_omits_none() -> None:
+    serialise = Querystring(array_format="brackets").stringify
+    assert unquote(serialise({"item": ["", None, "last"]})) == "item[]=&item[]=last"
+
+
+def test_none_remains_omitted() -> None:
+    assert stringify({"blank": None}) == ""


### PR DESCRIPTION
## Summary

Preserve explicitly empty string query parameters instead of silently dropping them from the request URL.

`Querystring._stringify_item()` currently converts a primitive value to a string and then drops it whenever the serialized result is falsy. That intentionally omits `None`, but it also conflates `""` with absence:

- `{"key": None}` -> parameter omitted
- `{"key": ""}` -> parameter also omitted

HTTP APIs can distinguish a missing parameter from an explicitly blank one (`key=`), so callers currently cannot express the latter through the SDK query serializer.

The same issue affects nested values and repeat/bracket array entries containing an empty string.

## Fix

Make omission depend on the original value being `None`, not on the truthiness of its serialized representation.

Existing behavior is preserved for `None`. Explicit empty strings now serialize as `key=`. All non-empty strings, numbers, booleans, nested mappings, and existing array formatting continue through the same serialization paths as before.

## Regression coverage

Adds focused tests covering:

- a top-level empty string -> `blank=`;
- a nested empty string -> `filter[name]=`;
- repeat-array empty strings remaining present while `None` entries stay omitted;
- bracket-array empty strings with the same behavior;
- the existing top-level `None` omission contract.

The production change is confined to the query-string serializer.