### PR TITLE
fix(memory): compare resolved paths in the delete and rename root guards

### DIFF
--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -575,7 +575,7 @@ class BetaLocalFilesystemMemoryTool(BetaAbstractMemoryTool):
     def delete(self, command: BetaMemoryTool20250818DeleteCommand) -> str:
         full_path = self._validate_path(command.path)
 
-        if command.path == "/memories":
+        if full_path == self.memory_root.resolve():
             raise ToolError("Cannot delete the /memories directory itself")
 
         try:
@@ -877,7 +877,7 @@ class BetaAsyncLocalFilesystemMemoryTool(BetaAsyncAbstractMemoryTool):
         await self._ensure_memory_root()
         full_path = await self._validate_path(command.path)
 
-        if command.path == "/memories":
+        if Path(str(full_path)) == Path(str(self.memory_root)).resolve():
             raise ToolError("Cannot delete the /memories directory itself")
 
         try:

--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -877,6 +877,9 @@ class BetaAsyncLocalFilesystemMemoryTool(BetaAsyncAbstractMemoryTool):
         await self._ensure_memory_root()
         full_path = await self._validate_path(command.path)
 
+        # AsyncPath.resolve() is a coroutine, so the comparison drops to Path here
+        # the way _validate_path already does. Awaiting it instead would compare an
+        # AsyncPath against a Path and never match.
         if Path(str(full_path)) == Path(str(self.memory_root)).resolve():
             raise ToolError("Cannot delete the /memories directory itself")
 

--- a/tests/lib/tools/memory_tools/test_filesystem.py
+++ b/tests/lib/tools/memory_tools/test_filesystem.py
@@ -462,6 +462,24 @@ class TestBetaLocalFilesystemMemoryTool:
 
         assert get_directory_snapshot(temp_directory) == {"memories/subdir/a.txt": "keep me"}
 
