### PR TITLE
fix(lib): correct typo 'propes' → 'props' in transform_schema comment

### DIFF
--- a/src/anthropic/lib/_parse/_transform.py
+++ b/src/anthropic/lib/_parse/_transform.py
@@ -160,7 +160,7 @@ def transform_schema(
     else:
         assert_never(type_)
 
-    # if there are any propes leftover then they aren't supported, so we add them to the description
+    # if there are any props leftover then they aren't supported, so we add them to the description
     # so that the model *might* follow them.
     if json_schema:
         description = strict_schema.get("description")


### PR DESCRIPTION
## Summary

Fixes a typo in a code comment in `src/anthropic/lib/_parse/_transform.py`: `propes` → `props`.

The comment on line 163 describes how leftover schema properties are handled — `propes` was a misspelling of `props`.

## Verification

- `git diff --check` — clean (no whitespace errors)
- `python3 -m py_compile src/anthropic/lib/_parse/_transform.py` — passes
- Diff is 1 line (comment-only, no behavior change)