### PR TITLE
fix(tools): support positional-only parameters in beta_tool

### DIFF
--- a/src/anthropic/lib/tools/_beta_functions.py
+++ b/src/anthropic/lib/tools/_beta_functions.py
@@ -4,7 +4,7 @@ import sys
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Union, Generic, TypeVar, Callable, Iterable, Coroutine, cast, overload
-from inspect import isawaitable, isasyncgenfunction, iscoroutinefunction, isgeneratorfunction
+from inspect import Parameter, signature, isawaitable, isasyncgenfunction, iscoroutinefunction, isgeneratorfunction
 from collections.abc import Awaitable
 from typing_extensions import Literal, TypeAlias, override
 
@@ -59,6 +59,28 @@ class ToolError(Exception):
             message = " ".join(parts) if parts else "Tool error"
         super().__init__(message)
         self.content = content
+
+
+def _positional_only_parameter_names(func: Callable[..., Any]) -> list[str]:
+    """Return the positional-only parameter names of ``func``, in declaration order.
+
+    Tool inputs arrive as JSON objects and are handed to the function by name, so
+    ``*args`` cannot be expressed at all and is rejected up front; positional-only
+    parameters are routed back into positional slots by :meth:`BaseFunctionTool._split_input`.
+    """
+    try:
+        parameters = signature(func).parameters.values()
+    except (TypeError, ValueError):
+        return []
+
+    for parameter in parameters:
+        if parameter.kind is Parameter.VAR_POSITIONAL:
+            raise TypeError(
+                f"Tool function {getattr(func, '__name__', func)!r} declares *{parameter.name}; "
+                "tool inputs are JSON objects passed by name, so variadic positional parameters are not supported"
+            )
+
+    return [parameter.name for parameter in parameters if parameter.kind is Parameter.POSITIONAL_ONLY]
 
 
 Function = Callable[..., BetaFunctionToolResultType]
@@ -163,6 +185,7 @@ class BaseFunctionTool(Generic[CallableT]):
             raise RuntimeError("Tool functions are only supported with Pydantic v2")
 
         self.func = func
+        self._positional_only_params = _positional_only_parameter_names(func)
         self._func_with_validate = pydantic.validate_call(func)
         self.name = name or func.__name__
         self._defer_loading = defer_loading
@@ -185,6 +208,24 @@ class BaseFunctionTool(Generic[CallableT]):
     @property
     def __call__(self) -> CallableT:
         return self.func
