### PR TITLE
fix: treat empty-string ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN as absent

### DIFF
--- a/src/anthropic/_client.py
+++ b/src/anthropic/_client.py
@@ -211,8 +211,8 @@ class Anthropic(SyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---
@@ -628,8 +628,8 @@ class AsyncAnthropic(AsyncAPIClient):
             or profile is not None
         )
         if not has_explicit_credential:
-            api_key = os.environ.get("ANTHROPIC_API_KEY")
-            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")
+            api_key = os.environ.get("ANTHROPIC_API_KEY") or None
+            auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
         self.api_key = api_key
         self.auth_token = auth_token
         # --- end credentials support ---

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -434,6 +434,17 @@ class TestAnthropic:
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
 
+    def test_empty_string_env_credentials_treated_as_absent(self) -> None:
+        # An empty-string env var must not be used as a credential — it would
+        # produce a malformed "Authorization: Bearer " header rejected by h11.
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = Anthropic(base_url=base_url, _strict_response_validation=True)
+
+        assert client.api_key is None
+        assert client.auth_token is None
+        assert client.auth_headers == {}
+
     def test_default_query_option(self) -> None:
         client = Anthropic(
             base_url=base_url, api_key=api_key, _strict_response_validation=True, default_query={"query_param": "bar"}
@@ -1545,6 +1556,17 @@ class TestAsyncAnthropic:
 
         request2 = client2._build_request(FinalRequestOptions(method="get", url="/foo", headers={"X-Api-Key": Omit()}))
         assert request2.headers.get("X-Api-Key") is None
+
+    def test_empty_string_env_credentials_treated_as_absent(self) -> None:
+        # An empty-string env var must not be used as a credential — it would
+        # produce a malformed "Authorization: Bearer " header rejected by h11.
+        with mock.patch("anthropic._client.default_credentials", return_value=None):
+            with update_env(ANTHROPIC_API_KEY="", ANTHROPIC_AUTH_TOKEN=""):
+                client = AsyncAnthropic(base_url=base_url, _strict_response_validation=True)
+
+        assert client.api_key is None
+        assert client.auth_token is None
+        assert client.auth_headers == {}
 
     async def test_default_query_option(self) -> None:
         client = AsyncAnthropic(


### PR DESCRIPTION
## Summary

`os.environ.get()` returns `""` for a present-but-empty environment variable, not `None`. When `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` is set to an empty string, the SDK stored `""` as the credential and later emitted an `Authorization: Bearer ` header (trailing space, no token). `h11` rejects that malformed header at write time, surfacing as `APIConnectionError`.

**Fix:** Apply `or None` to both env reads so an empty string is treated identically to the variable being absent.

```python
# before
api_key   = os.environ.get("ANTHROPIC_API_KEY")
auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN")

# after
api_key    = os.environ.get("ANTHROPIC_API_KEY")    or None
auth_token = os.environ.get("ANTHROPIC_AUTH_TOKEN") or None
```

Same fix applied to `AsyncAnthropic`.

## Tests

Added regression tests for both `Anthropic` and `AsyncAnthropic`:
- `ANTHROPIC_API_KEY=""` → `client.api_key` is `None`
- `ANTHROPIC_AUTH_TOKEN=""` → `client.auth_token` is `None`
- `auth_headers` stays empty rather than containing a blank `Authorization` header

## Checklist

- [x] Single focused change
- [x] Tests added (fail before fix, pass after)
- [x] No unrelated changes