### PR TITLE
fix(memory): require a separator after the /memories prefix

### DIFF
--- a/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
+++ b/src/anthropic/lib/tools/_beta_builtin_memory_tool.py
@@ -395,7 +395,10 @@ class BetaLocalFilesystemMemoryTool(BetaAbstractMemoryTool):
 
     def _validate_path(self, path: str) -> Path:
         """Validate and resolve memory paths"""
-        if not path.startswith("/memories"):
+        # The separator matters: without it "/memoriesX" passes the prefix check and
+        # then slices down to "X", so a path that names something outside the store
+        # is silently re-pointed at <root>/X.
+        if path != "/memories" and not path.startswith("/memories/"):
             raise ToolError(f"Path must start with /memories, got: {path}")
 
         relative_path = path[len("/memories") :].lstrip("/")
@@ -681,7 +684,10 @@ class BetaAsyncLocalFilesystemMemoryTool(BetaAsyncAbstractMemoryTool):
 
     async def _validate_path(self, path: str) -> AsyncPath:
         """Validate and resolve memory paths"""
-        if not path.startswith("/memories"):
+        # The separator matters: without it "/memoriesX" passes the prefix check and
+        # then slices down to "X", so a path that names something outside the store
+        # is silently re-pointed at <root>/X.
+        if path != "/memories" and not path.startswith("/memories/"):
             raise ToolError(f"Path must start with /memories, got: {path}")
 
         relative_path = path[len("/memories") :].lstrip("/")

--- a/tests/lib/tools/memory_tools/test_filesystem.py
+++ b/tests/lib/tools/memory_tools/test_filesystem.py
@@ -449,6 +449,27 @@ class TestBetaLocalFilesystemMemoryTool:
         with pytest.raises(ToolError, match="Cannot delete the /memories directory itself"):
             sync_local_filesystem_tool.delete(BetaMemoryTool20250818DeleteCommand(command="delete", path="/memories"))
 
+    @pytest.mark.parametrize("path", ["/memoriesX", "/memoriesXY/z.md", "/memoriessub", "/memories."])
+    def test_paths_sharing_the_prefix_without_a_separator_are_rejected(
+        self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool, temp_directory: str, path: str
+    ) -> None:
+        """Paths that share the prefix without a separator name nothing inside the
+        store. Unchecked, they slice down to a relative path and land on a real
+        entry: delete "/memoriessub" removes <root>/sub and reports success."""
+        sync_local_filesystem_tool.create(
+            BetaMemoryTool20250818CreateCommand(command="create", file_text="keep me", path="/memories/sub/a.txt")
+        )
+
+        with pytest.raises(ToolError, match="Path must start with /memories"):
+            sync_local_filesystem_tool.delete(BetaMemoryTool20250818DeleteCommand(command="delete", path=path))
+
+        with pytest.raises(ToolError, match="Path must start with /memories"):
+            sync_local_filesystem_tool.create(
+                BetaMemoryTool20250818CreateCommand(command="create", file_text="written", path=path)
+            )
+
+        assert get_directory_snapshot(temp_directory) == {"memories/sub/a.txt": "keep me"}
+
     def test_rename(self, sync_local_filesystem_tool: BetaLocalFilesystemMemoryTool) -> None:
         sync_local_filesystem_tool.create(
             BetaMemoryTool20250818CreateCommand(
@@ -987,6 +1008,27 @@ class TestBetaAsyncLocalFilesystemMemoryTool:
             await async_local_filesystem_tool.delete(
                 BetaMemoryTool20250818DeleteCommand(command="delete", path="/memories")
             )
+
+    @pytest.mark.parametrize("path", ["/memoriesX", "/memoriesXY/z.md", "/memoriessub", "/memories."])
+    async def test_paths_sharing_the_prefix_without_a_separator_are_rejected(
+        self, async_local_filesystem_tool: BetaAsyncLocalFilesystemMemoryTool, temp_directory: str, path: str
+    ) -> None:
+        """Paths that share the prefix without a separator name nothing inside the
+        store. Unchecked, they slice down to a relative path and land on a real
+        entry: delete "/memoriessub" removes <root>/sub and reports success."""
+        await async_local_filesystem_tool.create(
+            BetaMemoryTool20250818CreateCommand(command="create", file_text="keep me", path="/memories/sub/a.txt")
+        )
+
+        with pytest.raises(ToolError, match="Path must start with /memories"):
+            await async_local_filesystem_tool.delete(BetaMemoryTool20250818DeleteCommand(command="delete", path=path))
+
+        with pytest.raises(ToolError, match="Path must start with /memories"):
+            await async_local_filesystem_tool.create(
+                BetaMemoryTool20250818CreateCommand(command="create", file_text="written", path=path)
+            )
+
+        assert get_directory_snapshot(temp_directory) == {"memories/sub/a.txt": "keep me"}
 
     async def test_rename(self, async_local_filesystem_tool: BetaAsyncLocalFilesystemMemoryTool) -> None:
         await async_local_filesystem_tool.create(


### PR DESCRIPTION
`_validate_path` accepts any path beginning with the characters `/memories`, then slices that prefix off. There is no separator check, so a path that merely starts with those characters is re-pointed inside the store.

Measured on `main`, sentinel store holding `keep.md` and `sub/deep.md`:

```
create '/memoriesX'        -> File created successfully at: /memoriesX   ; <root>/X written
create '/memoriesXY/z.md'  -> ok                                         ; <root>/XY/z.md written
delete '/memoriessub'      -> Successfully deleted /memoriessub          ; <root>/sub is gone
```

Nothing escapes: `<base>/memoriesX` is never created and the escape check below still holds. What goes wrong is that a command aimed outside the store deletes a real directory inside it, and the confirmation names `/memoriessub`, a path that exists nowhere.

The fix requires exactly `/memories` or a `/memories/` prefix, in both the sync and async classes.

8 parametrized regression tests, sync and async, asserting `ToolError` and an untouched store. Reverting the two lines turns all 8 red. `tests/lib/tools/memory_tools`: 77 passed.

### Relationship to #1906

The source changes are independent: #1906 touches the `delete` root guard, this touches `_validate_path`, and they auto-merge. The test files do conflict, since both branches append at the same anchor in the sync and async classes; the resolution is the union of both blocks, and `tests/lib/tools/memory_tools` is 87 passed there. Whichever lands second needs a rebase.

**This PR does not close the delete class on its own.** A separator check cannot see a well-formed path that resolves to the root, so on this branch alone:

```
                        main    this PR   #1906   both
/memories/              wiped   wiped     blocked blocked
/memories/.             wiped   wiped     blocked blocked
/memories/root_link     wiped   wiped     blocked blocked   (symlink -> root)
/memoriessub            <root>/sub deleted   blocked <root>/sub deleted   blocked
/memoriesX (create)     wrote <root>/X  blocked   wrote <root>/X  blocked
```

What this PR uniquely closes on top of #1906 is one destructive shape, `/memories` immediately followed by the name of a real child, plus two stray-write shapes on `create`, plus a misleading "already exists" for a path nobody named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8X6AL5NTTrQ458Y5anofR

