### PR TITLE
fix(transform schema): preserve const constraints

### DIFF
--- a/src/anthropic/lib/_parse/_transform.py
+++ b/src/anthropic/lib/_parse/_transform.py
@@ -117,6 +117,10 @@ def transform_schema(
     if is_list(enum):
         strict_schema["enum"] = enum
 
+    # Use a key-presence check because `const: null` is a valid constraint.
+    if "const" in json_schema:
+        strict_schema["const"] = json_schema.pop("const")
+
     description = json_schema.pop("description", None)
     if description is not None:
         strict_schema["description"] = description

--- a/tests/lib/_parse/test_transform.py
+++ b/tests/lib/_parse/test_transform.py
@@ -73,6 +73,22 @@ def test_enum_schema():
     assert result == snapshot({"type": "string", "enum": ["foo", "bar"]})
 
 
+def test_const_schema():
+    # Pydantic v2 emits `const` for single-value `Literal` fields, e.g.
+    # `Literal["ok"]` -> `{"type": "string", "const": "ok"}`.
+    schema = {"type": "string", "const": "ok"}
+    result = transform_schema(schema)
+    assert result == snapshot({"type": "string", "const": "ok"})
+
+
+def test_const_null_schema():
+    # A present `const: None` constraint must not be confused with an
+    # absent `const` key.
+    schema = {"type": "null", "const": None}
+    result = transform_schema(schema)
+    assert result == snapshot({"type": "null", "const": None})
+
+
 def test_allof():
     schema = {
         "allOf": [


### PR DESCRIPTION
## Summary

- Preserve JSON Schema `const` constraints in `transform_schema()` instead of moving them into description text.
- Add regression coverage for scalar and null `const` values.

## Problem

Pydantic v2 emits `const` for single-value `Literal` fields. `transform_schema()` currently has explicit handling for `enum` but not `const`, so the keyword reaches the unsupported-property fallback and is moved into `description`. The request schema therefore loses a supported grammar-level constraint ([`const` is listed as supported for structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations)), while SDK-side parsing still validates against the original Pydantic model.

Related to the enum handling added in #1275.

```python
class Job(pydantic.BaseModel):
    status: Literal["ok"]

# property schema emitted by pydantic:   {"const": "ok", "title": "Status", "type": "string"}
# transform_schema() before this change: {"type": "string", "title": "Status", "description": "{const: ok}"}
# transform_schema() after this change:  {"type": "string", "const": "ok", "title": "Status"}
```

## Fix

Preserve `const` next to the existing `enum` handling. Use a key-presence check rather than `pop("const", None)` so a valid `const: null` constraint is not confused with an absent key.

## Tests

Both new tests fail on unmodified `upstream/next` because `const` is demoted into `description` (`{"type": "string", "const": "ok"}` becomes `{"type": "string", "description": "{const: ok}"}`).

Commands run (all exited zero):

- `uv run --isolated --all-extras pytest tests/lib/_parse/test_transform.py -n0` — 16 passed (Python 3.9, pydantic 2.12.5)
- `uv run --isolated --all-extras --no-extra=mcp --group=pydantic-v1 pytest tests/lib/_parse/test_transform.py -n0` — 16 passed (Python 3.9, pydantic v1)
- same test file with `UV_PYTHON=">=3.14.0"` — 16 passed (Python 3.14, pydantic 2.12)
- `uv run ruff check` on the two touched files — passed
- `uv run ruff format --check` on the two touched files — already formatted
- `uv run pyright` on the two touched files — 0 errors, 0 warnings

## Scope

Hand-maintained schema-transformer logic (`src/anthropic/lib/_parse/_transform.py`) and its focused regression tests only.
