### PR TITLE
fix(credentials): guard fchmod on Windows

### DIFF
--- a/src/anthropic/lib/credentials/_providers.py
+++ b/src/anthropic/lib/credentials/_providers.py
@@ -472,7 +472,9 @@ class CredentialsFile:
         fd, tmp = tempfile.mkstemp(dir=parent, prefix=f".{self._credentials_path.name}.", suffix=".tmp")
         try:
             try:
-                os.fchmod(fd, 0o600)
+                fchmod = getattr(os, "fchmod", None)
+                if fchmod is not None:
+                    fchmod(fd, 0o600)
                 os.write(fd, _json_dumps_secrets(data, indent=2))
                 os.fsync(fd)
             finally:

--- a/tests/lib/test_credentials.py
+++ b/tests/lib/test_credentials.py
@@ -605,6 +605,44 @@ class TestCredentialsFile:
 
     # -- "type": "authorized_user" ----------------------------------------
 
+    def test_atomic_write_credentials_without_fchmod(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        credentials_path = tmp_path / "credentials" / "default.json"
+        provider = CredentialsFile()
+        provider._credentials_path = credentials_path  # pyright: ignore[reportPrivateUsage]
+        monkeypatch.delattr(os, "fchmod", raising=False)
+
+        provider._atomic_write_credentials(  # pyright: ignore[reportPrivateUsage]
+            {"access_token": "new-token", "refresh_token": "new-refresh"}
+        )
+
+        assert json.loads(credentials_path.read_text()) == {
+            "access_token": "new-token",
+            "refresh_token": "new-refresh",
+        }
+        assert not list(credentials_path.parent.glob(".default.json.*.tmp"))
+
+    def test_atomic_write_credentials_uses_restrictive_mode_when_fchmod_available(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        credentials_path = tmp_path / "credentials" / "default.json"
+        provider = CredentialsFile()
+        provider._credentials_path = credentials_path  # pyright: ignore[reportPrivateUsage]
+        calls: List[tuple[int, int]] = []
+
+        def record_fchmod(fd: int, mode: int) -> None:
+            calls.append((fd, mode))
+
+        monkeypatch.setattr(os, "fchmod", record_fchmod, raising=False)
+
+        provider._atomic_write_credentials(  # pyright: ignore[reportPrivateUsage]
+            {"access_token": "new-token"}
+        )
+
+        assert len(calls) == 1
+        assert calls[0][1] == 0o600
+
     @pytest.mark.respx(base_url=BASE_URL)
     def test_authorized_user_refresh_and_writeback(self, respx_mock: MockRouter, tmp_path: pathlib.Path) -> None:
         """Refresh writes back to credentials/ only — configs/ stays untouched."""


### PR DESCRIPTION
Fixes #1868

## Summary

Guard the POSIX-only `os.fchmod` call when atomically writing credentials so
OAuth token refreshes can persist rotated credentials on Windows.

The write path still applies mode `0600` whenever `fchmod` is available. On
platforms without it, the existing atomic write, file `fsync`, and replacement
continue normally.

## Impact

Previously, the refresh request could succeed and rotate the server-side
refresh token, then Windows would raise `AttributeError` before writing the new
token. The credentials file retained the now-invalid old token and subsequent
refreshes failed with `invalid_grant`.

## Tests

- deterministic regression with `os.fchmod` removed
- security regression proving available `fchmod` is called with `0600`
- existing end-to-end mocked refresh/write-back test
- `tests/lib/test_credentials.py`: 219 passed, 4 skipped
- `ruff check .`
- targeted Ruff format, Pyright, and Mypy checks
- dependency-cap validation and import smoke test
- `git diff --check`

No real credentials, API calls, or external services are used by the
regression tests.
