### PR TITLE
fix(tools): preserve an explicitly empty description

### DIFF
--- a/src/anthropic/lib/tools/_beta_functions.py
+++ b/src/anthropic/lib/tools/_beta_functions.py
@@ -172,7 +172,7 @@ class BaseFunctionTool(Generic[CallableT]):
         self._input_examples = input_examples
         self._strict = strict
 
-        self.description = description or self._get_description_from_docstring()
+        self.description = description if description is not None else self._get_description_from_docstring()
 
         if input_schema is not None:
             if isinstance(input_schema, type):

--- a/tests/lib/tools/test_functions.py
+++ b/tests/lib/tools/test_functions.py
@@ -560,3 +560,15 @@ class TestContextManagerTool:
 
         with pytest.raises(TypeError, match="needs an explicit input_schema"):
             beta_async_tool(name="noschema")(cast(Any, noschema_cm))
+
+
+@pytest.mark.parametrize("description", ["", "Replacement description", None])
+def test_explicit_tool_description(description: str | None) -> None:
+    def example() -> str:
+        """Original description."""
+        return "ok"
+
+    tool = beta_tool(example, description=description)
+    expected = "Original description." if description is None else description
+    assert tool.description == expected
+    assert tool.to_dict()["description"] == expected

--- a/tests/lib/tools/test_functions.py
+++ b/tests/lib/tools/test_functions.py
@@ -562,6 +562,7 @@ class TestContextManagerTool:
             beta_async_tool(name="noschema")(cast(Any, noschema_cm))
 
 
+@pytest.mark.skipif(PYDANTIC_V1, reason="only applicable in pydantic v2")
 @pytest.mark.parametrize("description", ["", "Replacement description", None])
 def test_explicit_tool_description(description: str | None) -> None:
     def example() -> str:


### PR DESCRIPTION
Passing `description=""` to `beta_tool` currently restores the function docstring. Only fall back to the docstring when the argument is `None`, so callers can explicitly clear a description.

Adds tests for empty, custom, and omitted descriptions.