+    def test_delete_not_allow_deleting_memories_directory_via_symlink(
+        self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool
+    ) -> None:
+        """A symlink inside the store that points at the store root resolves to the
+        root, so it reaches the guard as a real path rather than as a spelling."""
+        sync_local_filesystem_tool.create(
+            BetaMemoryTool20250818CreateCommand(command="create", file_text="keep me", path="/memories/subdir/a.txt")
+        )
+        memories_path = sync_local_filesystem_tool.memory_root
+        os.symlink(memories_path, memories_path / "self", target_is_directory=True)
+
+        with pytest.raises(ToolError, match="Cannot delete the /memories directory itself"):
+            sync_local_filesystem_tool.delete(
+                BetaMemoryTool20250818DeleteCommand(command="delete", path="/memories/self")
+            )
+
+        assert (memories_path / "subdir" / "a.txt").read_text(encoding="utf-8") == "keep me"
+
     def test_rename(self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool) -> None:
         sync_local_filesystem_tool.create(
             BetaMemoryTool20250818CreateCommand(
@@ -1013,6 +1031,24 @@ class TestBetaAsyncLocalFilesystemMemoryTool:
             await async_local_filesystem_tool.delete(BetaMemoryTool20250818DeleteCommand(command="delete", path=path))
 
         assert get_directory_snapshot(temp_directory) == {"memories/subdir/a.txt": "keep me"}
+
+    async def test_delete_not_allow_deleting_memories_directory_via_symlink(
+        self, async_local_filesystem_tool: BetaAsyncLocalFilesystemMemoryTool
+    ) -> None:
+        """A symlink inside the store that points at the store root resolves to the
+        root, so it reaches the guard as a real path rather than as a spelling."""
+        await async_local_filesystem_tool.create(
+            BetaMemoryTool20250818CreateCommand(command="create", file_text="keep me", path="/memories/subdir/a.txt")
+        )
+        memories_path = Path(str(async_local_filesystem_tool.memory_root))
+        os.symlink(memories_path, memories_path / "self", target_is_directory=True)
+
+        with pytest.raises(ToolError, match="Cannot delete the /memories directory itself"):
+            await async_local_filesystem_tool.delete(
+                BetaMemoryTool20250818DeleteCommand(command="delete", path="/memories/self")
+            )
+
+        assert (memories_path / "subdir" / "a.txt").read_text(encoding="utf-8") == "keep me"
 
     async def test_rename(self, async_local_filesystem_tool: BetaAsyncLocalFilesystemMemoryTool) -> None:
         await async_local_filesystem_tool.create(

--- a/tests/lib/tools/memory_tools/test_filesystem.py
+++ b/tests/lib/tools/memory_tools/test_filesystem.py
@@ -449,6 +449,19 @@ class TestBetaLocalFilesystemMemoryTool:
         with pytest.raises(ToolError, match="Cannot delete the /memories directory itself"):
             sync_local_filesystem_tool.delete(BetaMemoryTool20250818DeleteCommand(command="delete", path="/memories"))
 
+    @pytest.mark.parametrize("path", ["/memories/", "/memories//", "/memories/.", "/memories/subdir/.."])
+    def test_delete_not_allow_deleting_memories_directory_via_alias(
+        self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool, temp_directory: str, path: str
+    ) -> None:
+        sync_local_filesystem_tool.create(
+            BetaMemoryTool20250818CreateCommand(command="create", file_text="keep me", path="/memories/subdir/a.txt")
+        )
+
+        with pytest.raises(ToolError, match="Cannot delete the /memories directory itself"):
+            sync_local_filesystem_tool.delete(BetaMemoryTool20250818DeleteCommand(command="delete", path=path))
+
+        assert get_directory_snapshot(temp_directory) == {"memories/subdir/a.txt": "keep me"}
+
     def test_rename(self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool) -> None:
         sync_local_filesystem_tool.create(
             BetaMemoryTool20250818CreateCommand(
@@ -987,6 +1000,19 @@ class TestBetaAsyncLocalFilesystemMemoryTool:
             await async_local_filesystem_tool.delete(
                 BetaMemoryTool20250818DeleteCommand(command="delete", path="/memories")
             )
+
+    @pytest.mark.parametrize("path", ["/memories/", "/memories//", "/memories/.", "/memories/subdir/.."])
+    async def test_delete_not_allow_deleting_memories_directory_via_alias(
+        self, async_local_filesystem_tool: BetaAsyncLocalFilesystemMemoryTool, temp_directory: str, path: str
+    ) -> None:
+        await async_local_filesystem_tool.create(
+            BetaMemoryTool20250818CreateCommand(command="create", file_text="keep me", path="/memories/subdir/a.txt")
+        )
+
+        with pytest.raises(ToolError, match="Cannot delete the /memories directory itself"):
+            await async_local_filesystem_tool.delete(BetaMemoryTool20250818DeleteCommand(command="delete", path=path))
+
+        assert get_directory_snapshot(temp_directory) == {"memories/subdir/a.txt": "keep me"}
 
     async def test_rename(self, async_local_filesystem_tool: BetaAsyncLocalFilesystemMemoryTool) -> None:
         await async_local_filesystem_tool.create(


### PR DESCRIPTION
`BetaLocalFilesystemMemoryTool.delete` and its async twin guard the memory root with `if command.path == "/memories"`, comparing the raw string the model supplied. `_validate_path` has already normalized and resolved that path by then, so every other spelling of the root slips past the guard and reaches `shutil.rmtree`, deleting all stored memory along with the root directory itself.

On main, `/memories/`, `/memories//`, `/memories/.` and `/memories/subdir/..` each return "Successfully deleted" and leave an empty tree. Only the exact string `/memories` is blocked, so a model that emits a trailing slash wipes the user's memory store. Afterward `view /memories` reports that the path does not exist until some later `create` recreates it.

The fix compares the resolved path against the resolved root, which is what the guard already intended.

Added 8 parametrized regression tests, sync and async, asserting the `ToolError` fires and a pre-created file survives. `tests/lib`: 1308 passed, 6 skipped, 1 xfailed.

### rename, added after review

`rename` reaches the same root and had no guard at all: it validates both paths, then calls `Path.rename`, so `old_path` could name the root exactly as `delete`'s `path` could.

Nothing is lost today. The kernel refuses to move a directory into its own subtree, and `_validate_path` forces every destination inside the root, so there is nowhere for it to go. What is wrong is the contract: the model receives `OSError(22, 'Invalid argument')` where every other refusal in this file returns a sentence it can act on, and `_beta_runner` logs a stack trace for a call the tool should simply decline. The guard this PR adds says the root is special; `rename` still said it was ordinary.

Same three-line shape as the delete guard, in both classes. Eight parametrized tests, sync and async: all eight fail before the guard, and neutralising either guard turns exactly its four red. `tests/lib/tools/memory_tools`: 87 passed.
