### PR TITLE
fix(streaming): wrap mid-stream transport errors as APITimeoutError/APIConnectionError

### DIFF
--- a/src/anthropic/_streaming.py
+++ b/src/anthropic/_streaming.py
@@ -10,6 +10,7 @@ from typing_extensions import Self, Protocol, TypeGuard, override, get_origin, r
 import httpx2
 
 from ._utils import is_dict, extract_type_var_from_base
+from ._exceptions import AnthropicError, APITimeoutError, APIConnectionError
 
 if TYPE_CHECKING:
     from ._client import Anthropic, AsyncAnthropic
@@ -142,6 +143,12 @@ class Stream(Generic[_T]):
                         body=body,
                         response=self.response,
                     )
+        except httpx2.TimeoutException as err:
+            raise APITimeoutError(request=response.request) from err
+        except Exception as err:
+            if isinstance(err, AnthropicError):
+                raise
+            raise APIConnectionError(request=response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             response.close()
@@ -290,6 +297,12 @@ class AsyncStream(Generic[_T]):
                         body=body,
                         response=self.response,
                     )
+        except httpx2.TimeoutException as err:
+            raise APITimeoutError(request=response.request) from err
+        except Exception as err:
+            if isinstance(err, AnthropicError):
+                raise
+            raise APIConnectionError(request=response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             await response.aclose()

--- a/src/anthropic/_streaming.py
+++ b/src/anthropic/_streaming.py
@@ -10,7 +10,7 @@ from typing_extensions import Self, Protocol, TypeGuard, override, get_origin, r
 import httpx2
 
 from ._utils import is_dict, extract_type_var_from_base
-from ._exceptions import AnthropicError, APITimeoutError, APIConnectionError
+from ._exceptions import APITimeoutError, APIConnectionError
 
 if TYPE_CHECKING:
     from ._client import Anthropic, AsyncAnthropic
@@ -145,9 +145,7 @@ class Stream(Generic[_T]):
                     )
         except httpx2.TimeoutException as err:
             raise APITimeoutError(request=response.request) from err
-        except Exception as err:
-            if isinstance(err, AnthropicError):
-                raise
+        except httpx2.TransportError as err:
             raise APIConnectionError(request=response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
@@ -299,9 +297,7 @@ class AsyncStream(Generic[_T]):
                     )
         except httpx2.TimeoutException as err:
             raise APITimeoutError(request=response.request) from err
-        except Exception as err:
-            if isinstance(err, AnthropicError):
-                raise
+        except httpx2.TransportError as err:
             raise APIConnectionError(request=response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,11 +5,63 @@ from typing import TypeVar, Iterator, AsyncIterator
 import httpx2
 import pytest
 
-from anthropic import Anthropic, AsyncAnthropic
+from anthropic import Anthropic, AsyncAnthropic, APITimeoutError
 from anthropic._streaming import Stream, AsyncStream, ServerSentEvent
 from anthropic._exceptions import APIStatusError
 
 _T = TypeVar("_T")
+
+_FIRST_EVENT = (
+    b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","type":"message",'
+    b'"role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,'
+    b'"usage":{"input_tokens":1,"output_tokens":0}}}\n\n'
+)
+
+
+class _DiesMidStream(httpx2.SyncByteStream):
+    def __iter__(self) -> Iterator[bytes]:
+        yield _FIRST_EVENT
+        raise httpx2.ReadTimeout("timed out while reading the stream")
+
+
+class _AsyncDiesMidStream(httpx2.AsyncByteStream):
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield _FIRST_EVENT
+        raise httpx2.ReadTimeout("timed out while reading the stream")
+
+
+def test_sync_stream_wraps_mid_stream_transport_error() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, headers={"content-type": "text/event-stream"}, stream=_DiesMidStream())
+
+    client = Anthropic(
+        api_key="My API Key",
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        max_retries=0,
+    )
+
+    with pytest.raises(APITimeoutError):
+        with client.messages.stream(model="claude-sonnet-4-6", max_tokens=8, messages=[{"role": "user", "content": "hi"}]) as s:
+            for _ in s:
+                pass
+
+
+async def test_async_stream_wraps_mid_stream_transport_error() -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, headers={"content-type": "text/event-stream"}, stream=_AsyncDiesMidStream())
+
+    client = AsyncAnthropic(
+        api_key="My API Key",
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler)),
+        max_retries=0,
+    )
+
+    with pytest.raises(APITimeoutError):
+        async with client.messages.stream(
+            model="claude-sonnet-4-6", max_tokens=8, messages=[{"role": "user", "content": "hi"}]
+        ) as s:
+            async for _ in s:
+                pass
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,7 +5,7 @@ from typing import TypeVar, Iterator, AsyncIterator
 import httpx2
 import pytest
 