+
+    def _split_input(self, input: dict[object, object]) -> tuple[list[object], dict[object, object]]:
+        """Split a tool input object into the positional and keyword arguments for ``func``.
+
+        Positional-only parameters cannot be passed by keyword, so their values are
+        pulled out of the input by name and forwarded positionally. Anything missing
+        or unexpected is left for ``validate_call`` to report.
+        """
+        if not self._positional_only_params:
+            return [], input
+
+        kwargs = dict(input)
+        positional: list[object] = []
+        for param_name in self._positional_only_params:
+            if param_name not in kwargs:
+                break
+            positional.append(kwargs.pop(param_name))
+        return positional, kwargs
 
     def to_dict(self) -> BetaToolParam:
         defn: BetaToolParam = {
@@ -224,7 +265,7 @@ class BaseFunctionTool(Generic[CallableT]):
 
         from pydantic_core import CoreSchema
         from pydantic.json_schema import JsonSchemaValue, GenerateJsonSchema
-        from pydantic_core.core_schema import ArgumentsParameter
+        from pydantic_core.core_schema import ArgumentsSchema, ArgumentsParameter
 
         class CustomGenerateJsonSchema(GenerateJsonSchema):
             def __init__(self, *, func: Callable[..., Any], parsed_docstring: Any) -> None:
@@ -234,6 +275,19 @@ class BaseFunctionTool(Generic[CallableT]):
 
             def __call__(self, *_args: Any, **_kwds: Any) -> "CustomGenerateJsonSchema":  # noqa: ARG002
                 return self
+
+            @override
+            def arguments_schema(self, schema: ArgumentsSchema) -> JsonSchemaValue:
+                # Tool inputs are JSON objects passed by name, so positional-only parameters
+                # must become named properties. Left alone, pydantic renders them (and only
+                # them) in its positional form: a `type: array` schema the API cannot accept.
+                arguments = [
+                    cast(ArgumentsParameter, {**argument, "mode": "positional_or_keyword"})
+                    if argument.get("mode") == "positional_only"
+                    else argument
+                    for argument in schema["arguments_schema"]
+                ]
+                return super().arguments_schema(cast(ArgumentsSchema, {**schema, "arguments_schema": arguments}))
 
             @override
             def kw_arguments_schema(
@@ -276,8 +330,9 @@ class BetaFunctionTool(BaseFunctionTool[FunctionT]):
         if not is_dict(input):
             raise TypeError(f"Input must be a dictionary, got {type(input).__name__}")
 
+        args, kwargs = self._split_input(input)
         try:
-            return self._func_with_validate(**cast(Any, input))
+            return self._func_with_validate(*args, **cast(Any, kwargs))
         except pydantic.ValidationError as e:
             raise ValueError(f"Invalid arguments for function {self.name}") from e
 
@@ -290,8 +345,9 @@ class BetaAsyncFunctionTool(BaseFunctionTool[AsyncFunctionT]):
         if not is_dict(input):
             raise TypeError(f"Input must be a dictionary, got {type(input).__name__}")
 
+        args, kwargs = self._split_input(input)
         try:
-            return await self._func_with_validate(**cast(Any, input))
+            return await self._func_with_validate(*args, **cast(Any, kwargs))
         except pydantic.ValidationError as e:
             raise ValueError(f"Invalid arguments for function {self.name}") from e
 

--- a/tests/lib/tools/test_functions.py
+++ b/tests/lib/tools/test_functions.py
@@ -440,6 +440,77 @@ class TestFunctionTool:
 
         assert function_tool.input_schema == expected_schema
 
+    def test_positional_only_parameters(self) -> None:
+        """Positional-only parameters are exposed as named properties and routed back positionally."""
+
+        def lookup(user_id: int, /, field: str = "name") -> str:
+            """Look up a field on a user record."""
+            return f"{user_id}:{field}"
+
+        function_tool = beta_tool(lookup)
+
+        # pydantic's own JSON schema for this signature is the positional `type: array`
+        # form, which is not a valid tool `input_schema`.
+        assert function_tool.input_schema == {
+            "additionalProperties": False,
+            "type": "object",
+            "properties": {
+                "user_id": {"title": "User Id", "type": "integer"},
+                "field": {"title": "Field", "type": "string", "default": "name"},
+            },
+            "required": ["user_id"],
+        }
+        assert function_tool.call({"user_id": 7, "field": "email"}) == "7:email"
+        assert function_tool.call({"user_id": 7}) == "7:name"
+
+        with pytest.raises(ValueError, match="Invalid arguments for function lookup"):
+            function_tool.call({"field": "email"})
+        with pytest.raises(ValueError, match="Invalid arguments for function lookup"):
+            function_tool.call({"user_id": "seven"})
+
+    def test_positional_only_with_keyword_only_parameters(self) -> None:
+        def combine(a: int, /, *, b: str) -> str:
+            """Combine two values."""
+            return f"{a}{b}"
+
+        function_tool = beta_tool(combine)
+
+        assert function_tool.input_schema == {
+            "additionalProperties": False,
+            "type": "object",
+            "properties": {"a": {"title": "A", "type": "integer"}, "b": {"title": "B", "type": "string"}},
+            "required": ["a", "b"],
+        }
+        assert function_tool.call({"a": 1, "b": "z"}) == "1z"
+
+    async def test_async_positional_only_parameters(self) -> None:
+        from anthropic.lib.tools._beta_functions import beta_async_tool
+
+        async def lookup(user_id: int, /, field: str = "name") -> str:
+            """Look up a field on a user record."""
+            return f"{user_id}:{field}"
+
+        function_tool = beta_async_tool(lookup)
+
+        assert function_tool.input_schema == {
+            "additionalProperties": False,
+            "type": "object",
+            "properties": {
+                "user_id": {"title": "User Id", "type": "integer"},
+                "field": {"title": "Field", "type": "string", "default": "name"},
+            },
+            "required": ["user_id"],
+        }
+        assert await function_tool.call({"user_id": 3, "field": "email"}) == "3:email"
+
+    def test_var_positional_parameter_raises(self) -> None:
+        def collect(*values: int) -> str:
+            """Sum values."""
+            return str(sum(values))
+
+        with pytest.raises(TypeError, match=r"declares \*values"):
+            beta_tool(collect)
+
 
 def _get_parameters_info(fn: BaseFunctionTool[Any]) -> dict[str, str]:
     param_info: dict[str, str] = {}


### PR DESCRIPTION
## What was wrong

`@beta_tool` / `@beta_async_tool` on a function with a positional-only parameter produced an invalid schema and an uncallable tool, without any error at decoration time:

```python
@beta_tool
def lookup(user_id: int, /, field: str = "name") -> str:
    """Look up a field on a user record."""
    return f"{user_id}:{field}"

lookup.input_schema
# {"maxItems": 2, "minItems": 1, "prefixItems": [...], "type": "array"}
lookup.call({"user_id": 7, "field": "email"})
# ValueError: Invalid arguments for function lookup
#   (2 validation errors: missing_positional_only_argument, unexpected_keyword_argument)
```

`def collect(*values: int)` produced `{"items": {"type": "integer"}, "type": "array"}` the same way. `InputSchema` requires `type: "object"`, so both schemas are rejected by the API, and the positional-only tool could never be invoked by the tool runner even with a hand-written `input_schema=`.

## Root cause

`_create_schema_from_function` delegates to pydantic's `GenerateJsonSchema.arguments_schema`, which renders the positional (array) form whenever a signature has positional-only parameters or `*args` and no keyword-only ones, so the docstring hook in `kw_arguments_schema` never runs for those signatures. `call()` then forwards the input object purely by keyword, which a positional-only parameter cannot accept.

## The fix

Tool inputs are JSON objects passed by name, so:

- `CustomGenerateJsonSchema.arguments_schema` is overridden to render positional-only parameters as ordinary named properties. The schema for `lookup` above is now identical to the one for `def lookup(user_id: int, field: str = "name")`.
- `BetaFunctionTool.call` / `BetaAsyncFunctionTool.call` route positional-only values back into positional slots (`_split_input`). Missing or unexpected values are still left to `validate_call`, so the existing `ValueError("Invalid arguments for function ...")` behaviour is unchanged.
- `*args`, which a JSON object cannot represent, now raises a `TypeError` at decoration time. This is the one behavioural change for existing code: such a tool previously constructed successfully but carried an array schema the API cannot accept.

`signature()` failures (builtins, some callables) fall back to the previous behaviour, and the lazily-entered `@asynccontextmanager` path is unaffected since its wrapper only takes `**kwargs`.

## Verification

CPU only, no API calls. From the repo root with a `uv venv` (Python 3.12, pydantic 2.13.5):

```
python -m pytest tests/lib/tools -q -o addopts="--tb=short -p tests._alias_httpx"
# 431 passed, 1 skipped, 1 xfailed
ruff check src/anthropic/lib/tools/_beta_functions.py tests/lib/tools/test_functions.py   # All checks passed
ruff format --check src/anthropic/lib/tools/_beta_functions.py tests/lib/tools/test_functions.py
pyright src/anthropic/lib/tools/_beta_functions.py tests/lib/tools/test_functions.py     # 0 errors
```

The four new tests (`test_positional_only_parameters`, `test_positional_only_with_keyword_only_parameters`, `test_async_positional_only_parameters`, `test_var_positional_parameter_raises`) fail on `main` and pass with this change.

Fixes #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)
