### PR TITLE
fix(streaming): resolve Pydantic validation bypass causing dict attribute crashes

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -469,7 +469,8 @@ def accumulate_event(
     if current_snapshot is None:
         if event.type == "message_start":
             return cast(
-                ParsedBetaMessage[ResponseFormatT], ParsedBetaMessage.construct(**cast(Any, event.message.to_dict()))
+                ParsedBetaMessage[ResponseFormatT],
+                construct_type(type_=ParsedBetaMessage, value=event.message.to_dict()),
             )
 
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -449,7 +449,10 @@ def accumulate_event(
 
     if current_snapshot is None:
         if event.type == "message_start":
-            return cast(ParsedMessage[ResponseFormatT], ParsedMessage.construct(**cast(Any, event.message.to_dict())))
+            return cast(
+                ParsedMessage[ResponseFormatT],
+                construct_type(type_=ParsedMessage, value=event.message.to_dict()),
+            )
 
         raise RuntimeError(f'Unexpected event order, got {event.type} before "message_start"')
 


### PR DESCRIPTION
## Summary
(Extracted from #1797 to isolate the Pydantic type safety bug from the out-of-order index bug).

The snapshot initialization currently uses Pydantic`s `construct(**event.message.to_dict())`. Because `construct()` skips validation and deep coercion, nested fields like `usage` are left as raw Python dictionaries rather than Pydantic objects.

When a subsequent usage delta arrives, `current_snapshot.usage.output_tokens = ...` will crash with `AttributeError: 'dict' object has no attribute 'output_tokens'`. This PR isolates and fixes this type safety bug by using `construct_type(type_=...)`, ensuring correct instantiation of nested models so they can be safely mutated by subsequent streaming events.