### PR TITLE
fix: use default timeout in request header

### DIFF
--- a/src/anthropic/_base_client.py
+++ b/src/anthropic/_base_client.py
@@ -461,9 +461,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         # lowest precedence first; any of these can be overridden or `Omit`-ted by the layers after it
         headers, omitted = build_headers(
             {
-                "x-stainless-timeout": str(options.timeout.read)
-                if isinstance(options.timeout, Timeout)
-                else str(options.timeout),
+                "x-stainless-timeout": str(timeout.read) if isinstance(timeout, Timeout) else str(timeout),
                 "x-stainless-retry-count": str(retries_taken),
                 **({"x-stainless-read-timeout": str(read_timeout)} if read_timeout is not None else {}),
                 **({idempotency_header: idempotency_key} if idempotency_header and idempotency_key else {}),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -328,6 +328,7 @@ class TestAnthropic:
         request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
         timeout = httpx2.Timeout(**request.extensions["timeout"])  # type: ignore
         assert timeout == DEFAULT_TIMEOUT
+        assert request.headers["x-stainless-timeout"] == str(DEFAULT_TIMEOUT.read)
 
         request = client._build_request(FinalRequestOptions(method="get", url="/foo", timeout=httpx2.Timeout(100.0)))
         timeout = httpx2.Timeout(**request.extensions["timeout"])  # type: ignore
@@ -1497,6 +1498,7 @@ class TestAsyncAnthropic:
         request = async_client._build_request(FinalRequestOptions(method="get", url="/foo"))
         timeout = httpx2.Timeout(**request.extensions["timeout"])  # type: ignore
         assert timeout == DEFAULT_TIMEOUT
+        assert request.headers["x-stainless-timeout"] == str(DEFAULT_TIMEOUT.read)
 
         request = async_client._build_request(
             FinalRequestOptions(method="get", url="/foo", timeout=httpx2.Timeout(100.0))


### PR DESCRIPTION
## Summary
- Use the resolved client timeout when setting the x-stainless-timeout request header.
- Add sync and async regression assertions for default request timeouts.

## Testing
- PYTHONPATH=src python -m pytest -n0 tests/test_client.py -k request_timeout -q

Related issue: #1676
