### PR TITLE
feat(bedrock): allow selecting Mantle auth mode

### DIFF
--- a/src/anthropic/lib/aws/_credentials.py
+++ b/src/anthropic/lib/aws/_credentials.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import os
-from typing import Sequence
+from typing import Literal, Sequence
+
+AuthMode = Literal["auto", "api_key", "sigv4"]
 
 
 def validate_credentials(
@@ -34,6 +36,7 @@ def resolve_auth_mode(
     aws_access_key: str | None,
     aws_secret_key: str | None,
     aws_profile: str | None,
+    auth_mode: AuthMode = "auto",
     api_key_env_vars: Sequence[str] = ("ANTHROPIC_AWS_API_KEY",),
 ) -> bool:
     """Determine whether to use SigV4 auth. Returns True for SigV4, False for API key.
@@ -45,6 +48,15 @@ def resolve_auth_mode(
     4. API key env var(s) → API key mode (checked in order; first match wins)
     5. Default AWS credential chain → SigV4
     """
+    if auth_mode not in ("auto", "api_key", "sigv4"):
+        raise ValueError("`auth_mode` must be one of 'auto', 'api_key', or 'sigv4'")
+
+    if auth_mode == "api_key":
+        return False
+
+    if auth_mode == "sigv4":
+        return True
+
     if api_key is not None:
         return False
 

--- a/src/anthropic/lib/bedrock/_mantle.py
+++ b/src/anthropic/lib/bedrock/_mantle.py
@@ -25,6 +25,7 @@ from ..._base_client import (
     merge_headers,
 )
 from ..aws._credentials import (
+    AuthMode,
     resolve_region,
     resolve_api_key,
     resolve_auth_mode,
@@ -111,6 +112,7 @@ def _resolve_mantle_config(
     aws_region: str | None,
     aws_profile: str | None,
     skip_auth: bool,
+    auth_mode: AuthMode,
     base_url: str | httpx2.URL | None,
     default_headers: Mapping[str, str] | None,
 ) -> tuple[str | None, str | httpx2.URL, bool, dict[str, str]]:
@@ -129,6 +131,7 @@ def _resolve_mantle_config(
             aws_access_key=aws_access_key,
             aws_secret_key=aws_secret_key,
             aws_profile=aws_profile,
+            auth_mode=auth_mode,
             api_key_env_vars=_MANTLE_API_KEY_ENV_VARS,
         )
 
@@ -171,6 +174,7 @@ class AnthropicBedrockMantle(BaseMantleClient[httpx2.Client, Stream[Any]], SyncA
     aws_session_token: str | None
     aws_profile: str | None
     skip_auth: bool
+    auth_mode: AuthMode
 
     _use_sigv4: bool
 
@@ -184,6 +188,7 @@ class AnthropicBedrockMantle(BaseMantleClient[httpx2.Client, Stream[Any]], SyncA
         aws_profile: str | None = None,
         api_key: str | None = None,
         skip_auth: bool = False,
+        auth_mode: AuthMode = "auto",
         base_url: str | httpx2.URL | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         max_retries: int = DEFAULT_MAX_RETRIES,
@@ -200,6 +205,7 @@ class AnthropicBedrockMantle(BaseMantleClient[httpx2.Client, Stream[Any]], SyncA
             aws_region=aws_region,
             aws_profile=aws_profile,
             skip_auth=skip_auth,
+            auth_mode=auth_mode,
             base_url=base_url,
             default_headers=default_headers,
         )
@@ -225,6 +231,7 @@ class AnthropicBedrockMantle(BaseMantleClient[httpx2.Client, Stream[Any]], SyncA
         self.aws_session_token = aws_session_token
         self.aws_profile = aws_profile
         self.skip_auth = skip_auth
+        self.auth_mode = auth_mode
         self._use_sigv4 = use_sigv4
 
         self.messages = Messages(self)
@@ -290,6 +297,7 @@ class AnthropicBedrockMantle(BaseMantleClient[httpx2.Client, Stream[Any]], SyncA
         aws_region: str | None = None,
         aws_profile: str | None = None,
         skip_auth: bool | None = None,
+        auth_mode: AuthMode | None = None,
         base_url: str | httpx2.URL | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx2.Client | None = None,
@@ -330,6 +338,7 @@ class AnthropicBedrockMantle(BaseMantleClient[httpx2.Client, Stream[Any]], SyncA
             aws_region=aws_region or self.aws_region,
             aws_profile=aws_profile or self.aws_profile,
             skip_auth=skip_auth if skip_auth is not None else self.skip_auth,
+            auth_mode=auth_mode if auth_mode is not None else self.auth_mode,
             base_url=base_url or self.base_url,
             timeout=self.timeout if isinstance(timeout, NotGiven) else timeout,
             http_client=http_client,
@@ -367,6 +376,7 @@ class AsyncAnthropicBedrockMantle(BaseMantleClient[httpx2.AsyncClient, AsyncStre
     aws_session_token: str | None
     aws_profile: str | None
     skip_auth: bool
+    auth_mode: AuthMode
 
     _use_sigv4: bool
 
@@ -380,6 +390,7 @@ class AsyncAnthropicBedrockMantle(BaseMantleClient[httpx2.AsyncClient, AsyncStre
         aws_profile: str | None = None,
         api_key: str | None = None,
         skip_auth: bool = False,
+        auth_mode: AuthMode = "auto",
         base_url: str | httpx2.URL | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         max_retries: int = DEFAULT_MAX_RETRIES,
@@ -396,6 +407,7 @@ class AsyncAnthropicBedrockMantle(BaseMantleClient[httpx2.AsyncClient, AsyncStre
             aws_region=aws_region,
             aws_profile=aws_profile,
             skip_auth=skip_auth,
+            auth_mode=auth_mode,
             base_url=base_url,
             default_headers=default_headers,
         )
@@ -421,6 +433,7 @@ class AsyncAnthropicBedrockMantle(BaseMantleClient[httpx2.AsyncClient, AsyncStre
         self.aws_session_token = aws_session_token
         self.aws_profile = aws_profile
         self.skip_auth = skip_auth
+        self.auth_mode = auth_mode
         self._use_sigv4 = use_sigv4
 
         self.messages = AsyncMessages(self)
@@ -486,6 +499,7 @@ class AsyncAnthropicBedrockMantle(BaseMantleClient[httpx2.AsyncClient, AsyncStre
         aws_region: str | None = None,
         aws_profile: str | None = None,
         skip_auth: bool | None = None,
+        auth_mode: AuthMode | None = None,
         base_url: str | httpx2.URL | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx2.AsyncClient | None = None,
@@ -526,6 +540,7 @@ class AsyncAnthropicBedrockMantle(BaseMantleClient[httpx2.AsyncClient, AsyncStre
             aws_region=aws_region or self.aws_region,
             aws_profile=aws_profile or self.aws_profile,
             skip_auth=skip_auth if skip_auth is not None else self.skip_auth,
+            auth_mode=auth_mode if auth_mode is not None else self.auth_mode,
             base_url=base_url or self.base_url,
             timeout=self.timeout if isinstance(timeout, NotGiven) else timeout,
             http_client=http_client,

--- a/tests/lib/test_bedrock_mantle.py
+++ b/tests/lib/test_bedrock_mantle.py
@@ -202,6 +202,30 @@ class TestAuthPrecedence:
         )
         assert client.auth_headers == {}
 
+    def test_explicit_sigv4_mode_ignores_api_key_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "env-key")
+        client = AnthropicBedrockMantle(
+            auth_mode="sigv4",
+            aws_region="us-east-1",
+        )
+        assert client._use_sigv4 is True
+        assert client.api_key is None
+
+    def test_explicit_api_key_mode_uses_environment_over_aws_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "env-key")
+        client = AnthropicBedrockMantle(
+            auth_mode="api_key",
+            aws_access_key="AKID",
+            aws_secret_key="secret",
+            aws_region="us-east-1",
+        )
+        assert client._use_sigv4 is False
+        assert client.api_key == "env-key"
+
+    def test_invalid_auth_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="auth_mode"):
+            AnthropicBedrockMantle(auth_mode="invalid", base_url="https://example.com")  # type: ignore[arg-type]
+
 
 class TestSkipAuth:
     def test_skip_auth_does_not_sign_request(self, get_auth_headers_recorder: GetAuthHeadersRecorder) -> None:
@@ -296,6 +320,22 @@ class TestCopy:
         )
         copied = client.copy(aws_region="us-west-2")
         assert copied.aws_region == "us-west-2"
+
+    def test_copy_preserves_auth_mode(self) -> None:
+        client = AnthropicBedrockMantle(auth_mode="sigv4", aws_region="us-east-1")
+        copied = client.copy()
+        assert copied.auth_mode == "sigv4"
+
+    def test_copy_overrides_auth_mode(self) -> None:
+        client = AnthropicBedrockMantle(api_key="test-key", aws_region="us-east-1")
+        copied = client.copy(auth_mode="sigv4")
+        assert copied.auth_mode == "sigv4"
+        assert copied._use_sigv4 is True
+
+    def test_async_copy_preserves_auth_mode(self) -> None:
+        client = AsyncAnthropicBedrockMantle(auth_mode="sigv4", aws_region="us-east-1")
+        copied = client.copy()
+        assert copied.auth_mode == "sigv4"
 
     def test_copy_x_stainless_helper_header_appends(self) -> None:
         # `x-stainless-helper` accumulates across copies instead of being clobbered


### PR DESCRIPTION
## Summary

Adds an explicit `auth_mode` option to `AnthropicBedrockMantle` and `AsyncAnthropicBedrockMantle`.

- `auto` preserves the existing authentication precedence.
- `api_key` selects bearer authentication even when AWS credentials are provided.
- `sigv4` selects the refreshable AWS credential chain even when bearer-key environment variables are set.
- `copy()` and `with_options()` preserve or override the selected mode.

This gives applications using ECS task roles, EC2 instance profiles, IRSA, or other rotating AWS credentials a public way to avoid ambient bearer-key selection.

Closes #1893

## Tests

- `python -m pytest tests/lib/test_bedrock_mantle.py -q` — 39 passed
- `ruff check src/anthropic/lib/aws/_credentials.py src/anthropic/lib/bedrock/_mantle.py tests/lib/test_bedrock_mantle.py`
- `ruff format --check` on the changed files
- `pyright src/anthropic/lib/aws/_credentials.py src/anthropic/lib/bedrock/_mantle.py`
- `git diff --check`

The test run uses the checkout's `src` via `PYTHONPATH` and does not require AWS credentials or network calls.