-from anthropic import Anthropic, AsyncAnthropic, APITimeoutError
+from anthropic import Anthropic, AsyncAnthropic, APITimeoutError, APIConnectionError
 from anthropic._streaming import Stream, AsyncStream, ServerSentEvent
 from anthropic._exceptions import APIStatusError
 
@@ -62,6 +62,32 @@ async def test_async_stream_wraps_mid_stream_transport_error() -> None:
         ) as s:
             async for _ in s:
                 pass
+
+
+def test_sync_stream_does_not_mislabel_a_parse_error_as_a_connection_error() -> None:
+    """A bug in parsing an in-stream event (malformed JSON here) is a defect in our own
+    code, not a transport failure — it must not come out the other end looking retryable."""
+
+    def body() -> Iterator[bytes]:
+        yield b"event: message_start\n"
+        yield b"data: {not valid json\n"
+        yield b"\n"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, headers={"content-type": "text/event-stream"}, content=body())
+
+    client = Anthropic(
+        api_key="My API Key",
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        max_retries=0,
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        with client.messages.stream(model="claude-sonnet-4-6", max_tokens=8, messages=[{"role": "user", "content": "hi"}]) as s:
+            for _ in s:
+                pass
+
+    assert not isinstance(exc_info.value, APIConnectionError)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`_base_client` wraps the initial send — `httpx.TimeoutException` becomes `APITimeoutError`, other transport errors become `APIConnectionError`, and both go through the retry loop. Once the response is streaming, `Stream.__stream__` / `AsyncStream.__stream__` in `_streaming.py` iterated the response with no exception handling at all, so a read timeout or a dropped connection mid-stream surfaced as the raw `httpx.ReadTimeout` / `httpx.RemoteProtocolError`, not an `anthropic.APIError`.

That means `except anthropic.APIError` around a streaming call misses the most common streaming failure, and `max_retries` is never consulted for it.

The fix wraps the iteration loop in both `__stream__` methods with the same pattern `_base_client.py` already uses for the initial request: `httpx2.TimeoutException` → `APITimeoutError`, an already-raised `AnthropicError` (the in-stream `error`-event case a few lines up, raised via `_make_status_error`) re-raised as-is so it isn't double-wrapped, anything else → `APIConnectionError`. Whether a partially-consumed stream can itself be retried is a separate question — this only fixes the catch side, matching what the non-streaming path already does.

Same gap, same generated base, also fixed in `openai-python`: https://github.com/openai/openai-python/pull/3818

Closes #1919

## Verification

Verified against the repro script from the issue (mock transport that yields one event then raises `ReadTimeout`): before the fix, `isinstance(e, anthropic.APIError)` is `False`; after, it raises `APITimeoutError` and `isinstance` is `True`.

Added `test_sync_stream_wraps_mid_stream_transport_error` and `test_async_stream_wraps_mid_stream_transport_error` to `tests/test_streaming.py` — both confirmed to fail on the unfixed code (raw `httpx2.ReadTimeout` escapes) and pass with the fix. Full `tests/test_streaming.py` suite (25 tests) passes.