### PR TITLE
fix(aws): stop ambient bearer credentials leaking under skip_auth

### DIFF
--- a/src/anthropic/lib/aws/_client.py
+++ b/src/anthropic/lib/aws/_client.py
@@ -136,6 +136,16 @@ class AnthropicAWS(Anthropic):
             return {}
         return super()._api_key_auth
 
+    @property
+    @override
+    def _bearer_auth(self) -> dict[str, str]:
+        # skip_auth must also silence ambient bearer credentials: the parent
+        # constructor falls back to ANTHROPIC_AUTH_TOKEN from the environment,
+        # and a leaked Authorization header defeats the point of skip_auth.
+        if self._skip_auth:
+            return {}
+        return super()._bearer_auth
+
     @override
     def _validate_headers(self, headers: httpx.Headers, omitted: frozenset[str]) -> None:
         if self._use_sigv4 or self._skip_auth:
@@ -343,6 +353,16 @@ class AsyncAnthropicAWS(AsyncAnthropic):
         if self._use_sigv4 or self._skip_auth:
             return {}
         return super()._api_key_auth
+
+    @property
+    @override
+    def _bearer_auth(self) -> dict[str, str]:
+        # skip_auth must also silence ambient bearer credentials: the parent
+        # constructor falls back to ANTHROPIC_AUTH_TOKEN from the environment,
+        # and a leaked Authorization header defeats the point of skip_auth.
+        if self._skip_auth:
+            return {}
+        return super()._bearer_auth
 
     @override
     def _validate_headers(self, headers: httpx.Headers, omitted: frozenset[str]) -> None:


### PR DESCRIPTION
> **Security note:** with `skip_auth=True` and `ANTHROPIC_AUTH_TOKEN` exported (standard in Claude Code sessions), every request carries `Authorization: Bearer <ambient token>` toward whatever base URL the client targets, including non-AWS hosts. This PR closes that leak.

## What

`AnthropicAWS` and `AsyncAnthropicAWS` suppress their own SigV4 and `x-api-key` layers when `skip_auth=True`, but the parent constructor's environment fallback for `ANTHROPIC_AUTH_TOKEN` still installed a Bearer `Authorization` header.

## Why

The subclass passes `auth_token=None` up to the base constructor, which treats that as "no explicit credential" and falls back to `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` from the environment. A client created with `skip_auth=True` therefore sends `Authorization: Bearer <ambient token>` to whatever base URL it targets, which is both a credential leak to a non-AWS host and the exact opposite of what `skip_auth` promises.

CI never catches this because the test suite runs without those environment variables set; the existing regression test fails deterministically on any machine where they are exported (for example Claude Code sessions).

## Change

Add a `_bearer_auth` override symmetric with the existing `_api_key_auth` override: return no header while `_skip_auth` is set.

`test_skip_auth_no_auth_headers` covers this directly: it fails on main when `ANTHROPIC_AUTH_TOKEN` is exported and passes with this change, in both exported and unset environments.