### PR TITLE
feat(credentials): support async identity_token_provider in WorkloadIdentityCredentials

### DIFF
--- a/src/anthropic/lib/credentials/_types.py
+++ b/src/anthropic/lib/credentials/_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Callable, Optional, Protocol
+from typing import Dict, Callable, Optional, Protocol, Union, Awaitable
 from dataclasses import field, dataclass
 from typing_extensions import override, runtime_checkable
 
@@ -80,7 +80,7 @@ class BaseURLBoundProvider(AccessTokenProvider, Protocol):
 
 # Innermost layer: returns the raw external JWT string (used as the
 # ``identity_token_provider`` argument to :class:`WorkloadIdentityCredentials`).
-IdentityTokenProvider = Callable[[], str]
+IdentityTokenProvider = Union[Callable[[], str], Callable[[], Awaitable[str]]]
 
 
 @dataclass(frozen=True)

--- a/src/anthropic/lib/credentials/_types.py
+++ b/src/anthropic/lib/credentials/_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Callable, Optional, Protocol, Union, Awaitable
+from typing import Any, Dict, Union, Callable, Optional, Protocol, Coroutine
 from dataclasses import field, dataclass
 from typing_extensions import override, runtime_checkable
 
@@ -80,7 +80,7 @@ class BaseURLBoundProvider(AccessTokenProvider, Protocol):
 
 # Innermost layer: returns the raw external JWT string (used as the
 # ``identity_token_provider`` argument to :class:`WorkloadIdentityCredentials`).
-IdentityTokenProvider = Union[Callable[[], str], Callable[[], Awaitable[str]]]
+IdentityTokenProvider = Union[Callable[[], str], Callable[[], Coroutine[Any, Any, str]]]
 
 
 @dataclass(frozen=True)

--- a/src/anthropic/lib/credentials/_workload.py
+++ b/src/anthropic/lib/credentials/_workload.py
@@ -139,7 +139,7 @@ class WorkloadIdentityError(AnthropicError):
 
 def _resolve_identity_token(provider: IdentityTokenProvider) -> str:
     raw = provider()
-    if inspect.isawaitable(raw):
+    if inspect.iscoroutine(raw):
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:

--- a/src/anthropic/lib/credentials/_workload.py
+++ b/src/anthropic/lib/credentials/_workload.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import copy
 import time
+import asyncio
+import inspect
 import logging
 from types import TracebackType
 from typing import Any, Dict, Type, Union, NoReturn, Optional
@@ -135,6 +137,22 @@ class WorkloadIdentityError(AnthropicError):
         return base
 
 
+def _resolve_identity_token(provider: IdentityTokenProvider) -> str:
+    raw = provider()
+    if inspect.isawaitable(raw):
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                return str(pool.submit(asyncio.run, raw).result())
+        return str(asyncio.run(raw))
+    return str(raw)
+
+
 class WorkloadIdentityCredentials:
     """Exchanges an external OIDC JWT for an Anthropic access token via the
     RFC 7523 ``jwt-bearer`` grant.
@@ -251,7 +269,7 @@ class WorkloadIdentityCredentials:
         # file (e.g. a k8s projected SA token) may have rotated. force_refresh
         # is a no-op: this provider has no cache to bypass.
         del force_refresh
-        jwt = SecretStr(self._identity_token_provider())
+        jwt = SecretStr(_resolve_identity_token(self._identity_token_provider))
 
         assertion_bytes = len(jwt.get_secret_value().encode("utf-8"))
         if assertion_bytes > _MAX_ASSERTION_BYTES:

--- a/tests/lib/test_credentials.py
+++ b/tests/lib/test_credentials.py
@@ -1002,6 +1002,31 @@ class TestWorkloadIdentityCredentials:
         assert "scope" not in body
 
     @pytest.mark.respx()
+    def test_exchange_with_async_identity_token_provider(self, respx_mock: MockRouter) -> None:
+        respx_mock.post(TOKEN_URL).mock(
+            return_value=httpx2.Response(
+                200,
+                json={"access_token": "sk-ant-oat01-async", "token_type": "Bearer", "expires_in": 600},
+            )
+        )
+
+        async def async_provider() -> str:
+            return "ext.jwt.async.value"
+
+        creds = WorkloadIdentityCredentials(
+            identity_token_provider=async_provider,
+            federation_rule_id="fdrl_01abc",
+            organization_id="00000000-0000-0000-0000-000000000000",
+        )
+
+        token = creds()
+        assert token.token == "sk-ant-oat01-async"
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 1
+        body = json.loads(calls[0].request.content)
+        assert body["assertion"] == "ext.jwt.async.value"
+
+    @pytest.mark.respx()
     def test_service_account_included(self, respx_mock: MockRouter) -> None:
         respx_mock.post(TOKEN_URL).mock(return_value=httpx2.Response(200, json={"access_token": "t", "expires_in": 60}))
         creds = WorkloadIdentityCredentials(


### PR DESCRIPTION
## Problem
When using Workload Identity Federation in asynchronous applications (e.g. fetching OIDC / STS tokens via an async AWS client), callers cannot pass an asynchronous `identity_token_provider` function to `WorkloadIdentityCredentials`. Invoking an async callable returns an unawaited coroutine object, causing `SecretStr` to fail with `AttributeError: 'coroutine' object has no attribute 'encode'`.

## Root Cause
`WorkloadIdentityCredentials.__call__` called `self._identity_token_provider()` synchronously and passed the return value directly to `SecretStr()`. `IdentityTokenProvider` was typed strictly as `Callable[[], str]`, with no resolution logic for awaitables/coroutines.

## Fix
1. Broaden `IdentityTokenProvider` type alias to `Union[Callable[[], str], Callable[[], Awaitable[str]]]`.
2. Add `_resolve_identity_token` helper to resolve and await asynchronous token provider callables safely, whether invoked outside or within an active running event loop.
3. Call `_resolve_identity_token` inside `WorkloadIdentityCredentials.__call__` before wrapping the assertion into `SecretStr`.

## Testing
Added unit test in `tests/lib/test_credentials.py::TestWorkloadIdentityCredentials::test_exchange_with_async_identity_token_provider` verifying token exchange with an async identity token provider. Verified with pytest.