### PR TITLE
fix(streaming): fire InputJsonEvent for server_tool_use blocks

### DIFF
--- a/src/anthropic/lib/streaming/_beta_messages.py
+++ b/src/anthropic/lib/streaming/_beta_messages.py
@@ -365,7 +365,7 @@ def build_events(
                     )
                 )
         elif event.delta.type == "input_json_delta":
-            if content_block.type == "tool_use" or content_block.type == "mcp_tool_use":
+            if content_block.type in ("tool_use", "mcp_tool_use", "server_tool_use"):
                 events_to_fire.append(
                     build(
                         BetaInputJsonEvent,

--- a/src/anthropic/lib/streaming/_messages.py
+++ b/src/anthropic/lib/streaming/_messages.py
@@ -360,7 +360,7 @@ def build_events(
                     )
                 )
         elif event.delta.type == "input_json_delta":
-            if content_block.type == "tool_use":
+            if content_block.type in ("tool_use", "server_tool_use"):
                 events_to_fire.append(
                     build(
                         InputJsonEvent,


### PR DESCRIPTION
## Summary
When streaming a response that includes a `server_tool_use` block (e.g. computer use / bash tools), the `build_events` function was failing to yield `InputJsonEvent`s (and `BetaInputJsonEvent`s) because it only checked `content_block.type == "tool_use"`.

This meant users trying to stream the arguments of a server tool use would silently receive nothing, even though the JSON was being correctly accumulated in the background into the snapshot.

This PR adds `"server_tool_use"` to the check, allowing `InputJsonEvent` to fire correctly for server tools in both stable and beta streaming.