### PR TITLE
fix: extract tuple file arrays in multipart uploads

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -17,7 +17,7 @@ from ._types import (
     HttpxFileContent,
     HttpxRequestFiles,
 )
-from ._utils import is_list, is_mapping, is_tuple_t, is_mapping_t, is_sequence_t
+from ._utils import is_list, is_tuple, is_mapping, is_tuple_t, is_mapping_t, is_sequence_t
 
 _T = TypeVar("_T")
 
@@ -161,11 +161,14 @@ def _deepcopy_with_paths(item: _T, paths: Sequence[Sequence[str]], index: int) -
             if key in result:
                 result[key] = _deepcopy_with_paths(result[key], subpaths, index + 1)
         return cast(_T, result)
-    if is_list(item):
+    if is_list(item) or is_tuple(item):
         array_paths = [path for path in paths if index < len(path) and path[index] == "<array>"]
 
-        # if no path expects a list here, nothing will be mutated inside it - return by reference
+        # if no path expects an array here, nothing will be mutated inside it - return by reference
         if not array_paths:
             return cast(_T, item)
-        return cast(_T, [_deepcopy_with_paths(entry, array_paths, index + 1) for entry in item])
+        copied_entries = [_deepcopy_with_paths(entry, array_paths, index + 1) for entry in item]
+        if is_tuple(item):
+            return cast(_T, tuple(copied_entries))
+        return cast(_T, copied_entries)
     return item

--- a/src/anthropic/_utils/_utils.py
+++ b/src/anthropic/_utils/_utils.py
@@ -72,6 +72,10 @@ def _array_suffix(array_format: ArrayFormat, array_index: int) -> str:
     )
 
 
+def _is_array_like(obj: object) -> TypeGuard[list[object] | tuple[object, ...]]:
+    return isinstance(obj, (list, tuple))
+
+
 def _extract_items(
     obj: object,
     path: Sequence[str],
@@ -130,7 +134,7 @@ def _extract_items(
             flattened_key=flattened_key,
             array_format=array_format,
         )
-    elif is_list(obj):
+    elif _is_array_like(obj):
         if key != "<array>":
             return []
 

--- a/tests/test_extract_files.py
+++ b/tests/test_extract_files.py
@@ -41,6 +41,21 @@ def test_top_level_file_array() -> None:
     assert query == {"title": "hello"}
 
 
+def test_top_level_file_tuple_array() -> None:
+    query = {"files": (b"file one", b"file two"), "title": "hello"}
+    assert extract_files(query, paths=[["files", "<array>"]]) == [("files[]", b"file one"), ("files[]", b"file two")]
+    assert query == {"title": "hello"}
+
+
+def test_nested_file_tuple_array() -> None:
+    query = {"documents": ({"file": b"My first file"}, {"file": b"My second file"})}
+    assert extract_files(query, paths=[["documents", "<array>", "file"]]) == [
+        ("documents[][file]", b"My first file"),
+        ("documents[][file]", b"My second file"),
+    ]
+    assert query == {"documents": ({}, {})}
+
+
 @pytest.mark.parametrize(
     "query,paths,expected",
     [

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -110,6 +110,18 @@ class TestDeepcopyWithPaths:
         assert_different_identities(result_items[0], elem1)
         assert_different_identities(result_items[1], elem2)
 
+    def test_nested_array_path_copies_tuple_and_elements(self) -> None:
+        elem1 = {"file": b"f1", "extra": 1}
+        elem2 = {"file": b"f2", "extra": 2}
+        original = {"items": (elem1, elem2)}
+        result = deepcopy_with_paths(original, [["items", "<array>", "file"]])
+        assert_different_identities(result, original)
+        result_items = result["items"]
+        assert isinstance(result_items, tuple)
+        assert_different_identities(result_items, original["items"])
+        assert_different_identities(result_items[0], elem1)
+        assert_different_identities(result_items[1], elem2)
+
     def test_empty_paths_returns_same_object(self) -> None:
         original = {"foo": "bar"}
         result = deepcopy_with_paths(original, [])


### PR DESCRIPTION
## Summary

Multipart file extraction accepts a sequence of file tuples, but tuple arrays can be silently skipped because the generic sequence branch only recognizes individual file-like values. This change normalizes tuple entries before the generic file-content path so tuple arrays are extracted consistently for both sync and async uploads.

The change also preserves tuple deepcopy isolation for nested extraction. Existing filename and content-type handling remains unchanged.

## Testing

- `uv run pytest tests/test_extract_files.py tests/test_files.py -q` - 29 passed.
- `uv run ruff check src/anthropic/_files.py src/anthropic/_utils/_utils.py tests/test_extract_files.py tests/test_files.py` - passed.
- `uv run ruff format --check src/anthropic/_files.py src/anthropic/_utils/_utils.py tests/test_extract_files.py tests/test_files.py` - passed.
- `uv run pyright src/anthropic/_files.py src/anthropic/_utils/_utils.py tests/test_extract_files.py tests/test_files.py` - 0 errors, 0 warnings, 0 informations.
- `git diff --check origin/main...HEAD` - passed.

The repository `scripts/lint` ruff and dependency-cap stages passed. Its full-repository pyright stage still reports existing optional-extra/provider typing and missing-import errors outside the changed files; the changed-file pyright run above is the relevant type evidence for this patch. No network calls or live credentials are required for the regression.

The submitted commit is SSH-signed and GitHub exposes the required verified signature on the exact head.

## Compatibility

This is backward compatible. It changes only which already-supported tuple-array inputs are extracted for multipart uploads; existing individual file values, filenames, content types, and async behavior retain their prior contracts.
