### PR TITLE
fix(docs): update file upload error link

### DIFF
--- a/src/anthropic/_files.py
+++ b/src/anthropic/_files.py
@@ -34,7 +34,7 @@ def assert_is_file_content(obj: object, *, key: str | None = None) -> None:
     if not is_file_content(obj) and not is_tuple_t(obj):
         prefix = f"Expected entry at `{key}`" if key is not None else f"Expected file input `{obj!r}`"
         raise RuntimeError(
-            f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://github.com/anthropics/anthropic-sdk-python/tree/main#file-uploads"
+            f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://platform.claude.com/docs/en/cli-sdks-libraries/sdks/python#file-uploads"
         ) from None
 
 


### PR DESCRIPTION
## Summary

Updates the stale file upload documentation link in `src/anthropic/_files.py` to point directly to the current Python SDK `File uploads` section.

The existing link points to a `#file-uploads` anchor in the repository README, but that section no longer exists.

## Context

#1796 previously identified this stale link along with the long-requests link. The long-requests link was later corrected in #1884, while the file-upload link remains on `main`.

This change updates the remaining stale link to the current dedicated file upload documentation.

## Test plan

- Ran `git diff --check`
- Verified the updated URL points to the current Python SDK `File uploads` section
- No runtime behavior changes beyond the documentation URL in the error message